### PR TITLE
Fix authors target in Makefile to get 'Author''s email not 'Committer'

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,13 +1,19 @@
 Amir Abushareb <yields@icloud.com>
+Amir Abu Shareb <yields@icloud.com>
 Bill Wang <bill.wang@myob.com>
 Bill Wang <ozbillwang@gmail.com>
 Chris Marchesi <cmarchesi@paybyphone.com>
+Daniel Fagnan <dnfagnan@gmail.com>
 Gavin Williams <fatmcgav@gmail.com>
+Jacob Gillespie <jacobwgillespie@gmail.com>
 Jocelyn Giroux <jgiroux@coveo.com>
+John Boggs <john.boggs@segment.com>
 Joshua Bussdieker <joshua.bussdieker@mulesoft.com>
+Khosrow Moossavi <khos2ow@gmail.com>
 Martin Etmajer <martin@etmajer.com>
 Martin Etmajer <metmajer@getcloudnative.io>
 Matthew Baker <mbaker@cozero.com.au>
+Matthew <mu.beta.06@gmail.com>
 Nick Walke <nwalke@smg.com>
 Sergiusz Urbaniak <sergiusz.urbaniak@gmail.com>
 Stuart Auld <sja@marsupialmusic.net>

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ all: clean deps lint test build
 
 .PHONY: authors
 authors:
-	git log --all --format='%aN <%cE>' | sort -u | egrep -v noreply > AUTHORS
+	git log --all --format='%aN <%aE>' | sort -u | egrep -v noreply > AUTHORS
 
 .PHONY: build
 build: authors build-darwin-amd64 build-freebsd-amd64 build-linux-amd64 build-windows-amd64


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

When `authors` target in `Makefile` is used committer's email is being used instead of actual author of the commit, as a result there were many rows added with wrong email addresses.

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into all boxes that apply:

- [x] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [ ] I have added tests to cover my changes.
- [ ] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
