### PR TITLE
Add support to print Markdown files with underscored variable names escaped (#48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ This project is no longer maintained by Segment. Instead, [Martin Etmajer](https
 
   Options:
     -h, --help                       show help information
+    --escape-underscores             escapes underscores in variable names when generating markdown
     --no-required                    omit "Required" column when generating markdown
     --no-sort                        omit sorted rendering of inputs and ouputs
     --with-aggregate-type-defaults   print default values of aggregate types

--- a/internal/pkg/doc/doc_test.go
+++ b/internal/pkg/doc/doc_test.go
@@ -148,6 +148,12 @@ func TestInputs(t *testing.T) {
 			},
 			Type: "list",
 		},
+		doc.Input{
+			Name:        "string_number_3",
+			Description: "A variable with underscores.",
+			Type:        "string",
+			Default:     nil,
+		},
 	}
 
 	assert.Equal(t, expected, actual)
@@ -237,6 +243,12 @@ func TestInputsFromVariablesTf(t *testing.T) {
 				},
 			},
 			Type: "list",
+		},
+		doc.Input{
+			Name:        "string_number_3",
+			Description: "A variable with underscores.",
+			Type:        "string",
+			Default:     nil,
 		},
 	}
 

--- a/internal/pkg/doc/testdata/variables.tf
+++ b/internal/pkg/doc/testdata/variables.tf
@@ -24,7 +24,8 @@ variable "map-1" {
     b = 2
     c = 3
   }
-  type    = "map"
+
+  type = "map"
 }
 
 variable "list-3" {
@@ -41,3 +42,6 @@ variable "list-1" {
   default = ["a", "b", "c"]
   type    = "list"
 }
+
+// A variable with underscores.
+variable "string_number_3" {}

--- a/internal/pkg/print/json/testdata/json-WithSorting.golden
+++ b/internal/pkg/print/json/testdata/json-WithSorting.golden
@@ -71,6 +71,12 @@
       "Description": "It's string number two.",
       "Default": null,
       "Type": "string"
+    },
+    {
+      "Name": "string_number_3",
+      "Description": "A variable with underscores.",
+      "Default": null,
+      "Type": "string"
     }
   ],
   "Outputs": [

--- a/internal/pkg/print/json/testdata/json.golden
+++ b/internal/pkg/print/json/testdata/json.golden
@@ -71,6 +71,12 @@
         ]
       },
       "Type": "list"
+    },
+    {
+      "Name": "string_number_3",
+      "Description": "A variable with underscores.",
+      "Default": null,
+      "Type": "string"
     }
   ],
   "Outputs": [

--- a/internal/pkg/print/markdown/markdown.go
+++ b/internal/pkg/print/markdown/markdown.go
@@ -92,7 +92,7 @@ func printInputs(buffer *bytes.Buffer, inputs []doc.Input, settings settings.Set
 	for _, input := range inputs {
 		buffer.WriteString(
 			fmt.Sprintf("| %s | %s | %s | %s |",
-				input.Name,
+				escapeUnderscoresIfSet(settings, input.Name),
 				prepareDescriptionForMarkdown(getInputDescription(&input)),
 				input.Type,
 				getInputDefaultValue(&input, settings)))
@@ -121,7 +121,7 @@ func printOutputs(buffer *bytes.Buffer, outputs []doc.Output, settings settings.
 	for _, output := range outputs {
 		buffer.WriteString(
 			fmt.Sprintf("| %s | %s |\n",
-				output.Name,
+				escapeUnderscoresIfSet(settings, output.Name),
 				prepareDescriptionForMarkdown(getOutputDescription(&output))))
 	}
 }
@@ -136,4 +136,12 @@ func prepareDescriptionForMarkdown(s string) string {
 
 	// Convert single newline to space.
 	return strings.Replace(s, "\n", " ", -1)
+}
+
+func escapeUnderscoresIfSet(settings settings.Settings, s string) string {
+	if !settings.Has(print.EscapeUnderscores) {
+		return s
+	}
+
+	return strings.Replace(s, "_", "\\_", -1)
 }

--- a/internal/pkg/print/markdown/markdown_test.go
+++ b/internal/pkg/print/markdown/markdown_test.go
@@ -83,3 +83,22 @@ func TestPrintWithSorting(t *testing.T) {
 
 	assert.Equal(t, expected, actual)
 }
+
+func TestPrintWithEscapedUnderscores(t *testing.T) {
+	doc := doc.TestDoc(t, "..")
+
+	var settings settings.Settings
+	settings.Add(print.EscapeUnderscores)
+
+	actual, err := markdown.Print(doc, settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected, err := print.ReadGoldenFile("markdown-WithEscapedUnderscores")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, expected, actual)
+}

--- a/internal/pkg/print/markdown/testdata/markdown-WithAggregateTypeDefaults.golden
+++ b/internal/pkg/print/markdown/testdata/markdown-WithAggregateTypeDefaults.golden
@@ -29,6 +29,7 @@ module "foo" {
 | list-3 | - | list | `[]` |
 | list-2 | It's list number two. | list | - |
 | list-1 | It's list number one. | list | `[ "a", "b", "c" ]` |
+| string_number_3 | A variable with underscores. | string | - |
 
 ## Outputs
 

--- a/internal/pkg/print/markdown/testdata/markdown-WithEscapedUnderscores.golden
+++ b/internal/pkg/print/markdown/testdata/markdown-WithEscapedUnderscores.golden
@@ -21,19 +21,19 @@ module "foo" {
 
 | Name | Description | Type | Default |
 |------|-------------|:----:|:-----:|
-| list-1 | It's list number one. | list | `<list>` |
-| list-2 | It's list number two. | list | - |
-| list-3 | - | list | `<list>` |
-| map-1 | It's map number one. | map | `<map>` |
-| map-2 | It's map number two. | map | - |
-| map-3 | - | map | `<map>` |
-| string-1 | It's string number one. | string | `bar` |
 | string-2 | It's string number two. | string | - |
-| string_number_3 | A variable with underscores. | string | - |
+| string-1 | It's string number one. | string | `bar` |
+| map-3 | - | map | `<map>` |
+| map-2 | It's map number two. | map | - |
+| map-1 | It's map number one. | map | `<map>` |
+| list-3 | - | list | `<list>` |
+| list-2 | It's list number two. | list | - |
+| list-1 | It's list number one. | list | `<list>` |
+| string\_number\_3 | A variable with underscores. | string | - |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| output-1 | It's output number one. |
 | output-2 | It's output number two. |
+| output-1 | It's output number one. |

--- a/internal/pkg/print/markdown/testdata/markdown-WithRequired.golden
+++ b/internal/pkg/print/markdown/testdata/markdown-WithRequired.golden
@@ -29,6 +29,7 @@ module "foo" {
 | list-3 | - | list | `<list>` | no |
 | list-2 | It's list number two. | list | - | yes |
 | list-1 | It's list number one. | list | `<list>` | no |
+| string_number_3 | A variable with underscores. | string | - | yes |
 
 ## Outputs
 

--- a/internal/pkg/print/markdown/testdata/markdown.golden
+++ b/internal/pkg/print/markdown/testdata/markdown.golden
@@ -29,6 +29,7 @@ module "foo" {
 | list-3 | - | list | `<list>` |
 | list-2 | It's list number two. | list | - |
 | list-1 | It's list number one. | list | `<list>` |
+| string_number_3 | A variable with underscores. | string | - |
 
 ## Outputs
 

--- a/internal/pkg/print/pretty/pretty_test.go
+++ b/internal/pkg/print/pretty/pretty_test.go
@@ -67,6 +67,9 @@ func TestPretty(t *testing.T) {
 			"  " + sgr_color_1 + "var.list-1" + sgr_reset + " (<list>)\n" +
 			"  " + sgr_color_2 + "It's list number one." + sgr_reset + "\n" +
 			"\n" +
+			"  " + sgr_color_1 + "var.string_number_3" + sgr_reset + " (required)\n" +
+			"  " + sgr_color_2 + "A variable with underscores." + sgr_reset + "\n" +
+			"\n" +
 			"\n" +
 			"\n" +
 			"  " + sgr_color_1 + "output.output-2" + sgr_reset + "\n" +
@@ -139,6 +142,9 @@ func TestPrettyWithWithAggregateTypeDefaults(t *testing.T) {
 			"  " + sgr_color_1 + "var.list-1" + sgr_reset + " ([ \"a\", \"b\", \"c\" ])\n" +
 			"  " + sgr_color_2 + "It's list number one." + sgr_reset + "\n" +
 			"\n" +
+			"  " + sgr_color_1 + "var.string_number_3" + sgr_reset + " (required)\n" +
+			"  " + sgr_color_2 + "A variable with underscores." + sgr_reset + "\n" +
+			"\n" +
 			"\n" +
 			"\n" +
 			"  " + sgr_color_1 + "output.output-2" + sgr_reset + "\n" +
@@ -210,6 +216,9 @@ func TestPrettyWithSorting(t *testing.T) {
 			"\n" +
 			"  " + sgr_color_1 + "var.string-2" + sgr_reset + " (required)\n" +
 			"  " + sgr_color_2 + "It's string number two." + sgr_reset + "\n" +
+			"\n" +
+			"  " + sgr_color_1 + "var.string_number_3" + sgr_reset + " (required)\n" +
+			"  " + sgr_color_2 + "A variable with underscores." + sgr_reset + "\n" +
 			"\n" +
 			"\n" +
 			"\n" +

--- a/internal/pkg/print/print.go
+++ b/internal/pkg/print/print.go
@@ -11,6 +11,8 @@ import (
 
 const (
 	_ settings.Setting = iota
+	// EscapeUnderscores escapes underscores in varables when printing markdown
+	EscapeUnderscores
 	// WithAggregateTypeDefaults prints defaults of aggregate type inputs
 	WithAggregateTypeDefaults
 	// WithRequired prints if inputs are required

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ const usage = `
 
   Options:
 	-h, --help                       show help information
+	--escape-underscores             escapes underscores in variable names when generating markdown
 	--no-required                    omit "Required" column when generating markdown
 	--no-sort                        omit sorted rendering of inputs and ouputs
 	--with-aggregate-type-defaults   print default values of aggregate types
@@ -63,6 +64,10 @@ func main() {
 	}
 
 	var printSettings settings.Settings
+	if !args["--escape-underscores"].(bool) {
+		printSettings.Add(print.EscapeUnderscores)
+	}
+
 	if !args["--no-required"].(bool) {
 		printSettings.Add(print.WithRequired)
 	}


### PR DESCRIPTION
Note: this will cause a conflict with #43 but I'll rebase whichever one needs it...

### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

Adds a flag to escape underscored variables / outputs when printing markdown.

### Issues Resolved

#48

### Checklist

Put an `x` into all boxes that apply:

- [x] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [x] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

#### Code Style

- [x] My code follows the code style of this project.
