### PR TITLE
Adding freebsd binary to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,6 @@ B="-X main.version=$(V)"
 
 dist:
 	@gox \
-		--os "darwin linux windows" \
+		--os "darwin linux windows freebsd" \
 		--output "dist/{{.Dir}}_{{.OS}}_{{.Arch}}" \
 		--ldflags=$(B)


### PR DESCRIPTION
I noticed that there was not a `freebsd` binary. Built and tested this change on a `freebsd 11.1-amd64` machine. Included the output from the `_example` below:

```
# ./terraform-docs_freebsd_amd64 --version                                                                                                                                                                                             
dev                                                                                                                                                                                                                                    
# ./terraform-docs_freebsd_amd64 md ../_example/main.tf                                                                                                                                                                                
Module usage:                                                                                                                                                                                                                          

     module "foo" {
       source = "github.com/foo/baz"
       subnet_ids = "${join(",", subnet.*.id)}"
     }



## Inputs

| Name | Description | Type | Default | Required |
|------|-------------|:----:|:-----:|:-----:|
| amis |  | string | `<map>` | no |
| security_group_ids |  | string | `sg-a, sg-b` | no |
| subnet_ids | a comma-separated list of subnet IDs | string | - | yes |

## Outputs

| Name | Description |
|------|-------------|
| vpc_id | The VPC ID. |
```

Let me know if you need me to test anything else. Unfortunately I dont have an `i386` or `arm` machine to test the cross-compiled builds of the freebsd bin.

~Rob