### PR TITLE
Allow top-level comments for variables, and markdown line break fixes, list placeholder

### DIFF
--- a/doc/doc.go
+++ b/doc/doc.go
@@ -23,6 +23,8 @@ func (i *Input) Value() string {
 			return i.Default.Literal
 		case "map":
 			return "<map>"
+		case "list":
+			return "<list>"
 		}
 	}
 
@@ -137,6 +139,11 @@ func get(items []*ast.ObjectItem, key string) *Value {
 
 			if _, ok := item.Val.(*ast.ObjectType); ok {
 				v.Type = "map"
+				return v
+			}
+
+			if _, ok := item.Val.(*ast.ListType); ok {
+				v.Type = "list"
 				return v
 			}
 

--- a/doc/doc.go
+++ b/doc/doc.go
@@ -216,7 +216,12 @@ func header(c *ast.CommentGroup) (comment string) {
 		lines = lines[1 : len(lines)-1]
 		for _, l := range lines {
 			l = strings.TrimSpace(l)
-			l = strings.TrimPrefix(l, "*")
+			switch {
+			case strings.TrimPrefix(l, "* ") != l:
+				l = strings.TrimPrefix(l, "* ")
+			default:
+				l = strings.TrimPrefix(l, "*")
+			}
 			comment += l + "\n"
 		}
 	}

--- a/doc/doc.go
+++ b/doc/doc.go
@@ -77,7 +77,13 @@ func inputs(list *ast.ObjectList) []Input {
 		if is(item, "variable") {
 			name, _ := strconv.Unquote(item.Keys[1].Token.Text)
 			items := item.Val.(*ast.ObjectType).List.Items
-			desc := description(items)
+			var desc string
+			switch {
+			case description(items) != "":
+				desc = description(items)
+			case item.LeadComment != nil:
+				desc = comment(item.LeadComment.List)
+			}
 			def := get(items, "default")
 			ret = append(ret, Input{
 				Name:        name,

--- a/print/print.go
+++ b/print/print.go
@@ -74,7 +74,7 @@ func Markdown(d *doc.Doc) (string, error) {
 
 		buf.WriteString(fmt.Sprintf("| %s | %s | %s | %v |\n",
 			v.Name,
-			strings.TrimSpace(v.Description),
+			strings.Replace(strings.TrimSpace(v.Description), "\n", "<br>", -1),
 			def,
 			humanize(v.Default)))
 	}

--- a/print/print.go
+++ b/print/print.go
@@ -74,7 +74,7 @@ func Markdown(d *doc.Doc) (string, error) {
 
 		buf.WriteString(fmt.Sprintf("| %s | %s | %s | %v |\n",
 			v.Name,
-			strings.Replace(strings.TrimSpace(v.Description), "\n", "<br>", -1),
+			normalizeMarkdownDesc(v.Description),
 			def,
 			humanize(v.Default)))
 	}
@@ -88,7 +88,7 @@ func Markdown(d *doc.Doc) (string, error) {
 	for _, v := range d.Outputs {
 		buf.WriteString(fmt.Sprintf("| %s | %s |\n",
 			v.Name,
-			strings.Replace(strings.TrimSpace(v.Description), "\n", "<br>", -1)))
+			normalizeMarkdownDesc(v.Description)))
 	}
 
 	return buf.String(), nil
@@ -111,4 +111,12 @@ func humanize(def *doc.Value) string {
 	}
 
 	return "no"
+}
+
+// normalizeMarkdownDesc fixes line breaks in descriptions for markdown:
+//
+//  * Double newlines are converted to <br><br>
+//  * A second pass replaces all other newlines with spaces
+func normalizeMarkdownDesc(s string) string {
+	return strings.Replace(strings.Replace(strings.TrimSpace(s), "\n\n", "<br><br>", -1), "\n", " ", -1)
 }

--- a/print/print.go
+++ b/print/print.go
@@ -88,7 +88,7 @@ func Markdown(d *doc.Doc) (string, error) {
 	for _, v := range d.Outputs {
 		buf.WriteString(fmt.Sprintf("| %s | %s |\n",
 			v.Name,
-			strings.TrimSpace(v.Description)))
+			strings.Replace(strings.TrimSpace(v.Description), "\n", "<br>", -1)))
 	}
 
 	return buf.String(), nil


### PR DESCRIPTION
Hi all!

Amazing tool, been looking to use this for a while but just have had the time to dive into it now. Noticed a couple of things that seemed like low-hanging fruit to fix.

First off, I've never really ever used the `description` parameter in variables, taking a godoc-style approach to documenting both variables and outputs (ie: using top-level comments). IMO it breaks workflow to have to throw docs one place and then a different place for something that's very similar in nature. Hence, I made a little backwards-compatible change that allows for the use of comments *if* description is not specified.

Second off, it looks like if one has line breaks in descriptions, the resulting markdown is broken, as markdown tables require line breaks as `<br>` tags. So the (first) commit addresses that.

**One more**: added a placeholder for list types for now. This addresses #15 somewhat, would be nice to see defaults fully rendered for both lists and maps, but at least this will properly document if a list variable is required or not.

**And another!** Updated the header comment processing logic so it handled the extra whitespace character after the `*` if it exists. This ensures that the header data is not indented mistakenly (can break markdown in a few places). This could probably be handled a bit better, but it fixed the issues I was seeing.

Thanks again for making this, is going to help me immensely when maintaining docs for our modules!