### PR TITLE
doc: fix map type

### DIFF
--- a/_example/main.tf
+++ b/_example/main.tf
@@ -12,6 +12,23 @@ variable "subnet_ids" {
   description = "a comma-separated list of subnet IDs"
 }
 
+variable "security_group_ids" {
+  default = "sg-a, sg-b"
+}
+
+variable "amis" {
+  default = {
+    "us-east-1" = "ami-8f7687e2"
+    "us-west-1" = "ami-bb473cdb"
+    "us-west-2" = "ami-84b44de4"
+    "eu-west-1" = "ami-4e6ffe3d"
+    "eu-central-1" = "ami-b0cc23df"
+    "ap-northeast-1" = "ami-095dbf68"
+    "ap-southeast-1" = "ami-cf03d2ac"
+    "ap-southeast-2" = "ami-697a540a"
+  }
+}
+
 // The VPC ID.
 output "vpc_id" {
   value = "vpc-5c1f55fd"

--- a/print/print.go
+++ b/print/print.go
@@ -23,17 +23,12 @@ func Pretty(d *doc.Doc) (string, error) {
 		for _, i := range d.Inputs {
 			format := "  \033[36mvar.%s\033[0m (%s)\n  \033[90m%s\033[0m\n\n"
 			desc := i.Description
-			def := i.Default
-
-			if def == "" {
-				def = "required"
-			}
 
 			if desc == "" {
 				desc = "-"
 			}
 
-			buf.WriteString(fmt.Sprintf(format, i.Name, def, desc))
+			buf.WriteString(fmt.Sprintf(format, i.Name, i.Value(), desc))
 		}
 
 		buf.WriteString("\n")
@@ -69,19 +64,11 @@ func Markdown(d *doc.Doc) (string, error) {
 	}
 
 	for _, v := range d.Inputs {
-		def := v.Default
-
-		if def == "" {
-			def = "-"
-		} else {
-			def = fmt.Sprintf("`%s`", def)
-		}
-
 		buf.WriteString(fmt.Sprintf("| %s | %s | %s | %v |\n",
 			v.Name,
 			v.Description,
-			def,
-			humanize(v.Default == "")))
+			v.Value(),
+			humanize(v.Default)))
 	}
 
 	if len(d.Outputs) > 0 {
@@ -110,14 +97,10 @@ func JSON(d *doc.Doc) (string, error) {
 }
 
 // Humanize the given `v`.
-func humanize(v interface{}) string {
-	switch v.(type) {
-	case bool:
-		if v.(bool) {
-			return "yes"
-		}
-		return "no"
-	default:
-		panic("unknown type")
+func humanize(def *doc.Value) string {
+	if def == nil {
+		return "yes"
 	}
+
+	return "no"
 }


### PR DESCRIPTION
Making sure it's not marked as required when a default exists, instead `<map>` will show up to indicate the type.

I might add `--verbose` in the future to print these types.

<img width="968" alt="screen shot 2016-06-29 at 3 38 33 pm" src="https://cloud.githubusercontent.com/assets/1661587/16452131/8e77556a-3e0f-11e6-8369-18db22a58219.png">

closes #9 
