### PR TITLE
*: add --no-required option

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ var version = "v0.1.0"
 
 const usage = `
   Usage:
-    terraform-docs [json | md | markdown] <path>...
+    terraform-docs [--no-required] [json | md | markdown] <path>...
     terraform-docs -h | --help
 
   Examples:
@@ -34,6 +34,9 @@ const usage = `
 
     # Generate markdown tables of inputs and outputs
     $ teraform-docs md ./my-module
+
+    # Generate markdown tables of inputs and outputs, but don't print "Required" column
+    $ teraform-docs --no-required md ./my-module
 
     # Generate markdown tables of inputs and outputs for the given module and ../config.tf
     $ teraform-docs md ./my-module ../config.tf
@@ -87,14 +90,15 @@ func main() {
 	}
 
 	doc := doc.Create(files)
+	printRequired := !args["--no-required"].(bool)
 
 	var out string
 
 	switch {
 	case args["markdown"].(bool):
-		out, err = print.Markdown(doc)
+		out, err = print.Markdown(doc, printRequired)
 	case args["md"].(bool):
-		out, err = print.Markdown(doc)
+		out, err = print.Markdown(doc, printRequired)
 	case args["json"].(bool):
 		out, err = print.JSON(doc)
 	default:

--- a/print/print.go
+++ b/print/print.go
@@ -50,7 +50,7 @@ func Pretty(d *doc.Doc) (string, error) {
 }
 
 // Markdown prints the given doc as markdown.
-func Markdown(d *doc.Doc) (string, error) {
+func Markdown(d *doc.Doc, printRequired bool) (string, error) {
 	var buf bytes.Buffer
 
 	if len(d.Comment) > 0 {
@@ -59,8 +59,20 @@ func Markdown(d *doc.Doc) (string, error) {
 
 	if len(d.Inputs) > 0 {
 		buf.WriteString("\n## Inputs\n\n")
-		buf.WriteString("| Name | Description | Type | Default | Required |\n")
-		buf.WriteString("|------|-------------|:----:|:-----:|:-----:|\n")
+		buf.WriteString("| Name | Description | Type | Default |")
+
+		if printRequired {
+			buf.WriteString(" Required |\n")
+		} else {
+			buf.WriteString("\n")
+		}
+
+		buf.WriteString("|------|-------------|:----:|:-----:|")
+		if printRequired {
+			buf.WriteString(":-----:|\n")
+		} else {
+			buf.WriteString("\n")
+		}
 	}
 
 	for _, v := range d.Inputs {
@@ -72,12 +84,18 @@ func Markdown(d *doc.Doc) (string, error) {
 			def = fmt.Sprintf("`%s`", def)
 		}
 
-		buf.WriteString(fmt.Sprintf("| %s | %s | %s | %s | %v |\n",
+		buf.WriteString(fmt.Sprintf("| %s | %s | %s | %s |",
 			v.Name,
 			normalizeMarkdownDesc(v.Description),
 			v.Type,
-			def,
-			humanize(v.Default)))
+			def))
+
+		if printRequired {
+			buf.WriteString(fmt.Sprintf(" %v |\n",
+				humanize(v.Default)))
+		} else {
+			buf.WriteString("\n")
+		}
 	}
 
 	if len(d.Outputs) > 0 {


### PR DESCRIPTION
Terraform implies a variable being required if you don't specify a default value, see [1].
Only if you leave out a default value the above "Required" column becomes a meaning.

The reality is, we specify a lot of default values for variables that are indeed required
but for whom we provide a sane default.

Furthermore we also specify quite some default empty string values "" for variables
which indeed are required, but we still cannot leave them out to mark them as required,
because of limitations in terraform where those values are being used in ternary operators.

Therefore the "Required" markdown column is meaningless in a lot of use
cases. This fixes it by introducing a `--no-required` option for markdown
generation which simply does not print it. It defaults to
false to retain current functionality.

[1] https://www.terraform.io/intro/getting-started/variables.html#defining-variables