### PR TITLE
Fix Main.tf Comment Handling on Windows

### DIFF
--- a/internal/pkg/doc/doc.go
+++ b/internal/pkg/doc/doc.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -91,7 +90,7 @@ func Create(files map[string]*ast.File) *Doc {
 		doc.Inputs = append(doc.Inputs, getInputs(objects)...)
 		doc.Outputs = append(doc.Outputs, getOutputs(objects)...)
 
-		filename := path.Base(name)
+		filename := filepath.Base(name)
 		comments := file.Comments
 		if filename == "main.tf" && len(comments) > 0 {
 			doc.Comment = header(comments[0])


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

This pull request changes the method used for extracting the filename from the path to check if main.tf is being processed. The current `path` package used is not OS agnostic, whereas `filepath` is. See [Package Filepath](https://golang.org/pkg/path/filepath/) for further info.

### Issues Resolved

#32 

### Checklist

Put an `x` into all boxes that apply:

- [x] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [ ] I have added tests to cover my changes.
- [ ] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [x] My code follows the code style of this project.
