### PR TITLE
Fix typo: "compatability" is a misspelling of "compatibility"

### DIFF
--- a/History.md
+++ b/History.md
@@ -9,7 +9,7 @@ v0.2.0 / 2017-08-15
 
   * fixed name handling to handle unquoted hcl variable names.
   * fix typo
-  * Prefer leading comments over description for outputs to maintain compatability.
+  * Prefer leading comments over description for outputs to maintain compatibility.
   * *: add --no-required option
   * doc: snakecase -> camelcase
   * Add support for printing the variable 'type' in Markdown. Currently only markdown supported, but trivial to add to other outputs.


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug (if you consider a doc typo to be a bug)
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

This is a cosmetic change that fixes a typo detected by `misspell` in `History.md`.

### Issues Resolved

None, it's just prettier to avoid misspells in the doc! :)

### Checklist

Put an `x` into all boxes that apply:

- [x] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

