### PR TITLE
Feature/follow modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ build: authors build-darwin-amd64 build-freebsd-amd64 build-linux-amd64 build-wi
 
 build-darwin-amd64:
 	GOOS=darwin GOARCH=amd64 $(GOBUILD) -o bin/darwin-amd64/$(NAME)
+	sudo cp bin/darwin-amd64/$(NAME) /usr/local/bin/$(NAME)
 
 build-freebsd-amd64:
 	GOOS=freebsd GOARCH=amd64 $(GOBUILD) -o bin/freebsd-amd64/$(NAME)

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,6 @@ build: authors build-darwin-amd64 build-freebsd-amd64 build-linux-amd64 build-wi
 
 build-darwin-amd64:
 	GOOS=darwin GOARCH=amd64 $(GOBUILD) -o bin/darwin-amd64/$(NAME)
-	sudo cp bin/darwin-amd64/$(NAME) /usr/local/bin/$(NAME)
 
 build-freebsd-amd64:
 	GOOS=freebsd GOARCH=amd64 $(GOBUILD) -o bin/freebsd-amd64/$(NAME)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This project is no longer maintained by Segment. Instead, [Martin Etmajer](https
 ```bash
 
   Usage:
-    terraform-docs [--no-required] [--no-sort | --sort-inputs-by-required] [--with-aggregate-type-defaults] [json | markdown | md] <path>...
+    terraform-docs [--no-required] [--no-sort | --sort-inputs-by-required] [--with-aggregate-type-defaults] [--follow-modules] [json | markdown | md] <path>...
     terraform-docs -h | --help
 
   Examples:
@@ -48,13 +48,16 @@ This project is no longer maintained by Segment. Instead, [Martin Etmajer](https
     # Generate markdown tables of inputs and outputs for the given module and ../config.tf
     $ terraform-docs md ./my-module ../config.tf
 
+    # Generate markdown tables of inputs, outputs and used local modules
+    $ terraform-docs --follow-modules md ./my-stack
+
   Options:
     -h, --help                       show help information
     --no-required                    omit "Required" column when generating markdown
     --no-sort                        omit sorted rendering of inputs and ouputs
     --sort-inputs-by-required        sort inputs by name and prints required inputs first
     --with-aggregate-type-defaults   print default values of aggregate types
-    --follow-modules                 follow modules in stacks
+    --follow-modules                 follow local modules in stacks (ignored when selected output is JSON)
     --version                        print version
 
 ```
@@ -129,8 +132,8 @@ This module has a variable and an output.  This text here will be output before 
 ```
 
 ## About the --follow-modules option
-This option allows to document a stack of terraform infrastructure and includes the used modules.
-The option follows the 1st level of modules only.
+This option allows to document a stack of terraform infrastructure and includes the used local modules.
+The option follows the 1st level of modules only, it does not attempt to download modules from a registry or repository.
 
 The option is silently dropped when using `JSON` output as the JSON document can not
 trivially be rewritten to include the modules documentation.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This project is no longer maintained by Segment. Instead, [Martin Etmajer](https
     --no-sort                        omit sorted rendering of inputs and ouputs
     --sort-inputs-by-required        sort inputs by name and prints required inputs first
     --with-aggregate-type-defaults   print default values of aggregate types
+    --follow-modules                 follow modules in stacks
     --version                        print version
 
 ```
@@ -126,6 +127,13 @@ This module has a variable and an output.  This text here will be output before 
 | vpc\_id | The VPC ID. |
 
 ```
+
+## About the --follow-modules option
+This option allows to document a stack of terraform infrastructure and includes the used modules.
+The option follows the 1st level of modules only.
+
+The option is silently dropped when using `JSON` output as the JSON document can not
+trivially be rewritten to include the modules documentation.
 
 ## License
 

--- a/internal/pkg/doc/doc.go
+++ b/internal/pkg/doc/doc.go
@@ -19,6 +19,7 @@ type Doc struct {
 	Comment string
 	Inputs  []Input
 	Outputs []Output
+	Modules []Module
 }
 
 // Value represents a Terraform value.
@@ -40,6 +41,11 @@ func (d *Doc) HasInputs() bool {
 // HasOutputs indicates if the document has outputs.
 func (d *Doc) HasOutputs() bool {
 	return len(d.Outputs) > 0
+}
+
+// HasModules indicates if the document has modules.
+func (d *Doc) HasModules() bool {
+	return len(d.Modules) > 0
 }
 
 // CreateFromPaths creates a new document from a list of file or directory paths.
@@ -89,6 +95,7 @@ func Create(files map[string]*ast.File) *Doc {
 
 		doc.Inputs = append(doc.Inputs, getInputs(objects)...)
 		doc.Outputs = append(doc.Outputs, getOutputs(objects)...)
+		doc.Modules = append(doc.Modules, getModules(objects)...)
 
 		filename := filepath.Base(name)
 		comments := file.Comments
@@ -127,6 +134,22 @@ func getOutputs(list *ast.ObjectList) []Output {
 			result = append(result, Output{
 				Name:        getItemName(item),
 				Description: getItemDescription(item),
+			})
+		}
+	}
+
+	return result
+}
+
+// getModules returns a list of modules from an ast.ObjectList.
+func getModules(list *ast.ObjectList) []Module {
+	var result []Module
+
+	for _, item := range list.Items {
+		if isItemOfKindModule(item) {
+			result = append(result, Module{
+				Name:   getItemName(item),
+				Source: getItemSource(item),
 			})
 		}
 	}
@@ -183,6 +206,11 @@ func getItemByKey(items []*ast.ObjectItem, key string) *Value {
 func getItemDefault(item *ast.ObjectItem) *Value {
 	items := item.Val.(*ast.ObjectType).List.Items
 	return getItemByKey(items, "default")
+}
+
+func getItemSource(item *ast.ObjectItem) string {
+	items := item.Val.(*ast.ObjectType).List.Items
+	return getItemByKey(items, "source").Value.(string)
 }
 
 func getItemDescription(item *ast.ObjectItem) string {
@@ -260,6 +288,10 @@ func isItemOfKindOutput(item *ast.ObjectItem) bool {
 
 func isItemOfKindVariable(item *ast.ObjectItem) bool {
 	return isItemOfKind(item, "variable")
+}
+
+func isItemOfKindModule(item *ast.ObjectItem) bool {
+	return isItemOfKind(item, "module")
 }
 
 // Header returns the header comment from the list

--- a/internal/pkg/doc/doc.go
+++ b/internal/pkg/doc/doc.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -156,9 +157,16 @@ func getModules(list *ast.ObjectList, basepath string) []Module {
 
 	for _, item := range list.Items {
 		if isItemOfKindModule(item) {
+
+			modulepath := filepath.Join(basepath, getItemSource(item))
+			if _, err := os.Stat(modulepath); os.IsNotExist(err) {
+				// the path does not exists, so the module will be either
+				// git based or registry based and can not be loaded
+				modulepath = getItemSource(item)
+			}
 			result = append(result, Module{
 				Name:   getItemName(item),
-				Source: filepath.Join(basepath, getItemSource(item)),
+				Source: modulepath,
 			})
 		}
 	}

--- a/internal/pkg/doc/doc.go
+++ b/internal/pkg/doc/doc.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -97,10 +96,7 @@ func Create(files map[string]*ast.File) *Doc {
 		doc.Inputs = append(doc.Inputs, getInputs(objects)...)
 		doc.Outputs = append(doc.Outputs, getOutputs(objects)...)
 
-		// We need the absolute path of the object we are working on to set the source of the module correctly
-		// Sadly it will be an absolute path but either that or force users to call terrafom-docs
-		// in the dir where the module's source is set as it will be (most likely) relative
-		// eg. `source = "../../modules/bar"`
+		// We need the absolute basepath of the object we are working on to set the source of the module correctly
 		basepath, err := filepath.Abs(filepath.Dir(name))
 		if err != nil {
 			log.Fatal(err)
@@ -157,16 +153,10 @@ func getModules(list *ast.ObjectList, basepath string) []Module {
 
 	for _, item := range list.Items {
 		if isItemOfKindModule(item) {
-
-			modulepath := filepath.Join(basepath, getItemSource(item))
-			if _, err := os.Stat(modulepath); os.IsNotExist(err) {
-				// the path does not exists, so the module will be either
-				// git based or registry based and can not be loaded
-				modulepath = getItemSource(item)
-			}
 			result = append(result, Module{
-				Name:   getItemName(item),
-				Source: modulepath,
+				Name:     getItemName(item),
+				Source:   getItemSource(item),
+				basepath: basepath,
 			})
 		}
 	}

--- a/internal/pkg/doc/module.go
+++ b/internal/pkg/doc/module.go
@@ -1,0 +1,7 @@
+package doc
+
+// Module represents a Terraform output.
+type Module struct {
+	Name   string
+	Source string
+}

--- a/internal/pkg/doc/module.go
+++ b/internal/pkg/doc/module.go
@@ -1,6 +1,6 @@
 package doc
 
-// Module represents a Terraform output.
+// Module represents a Terraform module.
 type Module struct {
 	Name   string
 	Source string

--- a/internal/pkg/doc/module.go
+++ b/internal/pkg/doc/module.go
@@ -2,6 +2,11 @@ package doc
 
 // Module represents a Terraform module.
 type Module struct {
-	Name   string
-	Source string
+	Name     string
+	Source   string
+	basepath string
+}
+
+func (o *Module) GetBasepath() string {
+	return o.basepath
 }

--- a/internal/pkg/print/json/testdata/json-WithSortByName.golden
+++ b/internal/pkg/print/json/testdata/json-WithSortByName.golden
@@ -98,5 +98,6 @@
       "Name": "unquoted",
       "Description": "It's unquoted output."
     }
-  ]
+  ],
+  "Modules": null
 }

--- a/internal/pkg/print/json/testdata/json-WithSortInputsByRequired.golden
+++ b/internal/pkg/print/json/testdata/json-WithSortInputsByRequired.golden
@@ -98,5 +98,6 @@
       "Name": "unquoted",
       "Description": "It's unquoted output."
     }
-  ]
+  ],
+  "Modules": null
 }

--- a/internal/pkg/print/json/testdata/json.golden
+++ b/internal/pkg/print/json/testdata/json.golden
@@ -98,5 +98,6 @@
       "Name": "output-1",
       "Description": "It's output number one."
     }
-  ]
+  ],
+  "Modules": null
 }

--- a/internal/pkg/print/markdown/markdown.go
+++ b/internal/pkg/print/markdown/markdown.go
@@ -42,6 +42,13 @@ func Print(document *doc.Doc, settings settings.Settings) (string, error) {
 		printOutputs(&buffer, document.Outputs, settings)
 	}
 
+	if document.HasModules() {
+		if document.HasOutputs() {
+			buffer.WriteString("\n")
+		}
+		printModules(&buffer, document.Modules, settings)
+	}
+
 	return buffer.String(), nil
 }
 
@@ -131,6 +138,19 @@ func printOutputs(buffer *bytes.Buffer, outputs []doc.Output, settings settings.
 			fmt.Sprintf("| %s | %s |\n",
 				strings.Replace(output.Name, "_", "\\_", -1),
 				prepareDescriptionForMarkdown(getOutputDescription(&output))))
+	}
+}
+
+func printModules(buffer *bytes.Buffer, modules []doc.Module, settings settings.Settings) {
+	buffer.WriteString("## Modules\n\n")
+	buffer.WriteString("| Name | Source |\n")
+	buffer.WriteString("|------|-------------|\n")
+
+	for _, module := range modules {
+		buffer.WriteString(
+			fmt.Sprintf("| %s | %s |\n",
+				strings.Replace(module.Name, "_", "\\_", -1),
+				strings.Replace(module.Source, "_", "\\_", -1)))
 	}
 }
 

--- a/internal/pkg/print/pretty/pretty.go
+++ b/internal/pkg/print/pretty/pretty.go
@@ -37,6 +37,10 @@ func Print(document *doc.Doc, settings settings.Settings) (string, error) {
 		printOutputs(&buffer, document.Outputs, settings)
 	}
 
+	if document.HasModules() {
+		printModules(&buffer, document.Modules, settings)
+	}
+
 	return buffer.String(), nil
 }
 
@@ -101,6 +105,22 @@ func printOutputs(buffer *bytes.Buffer, outputs []doc.Output, settings settings.
 				format,
 				output.Name,
 				getOutputDescription(&output)))
+	}
+
+	buffer.WriteString("\n")
+}
+
+func printModules(buffer *bytes.Buffer, modules []doc.Module, settings settings.Settings) {
+	buffer.WriteString("\n")
+
+	for _, module := range modules {
+		format := "  \033[36mmodule.%s\033[0m\n  \033[90m%s\033[0m\n\n"
+
+		buffer.WriteString(
+			fmt.Sprintf(
+				format,
+				module.Name,
+				module.Source))
 	}
 
 	buffer.WriteString("\n")

--- a/main.go
+++ b/main.go
@@ -43,13 +43,16 @@ const usage = `
     # Generate markdown tables of inputs and outputs for the given module and ../config.tf
     $ terraform-docs md ./my-module ../config.tf
 
+    # Generate markdown tables of inputs, outputs and used local modules
+    $ terraform-docs --follow-modules md ./my-stack
+
   Options:
     -h, --help                       show help information
     --no-required                    omit "Required" column when generating markdown
     --no-sort                        omit sorted rendering of inputs and ouputs
     --sort-inputs-by-required        sort inputs by name and prints required inputs first
     --with-aggregate-type-defaults   print default values of aggregate types
-    --follow-modules                 follow modules in stacks (ignored when selected output is JSON)
+    --follow-modules                 follow local modules in stacks (ignored when selected output is JSON)
     --version                        print version
 
 `

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ const usage = `
     --no-sort                        omit sorted rendering of inputs and ouputs
     --sort-inputs-by-required        sort inputs by name and prints required inputs first
     --with-aggregate-type-defaults   print default values of aggregate types
-    --follow-modules                 follow modules in stacks
+    --follow-modules                 follow modules in stacks (ignored when selected output is JSON)
     --version                        print version
 
 `


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description
This PR introduces the `--follow-modules` option.
```
    --follow-modules      follow local modules in stacks (ignored when selected output is JSON)
```
This option allows to document a stack of terraform infrastructure and includes the used local modules.
The option follows the 1st level of modules only, it does not attempt to download modules from a registry or repository.

The option is silently dropped when using `JSON` output as the JSON document can not trivially be rewritten to include the modules documentation.

This option changes the `main.go` in 3 ways
- the final output is collected by a `strings.Builder`
- there is a helper function `doPrint()` to re-use the main `switch()`
- there is a major code block added to rerun `doc.CreateFromPaths()` on every detected, local module

The option is not available as JSON output as this would have meant changes to the final `Doc struct`.
Additionally the change to `Doc struct` was discussed for cleaner code but as this meant a major re-write it was discarded in sake of easier adaption by means of uglier `main.go`.

### Checklist

Put an `x` into all boxes that apply:

- [x] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [ ] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

#### Code Style

- [x] My code follows the code style of this project.
