### PR TITLE
Add backticks option to markdown output

### DIFF
--- a/internal/pkg/print/markdown/markdown.go
+++ b/internal/pkg/print/markdown/markdown.go
@@ -100,7 +100,7 @@ func printInputs(buffer *bytes.Buffer, inputs []doc.Input, settings settings.Set
 	for _, input := range inputs {
 		buffer.WriteString(
 			fmt.Sprintf("| %s | %s | %s | %s |",
-				input.Name,
+				prepareNameForMarkdown(input.Name, settings),
 				prepareDescriptionForMarkdown(getInputDescription(&input)),
 				input.Type,
 				getInputDefaultValue(&input, settings)))
@@ -129,9 +129,16 @@ func printOutputs(buffer *bytes.Buffer, outputs []doc.Output, settings settings.
 	for _, output := range outputs {
 		buffer.WriteString(
 			fmt.Sprintf("| %s | %s |\n",
-				output.Name,
+				prepareNameForMarkdown(output.Name, settings),
 				prepareDescriptionForMarkdown(getOutputDescription(&output))))
 	}
+}
+
+func prepareNameForMarkdown(s string, settings settings.Settings) string {
+	if settings.Has(print.WithBackticks) {
+		return fmt.Sprintf("`%s`", s)
+	}
+	return s
 }
 
 func prepareDescriptionForMarkdown(s string) string {

--- a/internal/pkg/print/markdown/markdown_test.go
+++ b/internal/pkg/print/markdown/markdown_test.go
@@ -27,6 +27,25 @@ func TestPrint(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestWithBackticks(t *testing.T) {
+	doc := doc.TestDoc(t, "..")
+
+	var settings settings.Settings
+	settings.Add(print.WithBackticks)
+
+	actual, err := markdown.Print(doc, settings)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected, err := print.ReadGoldenFile("markdown-WithBackticks")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, expected, actual)
+}
+
 func TestWithAggregateTypeDefaults(t *testing.T) {
 	doc := doc.TestDoc(t, "..")
 

--- a/internal/pkg/print/markdown/testdata/markdown-WithBackticks.golden
+++ b/internal/pkg/print/markdown/testdata/markdown-WithBackticks.golden
@@ -1,0 +1,38 @@
+Usage:
+
+module "foo" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+
+## Inputs
+
+| Name | Description | Type | Default |
+|------|-------------|:----:|:-----:|
+| `unquoted` | - | string | - |
+| `string-2` | It's string number two. | string | - |
+| `string-1` | It's string number one. | string | `bar` |
+| `map-3` | - | map | `<map>` |
+| `map-2` | It's map number two. | map | - |
+| `map-1` | It's map number one. | map | `<map>` |
+| `list-3` | - | list | `<list>` |
+| `list-2` | It's list number two. | list | - |
+| `list-1` | It's list number one. | list | `<list>` |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `unquoted` | It's unquoted output. |
+| `output-2` | It's output number two. |
+| `output-1` | It's output number one. |

--- a/internal/pkg/print/print.go
+++ b/internal/pkg/print/print.go
@@ -19,6 +19,8 @@ const (
 	WithSortByName
 	// WithSortInputsByRequired sorts inputs by name and prints required inputs first
 	WithSortInputsByRequired
+	// WithBackticks prints variable and output name with backticks in Markdown
+	WithBackticks
 )
 
 // GetPrintableValue returns a printable representation of a Terraform value.

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ const usage = `
   Options:
     -h, --help                       show help information
     --no-required                    omit "Required" column when generating markdown
+    --with-backticks                 print variable and output names with backticks when generating markdown
     --no-sort                        omit sorted rendering of inputs and ouputs
     --sort-inputs-by-required        sort inputs by name and prints required inputs first
     --with-aggregate-type-defaults   print default values of aggregate types
@@ -66,6 +67,10 @@ func main() {
 	var printSettings settings.Settings
 	if !args["--no-required"].(bool) {
 		printSettings.Add(print.WithRequired)
+	}
+
+	if args["--with-backticks"].(bool) {
+		printSettings.Add(print.WithBackticks)
 	}
 
 	if !args["--no-sort"].(bool) {


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

This adds an option for markdown output to include backticks for
variable and output names. This is useful since names may include
underscores, which most markdown renderers treat as emphasis indicators.

### Issues Resolved

This is a slightly different twist on handling double underscores: https://github.com/segmentio/terraform-docs/issues/48

### Checklist

Put an `x` into all boxes that apply:

- [x] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [x] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

#### Code Style

- [x] My code follows the code style of this project.
