### PR TITLE
Add note about installing with Homebrew

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,6 +15,7 @@
 
   - `go get github.com/segmentio/terraform-docs`
   - [Binaries](https://github.com/segmentio/terraform-docs/releases)
+  - `brew install terraform-docs` (on macOS)
 
 ## Usage
 


### PR DESCRIPTION
Just got `terraform-docs` into Homebrew here: https://github.com/Homebrew/homebrew-core/pull/11768.