### PR TITLE
If there is a description on an output, it should be considered before the preceding comment

### DIFF
--- a/doc/doc.go
+++ b/doc/doc.go
@@ -140,15 +140,15 @@ func outputs(list *ast.ObjectList) []Output {
 			items := item.Val.(*ast.ObjectType).List.Items
 			var desc string
 			switch {
-			case item.LeadComment != nil:
-				desc = comment(item.LeadComment.List)
 			case description(items) != "":
 				desc = description(items)
+			case item.LeadComment != nil:
+				desc = comment(item.LeadComment.List)
 			}
 
 			ret = append(ret, Output{
 				Name:        name,
-				Description: desc,
+				Description: strings.TrimSpace(desc),
 			})
 		}
 	}


### PR DESCRIPTION
We have something like that in our terraform code:

```
#------------------------------------------------------------------------------
# Output variables
#------------------------------------------------------------------------------
output "out1" {
  description = "Description of out1"
  value       = "out1"
}

output "out2" {
  description = "Description of out2"
  value       = "out2"
}
```

If the comment is directly before our first output, the comment is considered as the description of out1 even if there is an explicit description. I think that explicit description should prevail over comment.