### PR TITLE
Extend options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist
+vendor

--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,7 @@
 
   - View docs for inputs and outputs
   - Generate docs for inputs and outputs
-  - Generate JSON docs (for customizing presentation)
+  - Generate JSON, YAML or HCL docs (for customizing presentation)
   - Generate markdown tables of inputs and outputs
 
 ## Installation
@@ -20,31 +20,39 @@
 ## Usage
 
 ```bash
+Usage:
+  terraform-docs [--inputs| --outputs] [--detailed] [--no-required] [--out-values=<file>] [--var-file=<file>...] [--color| --no-color] [json | yaml | hcl | md | markdown | xml] [<path>...]
+  terraform-docs -h | --help
 
-  Usage:
-    terraform-docs [json | md | markdown] <path>...
-    terraform-docs -h | --help
+Examples:
+  # View inputs and outputs
+  $ terraform-docs ./my-module
 
-  Examples:
+  # View inputs and outputs for variables.tf and outputs.tf only
+  $ terraform-docs variables.tf outputs.tf
 
-    # View inputs and outputs
-    $ terraform-docs ./my-module
+  # Generate a JSON of inputs and outputs
+  $ terraform-docs json ./my-module
 
-    # View inputs and outputs for variables.tf and outputs.tf only
-    $ terraform-docs variables.tf outputs.tf
+  # Generate markdown tables of inputs and outputs
+  $ terraform-docs md ./my-module
 
-    # Generate a JSON of inputs and outputs
-    $ terraform-docs json ./my-module
+  # Generate markdown tables of inputs and outputs, but don't print "Required" column
+  $ terraform-docs --no-required md ./my-module
 
-    # Generate markdown tables of inputs and outputs
-    $ terraform-docs md ./my-module
+  # Generate markdown tables of inputs and outputs for the given module and ../config.tf
+  $ terraform-docs md ./my-module ../config.tf
 
-    # Generate markdown tables of inputs and outputs for the given module and ../config.tf
-    $ terraform-docs md ./my-module ../config.tf
-
-  Options:
-    -h, --help     show help information
-
+Options:
+  -i, --inputs             Render only inputs
+  -o, --outputs            Render only outputs
+  -d, --detailed           Render detailed value for <list> and <map>
+      --color              Force rendering of color even if the output is redirected or piped
+      --no-color           Do not use color to render the result
+      --no-required        Do not output "Required" column
+      --out-values=<file>  File used to get output values (result of 'terraform output -json' or 'terraform plan -out file')
+  -v, --var-file=<file>... Files used to assign values to terraform variables (HCL format)
+  -h, --help               Show help information
 ```
 
 ## Example
@@ -62,7 +70,14 @@ variable "subnet_ids" {
 
 // The VPC ID.
 output "vpc_id" {
-  value = "vpc-5c1f55fd"
+  value     = "vpc-5c1f55fd"
+  sensitive = true
+}
+
+// This comment will be ignored
+output "vpc_cidr" {
+  value       = "10.1.0.0/24"
+  description = "The VPC CIDR"
 }
 
 ```
@@ -89,10 +104,22 @@ $ terraform-docs json _example
   "Outputs": [
     {
       "Name": "vpc_id",
-      "Description": "The VPC ID.\n"
+      "Description": "The VPC ID."
+    },
+    {
+      "Name": "vpc_cidr",
+      "Description": "The VPC CIDR"
     }
   ]
 }
+```
+
+To output YAML outputs:
+
+```bash
+$ terraform-docs yaml _example --outputs
+- name: vpc_id
+  description: The VPC ID.
 ```
 
 To output markdown docs:
@@ -113,9 +140,32 @@ This module has a variable and an output.  This text here will be output before 
 | Name | Description |
 |------|-------------|
 | vpc_id | The VPC ID. |
+| vpc_cidr | The VPC CIDR |
 
 ```
 
+To output markdown docs with resulting output:
+
+```bash
+$ terraform plan -out current_plan
+$ terraform-docs --out-values current_plan md _example
+This module has a variable and an output.  This text here will be output before any inputs or outputs!
+
+
+## Inputs
+
+| Name | Description | Default | Required |
+|------|-------------|:-----:|:-----:|
+| subnet_ids | a comma-separated list of subnet IDs | - | yes |
+
+## Outputs
+
+| Name | Description | Value | Type | Sensitive |
+|------|-------------|-------|------|-----------|
+| vpc_id | The VPC ID. | vpc-5c1f55fd | string | true |
+| vpc_cidr | The VPC CIDR | 10.1.0.0/24 | string | false |
+
+```
 ## License
 
 MIT License

--- a/Readme.md
+++ b/Readme.md
@@ -47,10 +47,10 @@ Options:
   -i, --inputs             Render only inputs
   -o, --outputs            Render only outputs
   -d, --detailed           Render detailed value for <list> and <map>
-      --color              Force rendering of color even if the output is redirected or piped
-      --no-color           Do not use color to render the result
-      --no-required        Do not output "Required" column
-      --out-values=<file>  File used to get output values (result of 'terraform output -json' or 'terraform plan -out file')
+  -c, --color              Force rendering of color even if the output is redirected or piped
+  -C, --no-color           Do not use color to render the result
+  -R, --no-required        Do not output "Required" column
+  -O, --out-values=<file>  File used to get output values (result of 'terraform output -json' or 'terraform plan -out file')
   -v, --var-file=<file>... Files used to assign values to terraform variables (HCL format)
   -h, --help               Show help information
 ```

--- a/doc/doc.go
+++ b/doc/doc.go
@@ -12,10 +12,10 @@ import (
 
 // Input represents a terraform input variable.
 type Input struct {
-	Name        string `json:"Name,omitempty" xml:",attr"`
-	Description string `json:"Description,omitempty" xml:",comment"`
-	Default     *Value `json:"Default,omitempty"`
-	Type        string `json:"Type,omitempty" xml:",attr"`
+	Name        string `xml:",attr"`
+	Description string `json:",omitempty" xml:",comment"`
+	Default     *Value `json:",omitempty"`
+	Type        string `json:",omitempty" xml:",attr"`
 }
 
 // Value returns the default value as a string.

--- a/doc/doc.go
+++ b/doc/doc.go
@@ -1,6 +1,7 @@
 package doc
 
 import (
+	"fmt"
 	"path"
 	"sort"
 	"strconv"
@@ -11,10 +12,10 @@ import (
 
 // Input represents a terraform input variable.
 type Input struct {
-	Name        string
-	Description string
-	Default     *Value
-	Type        string
+	Name        string `json:"Name,omitempty" xml:",attr"`
+	Description string `json:"Description,omitempty" xml:",comment"`
+	Default     *Value `json:"Default,omitempty"`
+	Type        string `json:"Type,omitempty" xml:",attr"`
 }
 
 // Value returns the default value as a string.
@@ -41,15 +42,30 @@ type Value struct {
 
 // Output represents a terraform output.
 type Output struct {
-	Name        string
-	Description string
+	Name          string `xml:",attr"`
+	Description   string `json:",omitempty" yaml:",omitempty" xml:",comment"`
+	*OutputResult `json:",omitempty" yaml:"result,omitempty"`
+}
+
+// OutputResult represents a terraform output value.
+type OutputResult struct {
+	Sensitive bool        `json:",omitempty" yaml:",omitempty" xml:",attr,omitempty"`
+	Type      string      `json:",omitempty" yaml:",omitempty" xml:",attr,omitempty"`
+	Value     interface{} `json:",omitempty" yaml:",omitempty" xml:",omitempty"`
+}
+
+func (o Output) String() string {
+	if o.OutputResult == nil {
+		return ""
+	}
+	return fmt.Sprintf("%v", o.OutputResult.Value)
 }
 
 // Doc represents a terraform module doc.
 type Doc struct {
-	Comment string
-	Inputs  []Input
-	Outputs []Output
+	Comment string   `json:",omitempty" yaml:",omitempty"  xml:",comment"`
+	Inputs  []Input  `json:",omitempty" yaml:",omitempty" xml:"Inputs>Input"`
+	Outputs []Output `json:",omitempty" yaml:",omitempty" xml:"Outputs>Output"`
 }
 
 type inputsByName []Input

--- a/doc/doc.go
+++ b/doc/doc.go
@@ -44,7 +44,7 @@ type Value struct {
 type Output struct {
 	Name        string `xml:",attr"`
 	Description string `json:",omitempty" yaml:",omitempty" xml:",comment"`
-	Result      `yaml:",inline,omitempty"`
+	Result      `yaml:",inline,omitempty" hcl:",inline,omitempty"`
 }
 
 // Result represents a terraform output value.
@@ -63,9 +63,9 @@ func (o Output) String() string {
 
 // Doc represents a terraform module doc.
 type Doc struct {
-	Comment string   `json:",omitempty" yaml:",omitempty"  xml:",comment"`
-	Inputs  []Input  `json:",omitempty" yaml:",omitempty" xml:"Inputs>Input"`
-	Outputs []Output `json:",omitempty" yaml:",omitempty" xml:"Outputs>Output"`
+	Comment string   `json:",omitempty" yaml:",omitempty" xml:",comment"`
+	Inputs  []Input  `json:"inputs,omitempty" yaml:",omitempty" xml:"Inputs>Input"`
+	Outputs []Output `json:"outputs,omitempty" yaml:",omitempty" xml:"Outputs>Output"`
 }
 
 type inputsByName []Input

--- a/doc/doc.go
+++ b/doc/doc.go
@@ -42,23 +42,23 @@ type Value struct {
 
 // Output represents a terraform output.
 type Output struct {
-	Name          string `xml:",attr"`
-	Description   string `json:",omitempty" yaml:",omitempty" xml:",comment"`
-	*OutputResult `json:",omitempty" yaml:"result,omitempty"`
+	Name        string `xml:",attr"`
+	Description string `json:",omitempty" yaml:",omitempty" xml:",comment"`
+	Result      `yaml:",inline,omitempty"`
 }
 
-// OutputResult represents a terraform output value.
-type OutputResult struct {
+// Result represents a terraform output value.
+type Result struct {
 	Sensitive bool        `json:",omitempty" yaml:",omitempty" xml:",attr,omitempty"`
 	Type      string      `json:",omitempty" yaml:",omitempty" xml:",attr,omitempty"`
 	Value     interface{} `json:",omitempty" yaml:",omitempty" xml:",omitempty"`
 }
 
 func (o Output) String() string {
-	if o.OutputResult == nil {
+	if o.Result.Value == nil {
 		return ""
 	}
-	return fmt.Sprintf("%v", o.OutputResult.Value)
+	return fmt.Sprintf("%v", o.Result.Value)
 }
 
 // Doc represents a terraform module doc.

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 904128e58fa28fdd1dcd91197a148c6a057a71de62f0d2898236bbacf0c0a6cc
-updated: 2017-12-22T16:18:30.504555879-05:00
+updated: 2018-01-30T18:58:07.819108-05:00
 imports:
 - name: github.com/agext/levenshtein
   version: 5f10fee965225ac1eecdc234c09daf5cd9e7f7b6
@@ -16,7 +16,7 @@ imports:
 - name: github.com/armon/go-radix
   version: 1fca145dffbcaa8fe914309b1ec0cfc67500fe61
 - name: github.com/aws/aws-sdk-go
-  version: 25ef42b41b82230caae56ab23d872c81fb5c0eae
+  version: 1b176c5c6b57adb03bb982c21930e708ebca5a77
   subpackages:
   - aws
   - aws/awserr
@@ -52,34 +52,35 @@ imports:
 - name: github.com/blang/semver
   version: 2ee87856327ba09384cabd113bc6b5d174e9ec0f
 - name: github.com/coveo/gotemplate
-  version: e89bb7a1ed53217c3942626f013fe1d25aa9e82d
+  version: d8c6f49325bd70c88abb5fe6c82b199b651b5d69
   subpackages:
   - errors
+  - hcl
   - utils
 - name: github.com/drhodes/goLorem
   version: ecccc744c2d953a1e13cbe5e5fc5d4cbc9b8daeb
 - name: github.com/fatih/color
   version: 5df930a27be2502f99b292b7cc09ebad4d0891f4
 - name: github.com/fatih/structs
-  version: f5faa72e73092639913f5833b75e1ac1d6bc7a63
+  version: ebf56d35bba727c68ac77f56f2fcf90b181851aa
 - name: github.com/go-errors/errors
-  version: 8fa88b06e5974e97fbf9899a7f86a344bfd1f105
+  version: 3afebba5a48dbc89b574d890b6b34d9ee10b4785
 - name: github.com/go-ini/ini
-  version: f384f410798cbe7cdce40eec40b79ed32bb4f1ad
+  version: 32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a
 - name: github.com/hashicorp/errwrap
   version: 7554cd9344cec97297fa6649b055a8c98c2a1e55
 - name: github.com/hashicorp/go-cleanhttp
-  version: 3573b8b52aa7b37b9358d966a898feb387f62437
+  version: d5fe4b57a186c716b0e00b8c301cbd9b4182694d
 - name: github.com/hashicorp/go-getter
-  version: 2f449c791e6af9e532bc1aca36d1d3865b8537f9
+  version: 285374cdfad63de2c43d7562f49ced6dde5a7ba0
   subpackages:
   - helper/url
 - name: github.com/hashicorp/go-multierror
-  version: 83588e72410abfbe4df460eeb6f30841ae47d4c4
+  version: b7773ae218740a7be65057fc60b366a49b538a44
 - name: github.com/hashicorp/go-uuid
   version: 64130c7a86d732268a38cb04cfbaf0cc987fda98
 - name: github.com/hashicorp/go-version
-  version: fc61389e27c71d120f87031ca8c88a3428f372dd
+  version: 4fe82ae3040f80a03d04d2cccb5606a626b8e1ee
 - name: github.com/hashicorp/hcl
   version: 23c074d0eceb2b8a5bfdbb271ab780cde70f05a8
   subpackages:
@@ -92,7 +93,7 @@ imports:
   - json/scanner
   - json/token
 - name: github.com/hashicorp/hcl2
-  version: 44bad6dbf5490f5da17ec991e664df3d017b706f
+  version: f70b6b00c8b1946cc6b0b6dc949a1edd09b076bb
   subpackages:
   - gohcl
   - hcl
@@ -107,7 +108,7 @@ imports:
   - parser
   - scanner
 - name: github.com/hashicorp/terraform
-  version: a42fdb08a43c7fabb8898fe8c286b793bbaa4835
+  version: a6008b8a48a749c7c167453b9cf55ffd572b9a5d
   subpackages:
   - config
   - config/configschema
@@ -118,6 +119,7 @@ imports:
   - helper/hilmapstructure
   - moduledeps
   - plugin/discovery
+  - registry
   - registry/regsrc
   - registry/response
   - svchost
@@ -131,7 +133,7 @@ imports:
 - name: github.com/imdario/mergo
   version: 7fe0c75c13abdee74b09fcacef5ea1c6bba6a874
 - name: github.com/jmespath/go-jmespath
-  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
+  version: dd801d4f4ce7ac746e7e7b4489d2fa600b3b096b
 - name: github.com/Masterminds/semver
   version: 59c29afe1a994eacb71c833025ca7acf874bb1da
 - name: github.com/Masterminds/sprig
@@ -141,8 +143,9 @@ imports:
   repo: https://github.com/mattn/go-colorable
 - name: github.com/mattn/go-isatty
   version: 57fdcb988a5c543893cc61bce354a6e24ab70022
+  repo: https://github.com/mattn/go-isatty
 - name: github.com/mitchellh/cli
-  version: 65fcae5817c8600da98ada9d7edf26dd1a84837b
+  version: 518dc677a1e1222682f4e7db06721942cb8e9e4c
 - name: github.com/mitchellh/copystructure
   version: d23ffcb85de31694d6ccaa23ccb4a03e55c1303f
 - name: github.com/mitchellh/go-homedir
@@ -154,17 +157,17 @@ imports:
 - name: github.com/mitchellh/hashstructure
   version: 2bca23e0e452137f789efbc8610126fd8b94f73b
 - name: github.com/mitchellh/mapstructure
-  version: 06020f85339e21b2478f756a78e295255ffa4d6a
+  version: b4575eea38cca1123ec2dc90c26529b5c5acfcff
 - name: github.com/mitchellh/reflectwalk
   version: 63d60e9d0dbc60cf9164e6510889b0db6683d98c
 - name: github.com/posener/complete
-  version: 88e59760adaddb8276c9b15511302890690e2dae
+  version: cdc49b71388c2ab059f57997ef2575c9e8b4f146
   subpackages:
   - cmd
   - cmd/install
   - match
 - name: github.com/satori/go.uuid
-  version: 879c5887cd475cd7864858769793b2ceb0d44feb
+  version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - name: github.com/tj/docopt
   version: c8470e45692f168e8b380c5d625327e756d7d0a9
 - name: github.com/ulikunitz/xz
@@ -174,7 +177,7 @@ imports:
   - internal/xlog
   - lzma
 - name: github.com/zclconf/go-cty
-  version: 48ce95f3a00f37ac934ff90a62e377146f9428e1
+  version: 709e4033eeb037dc543dbc2048065dfb814ce316
   subpackages:
   - cty
   - cty/convert
@@ -184,7 +187,7 @@ imports:
   - cty/json
   - cty/set
 - name: golang.org/x/crypto
-  version: 2509b142fb2b797aa7587dad548f113b2c0f20ce
+  version: 1875d0a70c90e57f11972aefd42276df65e895b9
   subpackages:
   - bcrypt
   - blowfish
@@ -198,7 +201,7 @@ imports:
   - pbkdf2
   - scrypt
 - name: golang.org/x/net
-  version: 4b14673ba32bee7f5ac0f990a48f033919fd418b
+  version: 0ed95abb35c445290478a5348a7b38bb154135fd
   subpackages:
   - html
   - html/atom
@@ -209,12 +212,12 @@ imports:
   subpackages:
   - unix
 - name: golang.org/x/text
-  version: eb22672bea55af56d225d4e35405f4d2e9f062a0
+  version: e19ae1496984b1c655b8044a65c0300a3c878dd3
   subpackages:
   - secure/bidirule
   - transform
   - unicode/bidi
   - unicode/norm
 - name: gopkg.in/yaml.v2
-  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
+  version: d670f9405373e636a5a2765eea47fac0c9bc91a4
 testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,220 @@
+hash: 904128e58fa28fdd1dcd91197a148c6a057a71de62f0d2898236bbacf0c0a6cc
+updated: 2017-12-22T16:18:30.504555879-05:00
+imports:
+- name: github.com/agext/levenshtein
+  version: 5f10fee965225ac1eecdc234c09daf5cd9e7f7b6
+- name: github.com/aokoli/goutils
+  version: 3391d3790d23d03408670993e957e8f408993c34
+- name: github.com/apparentlymart/go-cidr
+  version: 2bd8b58cf4275aeb086ade613de226773e29e853
+  subpackages:
+  - cidr
+- name: github.com/apparentlymart/go-textseg
+  version: b836f5c4d331d1945a2fead7188db25432d73b69
+  subpackages:
+  - textseg
+- name: github.com/armon/go-radix
+  version: 1fca145dffbcaa8fe914309b1ec0cfc67500fe61
+- name: github.com/aws/aws-sdk-go
+  version: 25ef42b41b82230caae56ab23d872c81fb5c0eae
+  subpackages:
+  - aws
+  - aws/awserr
+  - aws/awsutil
+  - aws/client
+  - aws/client/metadata
+  - aws/corehandlers
+  - aws/credentials
+  - aws/credentials/ec2rolecreds
+  - aws/credentials/endpointcreds
+  - aws/credentials/stscreds
+  - aws/defaults
+  - aws/ec2metadata
+  - aws/endpoints
+  - aws/request
+  - aws/session
+  - aws/signer/v4
+  - internal/shareddefaults
+  - private/protocol
+  - private/protocol/query
+  - private/protocol/query/queryutil
+  - private/protocol/rest
+  - private/protocol/restxml
+  - private/protocol/xml/xmlutil
+  - service/s3
+  - service/sts
+- name: github.com/bgentry/go-netrc
+  version: 9fd32a8b3d3d3f9d43c341bfe098430e07609480
+  subpackages:
+  - netrc
+- name: github.com/bgentry/speakeasy
+  version: 4aabc24848ce5fd31929f7d1e4ea74d3709c14cd
+- name: github.com/blang/semver
+  version: 2ee87856327ba09384cabd113bc6b5d174e9ec0f
+- name: github.com/coveo/gotemplate
+  version: e89bb7a1ed53217c3942626f013fe1d25aa9e82d
+  subpackages:
+  - errors
+  - utils
+- name: github.com/drhodes/goLorem
+  version: ecccc744c2d953a1e13cbe5e5fc5d4cbc9b8daeb
+- name: github.com/fatih/color
+  version: 5df930a27be2502f99b292b7cc09ebad4d0891f4
+- name: github.com/fatih/structs
+  version: f5faa72e73092639913f5833b75e1ac1d6bc7a63
+- name: github.com/go-errors/errors
+  version: 8fa88b06e5974e97fbf9899a7f86a344bfd1f105
+- name: github.com/go-ini/ini
+  version: f384f410798cbe7cdce40eec40b79ed32bb4f1ad
+- name: github.com/hashicorp/errwrap
+  version: 7554cd9344cec97297fa6649b055a8c98c2a1e55
+- name: github.com/hashicorp/go-cleanhttp
+  version: 3573b8b52aa7b37b9358d966a898feb387f62437
+- name: github.com/hashicorp/go-getter
+  version: 2f449c791e6af9e532bc1aca36d1d3865b8537f9
+  subpackages:
+  - helper/url
+- name: github.com/hashicorp/go-multierror
+  version: 83588e72410abfbe4df460eeb6f30841ae47d4c4
+- name: github.com/hashicorp/go-uuid
+  version: 64130c7a86d732268a38cb04cfbaf0cc987fda98
+- name: github.com/hashicorp/go-version
+  version: fc61389e27c71d120f87031ca8c88a3428f372dd
+- name: github.com/hashicorp/hcl
+  version: 23c074d0eceb2b8a5bfdbb271ab780cde70f05a8
+  subpackages:
+  - hcl/ast
+  - hcl/parser
+  - hcl/scanner
+  - hcl/strconv
+  - hcl/token
+  - json/parser
+  - json/scanner
+  - json/token
+- name: github.com/hashicorp/hcl2
+  version: 44bad6dbf5490f5da17ec991e664df3d017b706f
+  subpackages:
+  - gohcl
+  - hcl
+  - hcl/hclsyntax
+  - hcl/json
+  - hcldec
+  - hclparse
+- name: github.com/hashicorp/hil
+  version: fa9f258a92500514cc8e9c67020487709df92432
+  subpackages:
+  - ast
+  - parser
+  - scanner
+- name: github.com/hashicorp/terraform
+  version: a42fdb08a43c7fabb8898fe8c286b793bbaa4835
+  subpackages:
+  - config
+  - config/configschema
+  - config/hcl2shim
+  - config/module
+  - dag
+  - flatmap
+  - helper/hilmapstructure
+  - moduledeps
+  - plugin/discovery
+  - registry/regsrc
+  - registry/response
+  - svchost
+  - svchost/auth
+  - svchost/disco
+  - terraform
+  - tfdiags
+  - version
+- name: github.com/huandu/xstrings
+  version: 37469d0c81a7910b49d64a0d308ded4823e90937
+- name: github.com/imdario/mergo
+  version: 7fe0c75c13abdee74b09fcacef5ea1c6bba6a874
+- name: github.com/jmespath/go-jmespath
+  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
+- name: github.com/Masterminds/semver
+  version: 59c29afe1a994eacb71c833025ca7acf874bb1da
+- name: github.com/Masterminds/sprig
+  version: 9d9aa1f74c86fd9d36ecfe3f2a44a3093c3d4c15
+- name: github.com/mattn/go-colorable
+  version: 5411d3eea5978e6cdc258b30de592b60df6aba96
+  repo: https://github.com/mattn/go-colorable
+- name: github.com/mattn/go-isatty
+  version: 57fdcb988a5c543893cc61bce354a6e24ab70022
+- name: github.com/mitchellh/cli
+  version: 65fcae5817c8600da98ada9d7edf26dd1a84837b
+- name: github.com/mitchellh/copystructure
+  version: d23ffcb85de31694d6ccaa23ccb4a03e55c1303f
+- name: github.com/mitchellh/go-homedir
+  version: b8bc1bf767474819792c23f32d8286a45736f1c6
+- name: github.com/mitchellh/go-testing-interface
+  version: a61a99592b77c9ba629d254a693acffaeb4b7e28
+- name: github.com/mitchellh/go-wordwrap
+  version: ad45545899c7b13c020ea92b2072220eefad42b8
+- name: github.com/mitchellh/hashstructure
+  version: 2bca23e0e452137f789efbc8610126fd8b94f73b
+- name: github.com/mitchellh/mapstructure
+  version: 06020f85339e21b2478f756a78e295255ffa4d6a
+- name: github.com/mitchellh/reflectwalk
+  version: 63d60e9d0dbc60cf9164e6510889b0db6683d98c
+- name: github.com/posener/complete
+  version: 88e59760adaddb8276c9b15511302890690e2dae
+  subpackages:
+  - cmd
+  - cmd/install
+  - match
+- name: github.com/satori/go.uuid
+  version: 879c5887cd475cd7864858769793b2ceb0d44feb
+- name: github.com/tj/docopt
+  version: c8470e45692f168e8b380c5d625327e756d7d0a9
+- name: github.com/ulikunitz/xz
+  version: 0c6b41e72360850ca4f98dc341fd999726ea007f
+  subpackages:
+  - internal/hash
+  - internal/xlog
+  - lzma
+- name: github.com/zclconf/go-cty
+  version: 48ce95f3a00f37ac934ff90a62e377146f9428e1
+  subpackages:
+  - cty
+  - cty/convert
+  - cty/function
+  - cty/function/stdlib
+  - cty/gocty
+  - cty/json
+  - cty/set
+- name: golang.org/x/crypto
+  version: 2509b142fb2b797aa7587dad548f113b2c0f20ce
+  subpackages:
+  - bcrypt
+  - blowfish
+  - cast5
+  - openpgp
+  - openpgp/armor
+  - openpgp/elgamal
+  - openpgp/errors
+  - openpgp/packet
+  - openpgp/s2k
+  - pbkdf2
+  - scrypt
+- name: golang.org/x/net
+  version: 4b14673ba32bee7f5ac0f990a48f033919fd418b
+  subpackages:
+  - html
+  - html/atom
+  - idna
+- name: golang.org/x/sys
+  version: e24f485414aeafb646f6fca458b0bf869c0880a1
+  repo: https://go.googlesource.com/sys
+  subpackages:
+  - unix
+- name: golang.org/x/text
+  version: eb22672bea55af56d225d4e35405f4d2e9f062a0
+  subpackages:
+  - secure/bidirule
+  - transform
+  - unicode/bidi
+  - unicode/norm
+- name: gopkg.in/yaml.v2
+  version: eb3733d160e74a9c7e442f435eb3bea458e1d19f
+testImports: []

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 904128e58fa28fdd1dcd91197a148c6a057a71de62f0d2898236bbacf0c0a6cc
-updated: 2018-01-30T18:58:07.819108-05:00
+updated: 2018-02-23T15:14:06.582522-05:00
 imports:
 - name: github.com/agext/levenshtein
   version: 5f10fee965225ac1eecdc234c09daf5cd9e7f7b6
@@ -16,7 +16,7 @@ imports:
 - name: github.com/armon/go-radix
   version: 1fca145dffbcaa8fe914309b1ec0cfc67500fe61
 - name: github.com/aws/aws-sdk-go
-  version: 1b176c5c6b57adb03bb982c21930e708ebca5a77
+  version: 146470bc6ef7d6667ef2e9d4ae54f19e98b8ba82
   subpackages:
   - aws
   - aws/awserr
@@ -34,6 +34,7 @@ imports:
   - aws/request
   - aws/session
   - aws/signer/v4
+  - internal/sdkrand
   - internal/shareddefaults
   - private/protocol
   - private/protocol/query
@@ -50,9 +51,9 @@ imports:
 - name: github.com/bgentry/speakeasy
   version: 4aabc24848ce5fd31929f7d1e4ea74d3709c14cd
 - name: github.com/blang/semver
-  version: 2ee87856327ba09384cabd113bc6b5d174e9ec0f
+  version: a088618caaf34f5392024fc3386143873033fbea
 - name: github.com/coveo/gotemplate
-  version: d8c6f49325bd70c88abb5fe6c82b199b651b5d69
+  version: 0eb6af00e4ea61482541d051ab0c23ef0c0e60da
   subpackages:
   - errors
   - hcl
@@ -60,19 +61,19 @@ imports:
 - name: github.com/drhodes/goLorem
   version: ecccc744c2d953a1e13cbe5e5fc5d4cbc9b8daeb
 - name: github.com/fatih/color
-  version: 5df930a27be2502f99b292b7cc09ebad4d0891f4
+  version: 507f6050b8568533fb3f5504de8e5205fa62a114
 - name: github.com/fatih/structs
   version: ebf56d35bba727c68ac77f56f2fcf90b181851aa
 - name: github.com/go-errors/errors
   version: 3afebba5a48dbc89b574d890b6b34d9ee10b4785
 - name: github.com/go-ini/ini
-  version: 32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a
+  version: 32e4be5f41bb918afb6e37c07426e2ddbcb6647e
 - name: github.com/hashicorp/errwrap
   version: 7554cd9344cec97297fa6649b055a8c98c2a1e55
 - name: github.com/hashicorp/go-cleanhttp
   version: d5fe4b57a186c716b0e00b8c301cbd9b4182694d
 - name: github.com/hashicorp/go-getter
-  version: 285374cdfad63de2c43d7562f49ced6dde5a7ba0
+  version: da1332ad370dd543e363ee5ad0098987f60a429a
   subpackages:
   - helper/url
 - name: github.com/hashicorp/go-multierror
@@ -93,7 +94,7 @@ imports:
   - json/scanner
   - json/token
 - name: github.com/hashicorp/hcl2
-  version: f70b6b00c8b1946cc6b0b6dc949a1edd09b076bb
+  version: a42f1fdb237b38714f3bf58a3498fe9706c46981
   subpackages:
   - gohcl
   - hcl
@@ -108,7 +109,7 @@ imports:
   - parser
   - scanner
 - name: github.com/hashicorp/terraform
-  version: a6008b8a48a749c7c167453b9cf55ffd572b9a5d
+  version: 3802b14260603f90c7a1faf55994dcc8933e2069
   subpackages:
   - config
   - config/configschema
@@ -129,21 +130,19 @@ imports:
   - tfdiags
   - version
 - name: github.com/huandu/xstrings
-  version: 37469d0c81a7910b49d64a0d308ded4823e90937
+  version: 2bf18b218c51864a87384c06996e40ff9dcff8e1
 - name: github.com/imdario/mergo
   version: 7fe0c75c13abdee74b09fcacef5ea1c6bba6a874
 - name: github.com/jmespath/go-jmespath
-  version: dd801d4f4ce7ac746e7e7b4489d2fa600b3b096b
+  version: c2b33e8439af944379acbdd9c3a5fe0bc44bd8a5
 - name: github.com/Masterminds/semver
   version: 59c29afe1a994eacb71c833025ca7acf874bb1da
 - name: github.com/Masterminds/sprig
   version: 9d9aa1f74c86fd9d36ecfe3f2a44a3093c3d4c15
 - name: github.com/mattn/go-colorable
   version: 5411d3eea5978e6cdc258b30de592b60df6aba96
-  repo: https://github.com/mattn/go-colorable
 - name: github.com/mattn/go-isatty
   version: 57fdcb988a5c543893cc61bce354a6e24ab70022
-  repo: https://github.com/mattn/go-isatty
 - name: github.com/mitchellh/cli
   version: 518dc677a1e1222682f4e7db06721942cb8e9e4c
 - name: github.com/mitchellh/copystructure
@@ -157,7 +156,7 @@ imports:
 - name: github.com/mitchellh/hashstructure
   version: 2bca23e0e452137f789efbc8610126fd8b94f73b
 - name: github.com/mitchellh/mapstructure
-  version: b4575eea38cca1123ec2dc90c26529b5c5acfcff
+  version: 00c29f56e2386353d58c599509e8dc3801b0d716
 - name: github.com/mitchellh/reflectwalk
   version: 63d60e9d0dbc60cf9164e6510889b0db6683d98c
 - name: github.com/posener/complete
@@ -177,7 +176,7 @@ imports:
   - internal/xlog
   - lzma
 - name: github.com/zclconf/go-cty
-  version: 709e4033eeb037dc543dbc2048065dfb814ce316
+  version: a314db697f753da23560cb1a2a58cf344eff916b
   subpackages:
   - cty
   - cty/convert
@@ -187,7 +186,7 @@ imports:
   - cty/json
   - cty/set
 - name: golang.org/x/crypto
-  version: 1875d0a70c90e57f11972aefd42276df65e895b9
+  version: 49796115aa4b964c318aad4f3084fdb41e9aa067
   subpackages:
   - bcrypt
   - blowfish
@@ -201,23 +200,22 @@ imports:
   - pbkdf2
   - scrypt
 - name: golang.org/x/net
-  version: 0ed95abb35c445290478a5348a7b38bb154135fd
+  version: cbe0f9307d0156177f9dd5dc85da1a31abc5f2fb
   subpackages:
   - html
   - html/atom
   - idna
 - name: golang.org/x/sys
-  version: e24f485414aeafb646f6fca458b0bf869c0880a1
-  repo: https://go.googlesource.com/sys
+  version: 88d2dcc510266da9f7f8c7f34e1940716cab5f5c
   subpackages:
   - unix
 - name: golang.org/x/text
-  version: e19ae1496984b1c655b8044a65c0300a3c878dd3
+  version: 27420a1a391f5504f73155051cd274311bf70883
   subpackages:
   - secure/bidirule
   - transform
   - unicode/bidi
   - unicode/norm
 - name: gopkg.in/yaml.v2
-  version: d670f9405373e636a5a2765eea47fac0c9bc91a4
+  version: 7f97868eec74b32b0982dd158a51a446d1da7eb5
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,14 @@
+package: github.com/segmentio/terraform-docs
+import:
+- package: github.com/coveo/gotemplate
+  subpackages:
+  - utils
+- package: github.com/fatih/structs
+- package: github.com/hashicorp/hcl
+  subpackages:
+  - hcl/ast
+- package: github.com/hashicorp/terraform
+  subpackages:
+  - terraform
+- package: github.com/tj/docopt
+- package: gopkg.in/yaml.v2

--- a/main.go
+++ b/main.go
@@ -47,10 +47,10 @@ Options:
   -i, --inputs             Render only inputs
   -o, --outputs            Render only outputs
   -d, --detailed           Render detailed value for <list> and <map>
-      --color              Force rendering of color even if the output is redirected or piped
-      --no-color           Do not use color to render the result
-      --no-required        Do not output "Required" column
-      --out-values=<file>  File used to get output values (result of 'terraform output -json' or 'terraform plan -out file')
+  -c, --color              Force rendering of color even if the output is redirected or piped
+  -C, --no-color           Do not use color to render the result
+  -R, --no-required        Do not output "Required" column
+  -O, --out-values=<file>  File used to get output values (result of 'terraform output -json' or 'terraform plan -out file')
   -v, --var-file=<file>... Files used to assign values to terraform variables (HCL format) 
   -h, --help               Show help information
 `
@@ -156,7 +156,7 @@ func main() {
 		for i := range document.Outputs {
 			o := &document.Outputs[i]
 			if matched := outputs[o.Name]; matched != nil {
-				o.OutputResult = &doc.OutputResult{Sensitive: matched.Sensitive, Type: matched.Type, Value: matched.Value}
+				o.Result = doc.Result{Sensitive: matched.Sensitive, Type: matched.Type, Value: matched.Value}
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -173,7 +173,7 @@ func main() {
 	case args["yaml"].(bool):
 		out, err = print.YAML(document, renderMode)
 	case args["hcl"].(bool):
-		out = print.HCL(document, renderMode)
+		out, err = print.HCL(document, renderMode)
 	case args["xml"].(bool):
 		out, err = print.XML(document, renderMode)
 	default:

--- a/main.go
+++ b/main.go
@@ -1,14 +1,17 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
 
+	"github.com/fatih/color"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
+	"github.com/hashicorp/terraform/terraform"
 	"github.com/segmentio/terraform-docs/doc"
 	"github.com/segmentio/terraform-docs/print"
 	"github.com/tj/docopt"
@@ -17,43 +20,60 @@ import (
 var version = "dev"
 
 const usage = `
-  Usage:
-    terraform-docs [--no-required] [json | md | markdown] <path>...
-    terraform-docs -h | --help
+Usage:
+  terraform-docs [--inputs| --outputs] [--detailed] [--no-required] [--out-values=<file>] [--var-file=<file>...] [--color| --no-color] [json | yaml | hcl | md | markdown | xml] [<path>...]
+  terraform-docs -h | --help
 
-  Examples:
+Examples:
+  # View inputs and outputs
+  $ terraform-docs ./my-module
 
-    # View inputs and outputs
-    $ terraform-docs ./my-module
+  # View inputs and outputs for variables.tf and outputs.tf only
+  $ terraform-docs variables.tf outputs.tf
 
-    # View inputs and outputs for variables.tf and outputs.tf only
-    $ terraform-docs variables.tf outputs.tf
+  # Generate a JSON of inputs and outputs
+  $ terraform-docs json ./my-module
 
-    # Generate a JSON of inputs and outputs
-    $ terraform-docs json ./my-module
+  # Generate markdown tables of inputs and outputs
+  $ terraform-docs md ./my-module
 
-    # Generate markdown tables of inputs and outputs
-    $ terraform-docs md ./my-module
+  # Generate markdown tables of inputs and outputs, but don't print "Required" column
+  $ terraform-docs --no-required md ./my-module
 
-    # Generate markdown tables of inputs and outputs, but don't print "Required" column
-    $ terraform-docs --no-required md ./my-module
+  # Generate markdown tables of inputs and outputs for the given module and ../config.tf
+  $ terraform-docs md ./my-module ../config.tf
 
-    # Generate markdown tables of inputs and outputs for the given module and ../config.tf
-    $ terraform-docs md ./my-module ../config.tf
-
-  Options:
-    -h, --help     show help information
-
+Options:
+  -i, --inputs             Render only inputs
+  -o, --outputs            Render only outputs
+  -d, --detailed           Render detailed value for <list> and <map>
+      --color              Force rendering of color even if the output is redirected or piped
+      --no-color           Do not use color to render the result
+      --no-required        Do not output "Required" column
+      --out-values=<file>  File used to get output values (result of 'terraform output -json' or 'terraform plan -out file')
+  -v, --var-file=<file>... Files used to assign values to terraform variables (HCL format) 
+  -h, --help               Show help information
 `
 
 func main() {
-	args, err := docopt.Parse(usage, nil, true, version, true)
+	args, err := docopt.Parse(usage, nil, true, version, false)
 	if err != nil {
 		log.Fatal(err)
 	}
 
+	// If color options are specified, set the color mode (if nothing is specified, the color mode is determined by the library depending
+	// if the output is redirected or piped or rendered to console)
+	if args["--color"].(bool) {
+		color.NoColor = false
+	} else if args["--no-color"].(bool) {
+		color.NoColor = true
+	}
+
 	var names []string
 	paths := args["<path>"].([]string)
+	if len(paths) == 0 {
+		paths = []string{"."}
+	}
 	for _, p := range paths {
 		pi, err := os.Stat(p)
 		if err != nil {
@@ -89,20 +109,75 @@ func main() {
 		files[name] = f
 	}
 
-	doc := doc.Create(files)
+	document := doc.Create(files)
+
+	// Determine the render mode parameters
+	var renderMode print.RenderMode
+	if args["--inputs"].(bool) {
+		renderMode |= print.RenderInputs
+	}
+	if args["--outputs"].(bool) {
+		renderMode |= print.RenderOutputs
+	}
+	if args["--detailed"].(bool) {
+		renderMode |= print.RenderDetailed
+	}
+	if renderMode&print.RenderAll == 0 {
+		renderMode |= print.RenderAll
+	}
+
+	// Import the optionally supplied tfvars files
+	vars := make(map[string]interface{})
+	for _, file := range args["--var-file"].([]string) {
+		if content, err := LoadHCL(file); err != nil {
+			log.Fatal(err)
+		} else {
+			for k, v := range content {
+				vars[k] = v
+			}
+		}
+	}
+	for i := range document.Inputs {
+		i := &document.Inputs[i]
+		if value, ok := vars[i.Name]; ok {
+			if i.Default == nil {
+				i.Default = &doc.Value{"", ""}
+			}
+			i.Default.Literal = fmt.Sprintf("%v", value)
+		}
+	}
+
+	// Import the optionally supplied outputs file
+	if outFile := args["--out-values"]; outFile != nil {
+		outputs, err := LoadOutputs(outFile.(string))
+		if err != nil {
+			log.Fatal(err)
+		}
+		for i := range document.Outputs {
+			o := &document.Outputs[i]
+			if matched := outputs[o.Name]; matched != nil {
+				o.OutputResult = &doc.OutputResult{Sensitive: matched.Sensitive, Type: matched.Type, Value: matched.Value}
+			}
+		}
+	}
+
 	printRequired := !args["--no-required"].(bool)
 
 	var out string
 
 	switch {
-	case args["markdown"].(bool):
-		out, err = print.Markdown(doc, printRequired)
-	case args["md"].(bool):
-		out, err = print.Markdown(doc, printRequired)
+	case args["markdown"].(bool) || args["md"].(bool):
+		out, err = print.Markdown(document, renderMode, printRequired, args["--out-values"] != nil)
 	case args["json"].(bool):
-		out, err = print.JSON(doc)
+		out, err = print.JSON(document, renderMode)
+	case args["yaml"].(bool):
+		out, err = print.YAML(document, renderMode)
+	case args["hcl"].(bool):
+		out = print.HCL(document, renderMode)
+	case args["xml"].(bool):
+		out, err = print.XML(document, renderMode)
 	default:
-		out, err = print.Pretty(doc)
+		out, err = print.Pretty(document, renderMode)
 	}
 
 	if err != nil {
@@ -110,4 +185,37 @@ func main() {
 	}
 
 	fmt.Println(out)
+}
+
+// LoadHCL loads hcl file into variable
+func LoadHCL(filename string) (result map[string]interface{}, err error) {
+	if content, err := ioutil.ReadFile(filename); err == nil {
+		err = hcl.Unmarshal(content, &result)
+	}
+	return
+}
+
+// LoadOutputs loads output values coming either from a JSON file resulting of 'terraform output -json' or
+// the outputs contained in the out file resulting of 'terraform plan -out <file>'
+func LoadOutputs(filename string) (result map[string]*terraform.OutputState, err error) {
+	reader, err := os.Open(filename)
+	if err != nil {
+		return
+	}
+	plan, err := terraform.ReadPlan(reader)
+	if err != nil {
+		reader.Seek(0, 0)
+		// The outFile may be a JSON file
+		var content []byte
+		if content, err = ioutil.ReadAll(reader); err == nil {
+			err = json.Unmarshal(content, &result)
+		}
+		if err != nil {
+			err = fmt.Errorf("The out-values file must be either a JSON file resulting from 'terraform output -json' or the out file produced by 'terraform plan -out <file>': %v", err)
+			return
+		}
+	} else {
+		result = plan.State.Modules[0].Outputs
+	}
+	return
 }

--- a/print/print.go
+++ b/print/print.go
@@ -3,124 +3,208 @@ package print
 import (
 	"bytes"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"strings"
 
+	coveoutils "github.com/coveo/gotemplate/utils"
+	"github.com/fatih/color"
 	"github.com/segmentio/terraform-docs/doc"
+	yaml "gopkg.in/yaml.v2"
 )
 
+// RenderMode represents the mode used to render the results
+type RenderMode int
+
+const (
+	renderNone RenderMode = iota
+	// RenderInputs = Only render Inputs
+	RenderInputs
+	// RenderOutputs = Only render Outputs
+	RenderOutputs
+	// RenderAll = render both Inputs & Outputs
+	RenderAll
+	// RenderDetailed = render content of lists & maps
+	RenderDetailed
+)
+
+//var dimmed = color.New(color.FgHiWhite, color.Bold, color.Faint, color.Italic).Sprintf
+var dimmed = color.New(color.FgHiBlack, color.Bold, color.Italic).Sprintf
+
+func varStr(name string) string { return color.CyanString(fmt.Sprintf("var.%s", name)) }
+func outStr(name string) string { return color.CyanString(fmt.Sprintf("output.%s", name)) }
+
+func valStr(value interface{}) string {
+	if value == nil {
+		return ""
+	}
+	return color.WhiteString(fmt.Sprintf(" (%v)", value))
+}
+
+func desStr(description string) string {
+	if description == "" {
+		return ""
+	}
+	return fmt.Sprintf("\n%s", dimmed(description))
+}
+
 // Pretty printer pretty prints a doc.
-func Pretty(d *doc.Doc) (string, error) {
+func Pretty(d *doc.Doc, mode RenderMode) (string, error) {
 	var buf bytes.Buffer
 
 	if len(d.Comment) > 0 {
 		buf.WriteString(fmt.Sprintf("\n%s\n", d.Comment))
 	}
 
-	if len(d.Inputs) > 0 {
-		buf.WriteString("\n")
-
+	if mode&RenderInputs != 0 && len(d.Inputs) > 0 {
 		for _, i := range d.Inputs {
-			format := "  \033[36mvar.%s\033[0m (%s)\n  \033[90m%s\033[0m\n\n"
-			desc := i.Description
-
-			if desc == "" {
-				desc = "-"
+			value := i.Value()
+			if mode&RenderDetailed != 0 {
+				value = string(coveoutils.ToHCL(i.Default.Literal))
 			}
-
-			buf.WriteString(fmt.Sprintf(format, i.Name, i.Value(), desc))
+			buf.WriteString(fmt.Sprintf("%s%s%s\n\n", varStr(i.Name), valStr(value), desStr(i.Description)))
 		}
-
-		buf.WriteString("\n")
 	}
 
-	if len(d.Outputs) > 0 {
-		buf.WriteString("\n")
-
-		for _, i := range d.Outputs {
-			format := "  \033[36moutput.%s\033[0m\n  \033[90m%s\033[0m\n\n"
-			s := fmt.Sprintf(format, i.Name, strings.TrimSpace(i.Description))
-			buf.WriteString(s)
+	if mode&RenderOutputs != 0 && len(d.Outputs) > 0 {
+		for _, o := range d.Outputs {
+			buf.WriteString(fmt.Sprintf("%s%s%s\n\n", outStr(o.Name), valStr(o), desStr(o.Description)))
 		}
-
-		buf.WriteString("\n")
 	}
 
 	return buf.String(), nil
 }
 
 // Markdown prints the given doc as markdown.
-func Markdown(d *doc.Doc, printRequired bool) (string, error) {
+func Markdown(d *doc.Doc, mode RenderMode, printRequired, printValues bool) (string, error) {
 	var buf bytes.Buffer
 
 	if len(d.Comment) > 0 {
 		buf.WriteString(fmt.Sprintf("%s\n", d.Comment))
 	}
 
-	if len(d.Inputs) > 0 {
-		buf.WriteString("\n## Inputs\n\n")
-		buf.WriteString("| Name | Description | Type | Default |")
+	if mode&RenderInputs != 0 {
+		if len(d.Inputs) > 0 {
+			buf.WriteString("\n## Inputs\n\n")
+			buf.WriteString("| Name | Description | Type | Default |")
 
-		if printRequired {
-			buf.WriteString(" Required |\n")
-		} else {
-			buf.WriteString("\n")
+			if printRequired {
+				buf.WriteString(" Required |\n")
+			} else {
+				buf.WriteString("\n")
+			}
+
+			buf.WriteString("|------|-------------|:----:|:-----:|")
+			if printRequired {
+				buf.WriteString(":-----:|\n")
+			} else {
+				buf.WriteString("\n")
+			}
 		}
 
-		buf.WriteString("|------|-------------|:----:|:-----:|")
-		if printRequired {
-			buf.WriteString(":-----:|\n")
-		} else {
-			buf.WriteString("\n")
+		for _, v := range d.Inputs {
+			def := v.Value()
+
+			if def == "required" {
+				def = "-"
+			} else {
+				def = fmt.Sprintf("`%s`", def)
+			}
+
+			buf.WriteString(fmt.Sprintf("| %s | %s | %s | %s |",
+				v.Name,
+				normalizeMarkdownDesc(v.Description),
+				v.Type,
+				normalizeMarkdownDesc(def)))
+
+			if printRequired {
+				buf.WriteString(fmt.Sprintf(" %v |\n",
+					humanize(v.Default)))
+			} else {
+				buf.WriteString("\n")
+			}
 		}
 	}
 
-	for _, v := range d.Inputs {
-		def := v.Value()
-
-		if def == "required" {
-			def = "-"
-		} else {
-			def = fmt.Sprintf("`%s`", def)
+	if mode&RenderOutputs != 0 {
+		if len(d.Outputs) > 0 {
+			var ext, sep string
+			if printValues {
+				ext = " Value | Type | Sensitive |"
+				sep = "-------|------|-----------|"
+			}
+			buf.WriteString("\n## Outputs\n\n")
+			buf.WriteString(fmt.Sprintf("| Name | Description |%s\n", ext))
+			buf.WriteString(fmt.Sprintf("|------|-------------|%s\n", sep))
 		}
 
-		buf.WriteString(fmt.Sprintf("| %s | %s | %s | %s |",
-			v.Name,
-			normalizeMarkdownDesc(v.Description),
-			v.Type,
-			normalizeMarkdownDesc(def)))
-
-		if printRequired {
-			buf.WriteString(fmt.Sprintf(" %v |\n",
-				humanize(v.Default)))
-		} else {
-			buf.WriteString("\n")
+		for _, v := range d.Outputs {
+			var val string
+			if printValues {
+				val = fmt.Sprintf(" %v | %s | %t |", v.OutputResult.Value, v.OutputResult.Type, v.OutputResult.Sensitive)
+			}
+			buf.WriteString(fmt.Sprintf("| %s | %s |%s\n", v.Name, normalizeMarkdownDesc(v.Description), val))
 		}
-	}
-
-	if len(d.Outputs) > 0 {
-		buf.WriteString("\n## Outputs\n\n")
-		buf.WriteString("| Name | Description |\n")
-		buf.WriteString("|------|-------------|\n")
-	}
-
-	for _, v := range d.Outputs {
-		buf.WriteString(fmt.Sprintf("| %s | %s |\n",
-			v.Name,
-			normalizeMarkdownDesc(v.Description)))
 	}
 
 	return buf.String(), nil
 }
 
 // JSON prints the given doc as json.
-func JSON(d *doc.Doc) (string, error) {
-	s, err := json.MarshalIndent(d, "", "  ")
+func JSON(d *doc.Doc, mode RenderMode) (string, error) {
+	result, err := json.MarshalIndent(filter(*d, mode), "", "  ")
 	if err != nil {
 		return "", err
 	}
 
-	return string(s), nil
+	return string(result), nil
+}
+
+// YAML prints the given doc as yaml.
+func YAML(d *doc.Doc, mode RenderMode) (string, error) {
+	result, err := yaml.Marshal(filter(*d, mode))
+	if err != nil {
+		return "", err
+	}
+
+	return string(result), nil
+}
+
+// XML prints the given doc as hcl.
+func XML(d *doc.Doc, mode RenderMode) (string, error) {
+	data := filter(*d, mode)
+
+	for i := range data.Outputs {
+		output := &data.Outputs[i]
+		if output.OutputResult != nil {
+			switch value := output.OutputResult.Value.(type) {
+			case map[string]interface{}:
+				output.OutputResult.Value = coveoutils.ToHCL(value)
+			}
+		}
+	}
+	result, err := xml.MarshalIndent(data, "", "  ")
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(result), nil
+}
+
+// HCL prints the given doc as hcl.
+func HCL(d *doc.Doc, mode RenderMode) string {
+	return string(coveoutils.ToPrettyHCL(filter(*d, mode)))
+}
+
+func filter(d doc.Doc, mode RenderMode) doc.Doc {
+	switch mode & RenderAll {
+	case RenderInputs:
+		d.Outputs = nil
+	case RenderOutputs:
+		d.Inputs = nil
+	}
+	return d
 }
 
 // Humanize the given `v`.

--- a/print/print.go
+++ b/print/print.go
@@ -108,18 +108,13 @@ func Markdown(d *doc.Doc, mode RenderMode, printRequired, printValues bool) (str
 			if def == "required" {
 				def = "-"
 			} else {
-				def = fmt.Sprintf("`%s`", def)
+				def = fmt.Sprintf("`%s `", def)
 			}
 
-			buf.WriteString(fmt.Sprintf("| %s | %s | %s | %s |",
-				v.Name,
-				normalizeMarkdownDesc(v.Description),
-				v.Type,
-				normalizeMarkdownDesc(def)))
+			buf.WriteString(fmt.Sprintf("| %s | %s | %s | %s |", v.Name, normalizeMarkdownDesc(v.Description), v.Type, normalizeMarkdownDesc(def)))
 
 			if printRequired {
-				buf.WriteString(fmt.Sprintf(" %v |\n",
-					humanize(v.Default)))
+				buf.WriteString(fmt.Sprintf(" %v |\n", humanize(v.Default == nil)))
 			} else {
 				buf.WriteString("\n")
 			}
@@ -141,7 +136,7 @@ func Markdown(d *doc.Doc, mode RenderMode, printRequired, printValues bool) (str
 		for _, v := range d.Outputs {
 			var val string
 			if printValues {
-				val = fmt.Sprintf(" %v | %s | %t |", v.Result.Value, v.Result.Type, v.Result.Sensitive)
+				val = fmt.Sprintf(" `%v ` | %s | %s |", v.Result.Value, v.Result.Type, humanize(v.Result.Sensitive))
 			}
 			buf.WriteString(fmt.Sprintf("| %s | %s |%s\n", v.Name, normalizeMarkdownDesc(v.Description), val))
 		}
@@ -207,13 +202,12 @@ func filter(d doc.Doc, mode RenderMode) doc.Doc {
 	return d
 }
 
-// Humanize the given `v`.
-func humanize(def *doc.Value) string {
-	if def == nil {
-		return "yes"
-	}
-
-	return "no"
+// Humanize the given boolean value.
+func humanize(value bool) string {
+	return map[bool]string{
+		true:  "yes",
+		false: "no",
+	}[value]
 }
 
 // normalizeMarkdownDesc fixes line breaks in descriptions for markdown:

--- a/print/print.go
+++ b/print/print.go
@@ -141,7 +141,7 @@ func Markdown(d *doc.Doc, mode RenderMode, printRequired, printValues bool) (str
 		for _, v := range d.Outputs {
 			var val string
 			if printValues {
-				val = fmt.Sprintf(" %v | %s | %t |", v.OutputResult.Value, v.OutputResult.Type, v.OutputResult.Sensitive)
+				val = fmt.Sprintf(" %v | %s | %t |", v.Result.Value, v.Result.Type, v.Result.Sensitive)
 			}
 			buf.WriteString(fmt.Sprintf("| %s | %s |%s\n", v.Name, normalizeMarkdownDesc(v.Description), val))
 		}
@@ -176,10 +176,10 @@ func XML(d *doc.Doc, mode RenderMode) (string, error) {
 
 	for i := range data.Outputs {
 		output := &data.Outputs[i]
-		if output.OutputResult != nil {
-			switch value := output.OutputResult.Value.(type) {
+		if output.Result.Value != nil {
+			switch value := output.Result.Value.(type) {
 			case map[string]interface{}:
-				output.OutputResult.Value = coveoutils.ToHCL(value)
+				output.Result.Value = coveoutils.ToHCL(value)
 			}
 		}
 	}


### PR DESCRIPTION
Hi, 

I added several new options to terraform-docs in order to be able to export results in various format YAML, HCL, XML in addition to JSON and MD. It is also possible to select only part of the data (inputs or outputs).

We can also inject variables files and even output results coming either from `terraform output -json` or outfile from `terraform plan -out outfile` (working with terraform 0.11.2).

I invite you to try it and don't hesitate to communicate with me if you have any comment or question.

Regards,

Jo

P.S. Our binaries are available in https://github.com/coveo/terraform-docs/releases