### PR TITLE
Add support for printing the variable 'type' in Markdown.

### DIFF
--- a/doc/doc.go
+++ b/doc/doc.go
@@ -13,6 +13,7 @@ type Input struct {
 	Name        string
 	Description string
 	Default     *Value
+	Type        string
 }
 
 // Value returns the default value as a string.
@@ -97,11 +98,21 @@ func inputs(list *ast.ObjectList) []Input {
 			case item.LeadComment != nil:
 				desc = comment(item.LeadComment.List)
 			}
+
+			var item_type string
+			items_type := get(items, "type")
+			if items_type == nil || items_type.Literal == "" {
+				item_type = "string"
+			} else {
+				item_type = items_type.Literal
+			}
+
 			def := get(items, "default")
 			ret = append(ret, Input{
 				Name:        name,
 				Description: desc,
 				Default:     def,
+				Type:        item_type,
 			})
 		}
 	}

--- a/print/print.go
+++ b/print/print.go
@@ -59,8 +59,8 @@ func Markdown(d *doc.Doc) (string, error) {
 
 	if len(d.Inputs) > 0 {
 		buf.WriteString("\n## Inputs\n\n")
-		buf.WriteString("| Name | Description | Default | Required |\n")
-		buf.WriteString("|------|-------------|:-----:|:-----:|\n")
+		buf.WriteString("| Name | Description | Type | Default | Required |\n")
+		buf.WriteString("|------|-------------|:----:|:-----:|:-----:|\n")
 	}
 
 	for _, v := range d.Inputs {
@@ -72,9 +72,10 @@ func Markdown(d *doc.Doc) (string, error) {
 			def = fmt.Sprintf("`%s`", def)
 		}
 
-		buf.WriteString(fmt.Sprintf("| %s | %s | %s | %v |\n",
+		buf.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %v |\n",
 			v.Name,
 			normalizeMarkdownDesc(v.Description),
+			v.Type,
 			def,
 			humanize(v.Default)))
 	}


### PR DESCRIPTION
I thought it would be really useful if it was possible to document the variable type in addition to the existing documentation. So I've added support :) 

Currently only markdown supported, but trivial to add to other outputs.