### PR TITLE
Strip # prefix from comments

### DIFF
--- a/doc/doc.go
+++ b/doc/doc.go
@@ -196,6 +196,7 @@ func comment(l []*ast.Comment) string {
 
 	for _, t := range l {
 		line = strings.TrimSpace(t.Text)
+		line = strings.TrimPrefix(line, "#")
 		line = strings.TrimPrefix(line, "//")
 		ret += strings.TrimSpace(line) + "\n"
 	}


### PR DESCRIPTION
As it stands, comments like the following actually capture the `#` as part of the comment text:

```hcl
# a comment
output "something" {}
```
