### PR TITLE
Enable new go linters and fix the existing issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,3 +2,38 @@ run:
   deadline: 5m
   tests: true
   modules-download-mode: vendor
+
+linters:
+  disable-all: true
+  enable:
+    - govet
+    - golint
+    - goconst
+    - misspell
+    - varcheck
+    - structcheck
+    - staticcheck
+    - errcheck
+    - unconvert
+    - unused
+
+linters-settings:
+  govet:
+    check-shadowing: true
+  golint:
+    min-confidence: 0
+  goconst:
+    min-len: 2
+    min-occurrences: 2
+  misspell:
+    locale: US
+  unused:
+    check-exported: false
+
+issues:
+  exclude-rules:
+    - linters:
+        - golint
+      text: "should have a package comment"
+
+  exclude-use-default: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,6 @@ linters:
   enable:
     - govet
     - golint
-    - goconst
     - misspell
     - varcheck
     - structcheck

--- a/internal/pkg/hcl/hcl.go
+++ b/internal/pkg/hcl/hcl.go
@@ -28,13 +28,13 @@ func ParseAstNode(node *ast.Node, nodeType string) (interface{}, error) {
 	// Unmarshals HCL Text into a Go data structure
 	err := hcl.Unmarshal(buffer.Bytes(), &result)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to parse HCL: %s", err)
+		return nil, fmt.Errorf("unable to parse HCL: %s", err)
 	}
 
 	// Marshals the Go data structure into JSON text
 	data, err := json.Marshal(result)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to marshal JSON: %s", err)
+		return nil, fmt.Errorf("unable to marshal JSON: %s", err)
 	}
 
 	// Extract the desired value from JSON text
@@ -45,13 +45,13 @@ func ParseAstNode(node *ast.Node, nodeType string) (interface{}, error) {
 
 	data, _, _, err = jsonparser.Get(data, path...)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to extract value from JSON: %s", err)
+		return nil, fmt.Errorf("unable to extract value from JSON: %s", err)
 	}
 
 	// Unmarshal JSON text into a Go data structure
 	err = json.Unmarshal(data, &result)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to unmarshal JSON: %s", err)
+		return nil, fmt.Errorf("unable to unmarshal JSON: %s", err)
 	}
 
 	return result, nil

--- a/internal/pkg/print/markdown/document/document.go
+++ b/internal/pkg/print/markdown/document/document.go
@@ -103,7 +103,7 @@ func printFencedCodeBlock(code string) string {
 func printInput(buffer *bytes.Buffer, input doc.Input, settings *settings.Settings) {
 	buffer.WriteString("\n")
 	buffer.WriteString(fmt.Sprintf("%s %s\n\n", markdown.GenerateIndentation(1, settings), markdown.SanitizeName(input.Name, settings)))
-	buffer.WriteString(fmt.Sprintf("Description: %s\n\n", markdown.SanitizeDescription(input.Description, settings)))
+	buffer.WriteString(fmt.Sprintf("Description: %s\n\n", markdown.SanitizeDescriptionForDocument(input.Description, settings)))
 	buffer.WriteString(fmt.Sprintf("Type: `%s`\n", input.Type))
 
 	// Don't print defaults for required inputs when we're already explicit about it being required
@@ -149,6 +149,6 @@ func printOutputs(buffer *bytes.Buffer, outputs []doc.Output, settings *settings
 	for _, output := range outputs {
 		buffer.WriteString("\n")
 		buffer.WriteString(fmt.Sprintf("%s %s\n\n", markdown.GenerateIndentation(1, settings), markdown.SanitizeName(output.Name, settings)))
-		buffer.WriteString(fmt.Sprintf("Description: %s\n", markdown.SanitizeDescription(output.Description, settings)))
+		buffer.WriteString(fmt.Sprintf("Description: %s\n", markdown.SanitizeDescriptionForDocument(output.Description, settings)))
 	}
 }

--- a/internal/pkg/print/markdown/markdown.go
+++ b/internal/pkg/print/markdown/markdown.go
@@ -18,7 +18,8 @@ func SanitizeName(s string, settings *settings.Settings) string {
 	return s
 }
 
-func SanitizeDescription(s string, settings *settings.Settings) string {
+// SanitizeDescriptionForDocument converts description to suitable Markdown representation for a document. (including line-break, illegal characters, code blocks etc)
+func SanitizeDescriptionForDocument(s string, settings *settings.Settings) string {
 	// s = ConvertMultiLineText(s)
 	// s = EscapeIllegalCharacters(s, settings)
 	// return s
@@ -45,7 +46,7 @@ func SanitizeDescription(s string, settings *settings.Settings) string {
 	return buf.String()
 }
 
-// SanitizeDescription converts description to suitable Markdown representation for a table. (including line-break, illegal characters, code blocks etc)
+// SanitizeDescriptionForTable converts description to suitable Markdown representation for a table. (including line-break, illegal characters, code blocks etc)
 func SanitizeDescriptionForTable(s string, settings *settings.Settings) string {
 	// Isolate blocks of code. Dont escape anything inside them
 	nextIsInCodeBlock := strings.HasPrefix(s, "```\n")

--- a/internal/pkg/print/pretty/pretty_test.go
+++ b/internal/pkg/print/pretty/pretty_test.go
@@ -19,9 +19,9 @@ func TestPretty(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sgr_color_1 := "\x1b[36m"
-	sgr_color_2 := "\x1b[90m"
-	sgr_reset := "\x1b[0m"
+	sgrColor1 := "\x1b[36m"
+	sgrColor2 := "\x1b[90m"
+	sgrReset := "\x1b[0m"
 
 	expected :=
 		"\nUsage:\n" +
@@ -42,55 +42,55 @@ func TestPretty(t *testing.T) {
 			"}\n" +
 			"\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.unquoted" + sgr_reset + " (required)\n" +
-			"  " + sgr_color_2 + "" + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.unquoted" + sgrReset + " (required)\n" +
+			"  " + sgrColor2 + "" + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.string-3" + sgr_reset + " (\"\")\n" +
-			"  " + sgr_color_2 + "" + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.string-3" + sgrReset + " (\"\")\n" +
+			"  " + sgrColor2 + "" + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.string-2" + sgr_reset + " (required)\n" +
-			"  " + sgr_color_2 + "It's string number two." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.string-2" + sgrReset + " (required)\n" +
+			"  " + sgrColor2 + "It's string number two." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.string-1" + sgr_reset + " (\"bar\")\n" +
-			"  " + sgr_color_2 + "It's string number one." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.string-1" + sgrReset + " (\"bar\")\n" +
+			"  " + sgrColor2 + "It's string number one." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.map-3" + sgr_reset + " (<map>)\n" +
-			"  " + sgr_color_2 + "" + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.map-3" + sgrReset + " (<map>)\n" +
+			"  " + sgrColor2 + "" + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.map-2" + sgr_reset + " (required)\n" +
-			"  " + sgr_color_2 + "It's map number two." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.map-2" + sgrReset + " (required)\n" +
+			"  " + sgrColor2 + "It's map number two." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.map-1" + sgr_reset + " (<map>)\n" +
-			"  " + sgr_color_2 + "It's map number one." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.map-1" + sgrReset + " (<map>)\n" +
+			"  " + sgrColor2 + "It's map number one." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.list-3" + sgr_reset + " (<list>)\n" +
-			"  " + sgr_color_2 + "" + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.list-3" + sgrReset + " (<list>)\n" +
+			"  " + sgrColor2 + "" + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.list-2" + sgr_reset + " (required)\n" +
-			"  " + sgr_color_2 + "It's list number two." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.list-2" + sgrReset + " (required)\n" +
+			"  " + sgrColor2 + "It's list number two." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.list-1" + sgr_reset + " (<list>)\n" +
-			"  " + sgr_color_2 + "It's list number one." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.list-1" + sgrReset + " (<list>)\n" +
+			"  " + sgrColor2 + "It's list number one." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.input_with_underscores" + sgr_reset + " (required)\n" +
-			"  " + sgr_color_2 + "A variable with underscores." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.input_with_underscores" + sgrReset + " (required)\n" +
+			"  " + sgrColor2 + "A variable with underscores." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.input-with-pipe" + sgr_reset + " (\"v1\")\n" +
-			"  " + sgr_color_2 + "It includes v1 | v2 | v3" + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.input-with-pipe" + sgrReset + " (\"v1\")\n" +
+			"  " + sgrColor2 + "It includes v1 | v2 | v3" + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.input-with-code-block" + sgr_reset + " (<list>)\n" +
-			"  " + sgr_color_2 + "This is a complicated one. We need a newline.  \nAnd an example in a code block\n```\ndefault     = [\n  \"machine rack01:neptune\"\n]\n```\n" + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.input-with-code-block" + sgrReset + " (<list>)\n" +
+			"  " + sgrColor2 + "This is a complicated one. We need a newline.  \nAnd an example in a code block\n```\ndefault     = [\n  \"machine rack01:neptune\"\n]\n```\n" + sgrReset + "\n" +
 			"\n" +
 			"\n" +
 			"\n" +
-			"  " + sgr_color_1 + "output.unquoted" + sgr_reset + "\n" +
-			"  " + sgr_color_2 + "It's unquoted output." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "output.unquoted" + sgrReset + "\n" +
+			"  " + sgrColor2 + "It's unquoted output." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "output.output-2" + sgr_reset + "\n" +
-			"  " + sgr_color_2 + "It's output number two." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "output.output-2" + sgrReset + "\n" +
+			"  " + sgrColor2 + "It's output number two." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "output.output-1" + sgr_reset + "\n" +
-			"  " + sgr_color_2 + "It's output number one." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "output.output-1" + sgrReset + "\n" +
+			"  " + sgrColor2 + "It's output number one." + sgrReset + "\n" +
 			"\n" +
 			"\n"
 
@@ -109,9 +109,9 @@ func TestPrettyWithWithAggregateTypeDefaults(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sgr_color_1 := "\x1b[36m"
-	sgr_color_2 := "\x1b[90m"
-	sgr_reset := "\x1b[0m"
+	sgrColor1 := "\x1b[36m"
+	sgrColor2 := "\x1b[90m"
+	sgrReset := "\x1b[0m"
 
 	expected :=
 		"\nUsage:\n" +
@@ -132,55 +132,55 @@ func TestPrettyWithWithAggregateTypeDefaults(t *testing.T) {
 			"}\n" +
 			"\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.unquoted" + sgr_reset + " (required)\n" +
-			"  " + sgr_color_2 + "" + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.unquoted" + sgrReset + " (required)\n" +
+			"  " + sgrColor2 + "" + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.string-3" + sgr_reset + " (\"\")\n" +
-			"  " + sgr_color_2 + "" + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.string-3" + sgrReset + " (\"\")\n" +
+			"  " + sgrColor2 + "" + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.string-2" + sgr_reset + " (required)\n" +
-			"  " + sgr_color_2 + "It's string number two." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.string-2" + sgrReset + " (required)\n" +
+			"  " + sgrColor2 + "It's string number two." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.string-1" + sgr_reset + " (\"bar\")\n" +
-			"  " + sgr_color_2 + "It's string number one." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.string-1" + sgrReset + " (\"bar\")\n" +
+			"  " + sgrColor2 + "It's string number one." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.map-3" + sgr_reset + " ({})\n" +
-			"  " + sgr_color_2 + "" + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.map-3" + sgrReset + " ({})\n" +
+			"  " + sgrColor2 + "" + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.map-2" + sgr_reset + " (required)\n" +
-			"  " + sgr_color_2 + "It's map number two." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.map-2" + sgrReset + " (required)\n" +
+			"  " + sgrColor2 + "It's map number two." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.map-1" + sgr_reset + " ({ \"a\": 1, \"b\": 2, \"c\": 3 })\n" +
-			"  " + sgr_color_2 + "It's map number one." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.map-1" + sgrReset + " ({ \"a\": 1, \"b\": 2, \"c\": 3 })\n" +
+			"  " + sgrColor2 + "It's map number one." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.list-3" + sgr_reset + " ([])\n" +
-			"  " + sgr_color_2 + "" + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.list-3" + sgrReset + " ([])\n" +
+			"  " + sgrColor2 + "" + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.list-2" + sgr_reset + " (required)\n" +
-			"  " + sgr_color_2 + "It's list number two." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.list-2" + sgrReset + " (required)\n" +
+			"  " + sgrColor2 + "It's list number two." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.list-1" + sgr_reset + " ([ \"a\", \"b\", \"c\" ])\n" +
-			"  " + sgr_color_2 + "It's list number one." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.list-1" + sgrReset + " ([ \"a\", \"b\", \"c\" ])\n" +
+			"  " + sgrColor2 + "It's list number one." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.input_with_underscores" + sgr_reset + " (required)\n" +
-			"  " + sgr_color_2 + "A variable with underscores." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.input_with_underscores" + sgrReset + " (required)\n" +
+			"  " + sgrColor2 + "A variable with underscores." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.input-with-pipe" + sgr_reset + " (\"v1\")\n" +
-			"  " + sgr_color_2 + "It includes v1 | v2 | v3" + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.input-with-pipe" + sgrReset + " (\"v1\")\n" +
+			"  " + sgrColor2 + "It includes v1 | v2 | v3" + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.input-with-code-block" + sgr_reset + " ([ \"name rack:location\" ])\n" +
-			"  " + sgr_color_2 + "This is a complicated one. We need a newline.  \nAnd an example in a code block\n```\ndefault     = [\n  \"machine rack01:neptune\"\n]\n```\n" + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.input-with-code-block" + sgrReset + " ([ \"name rack:location\" ])\n" +
+			"  " + sgrColor2 + "This is a complicated one. We need a newline.  \nAnd an example in a code block\n```\ndefault     = [\n  \"machine rack01:neptune\"\n]\n```\n" + sgrReset + "\n" +
 			"\n" +
 			"\n" +
 			"\n" +
-			"  " + sgr_color_1 + "output.unquoted" + sgr_reset + "\n" +
-			"  " + sgr_color_2 + "It's unquoted output." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "output.unquoted" + sgrReset + "\n" +
+			"  " + sgrColor2 + "It's unquoted output." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "output.output-2" + sgr_reset + "\n" +
-			"  " + sgr_color_2 + "It's output number two." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "output.output-2" + sgrReset + "\n" +
+			"  " + sgrColor2 + "It's output number two." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "output.output-1" + sgr_reset + "\n" +
-			"  " + sgr_color_2 + "It's output number one." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "output.output-1" + sgrReset + "\n" +
+			"  " + sgrColor2 + "It's output number one." + sgrReset + "\n" +
 			"\n" +
 			"\n"
 
@@ -199,9 +199,9 @@ func TestPrettyWithSortByName(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sgr_color_1 := "\x1b[36m"
-	sgr_color_2 := "\x1b[90m"
-	sgr_reset := "\x1b[0m"
+	sgrColor1 := "\x1b[36m"
+	sgrColor2 := "\x1b[90m"
+	sgrReset := "\x1b[0m"
 
 	expected :=
 		"\nUsage:\n" +
@@ -222,55 +222,55 @@ func TestPrettyWithSortByName(t *testing.T) {
 			"}\n" +
 			"\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.input-with-code-block" + sgr_reset + " (<list>)\n" +
-			"  " + sgr_color_2 + "This is a complicated one. We need a newline.  \nAnd an example in a code block\n```\ndefault     = [\n  \"machine rack01:neptune\"\n]\n```\n" + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.input-with-code-block" + sgrReset + " (<list>)\n" +
+			"  " + sgrColor2 + "This is a complicated one. We need a newline.  \nAnd an example in a code block\n```\ndefault     = [\n  \"machine rack01:neptune\"\n]\n```\n" + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.input-with-pipe" + sgr_reset + " (\"v1\")\n" +
-			"  " + sgr_color_2 + "It includes v1 | v2 | v3" + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.input-with-pipe" + sgrReset + " (\"v1\")\n" +
+			"  " + sgrColor2 + "It includes v1 | v2 | v3" + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.input_with_underscores" + sgr_reset + " (required)\n" +
-			"  " + sgr_color_2 + "A variable with underscores." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.input_with_underscores" + sgrReset + " (required)\n" +
+			"  " + sgrColor2 + "A variable with underscores." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.list-1" + sgr_reset + " (<list>)\n" +
-			"  " + sgr_color_2 + "It's list number one." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.list-1" + sgrReset + " (<list>)\n" +
+			"  " + sgrColor2 + "It's list number one." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.list-2" + sgr_reset + " (required)\n" +
-			"  " + sgr_color_2 + "It's list number two." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.list-2" + sgrReset + " (required)\n" +
+			"  " + sgrColor2 + "It's list number two." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.list-3" + sgr_reset + " (<list>)\n" +
-			"  " + sgr_color_2 + "" + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.list-3" + sgrReset + " (<list>)\n" +
+			"  " + sgrColor2 + "" + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.map-1" + sgr_reset + " (<map>)\n" +
-			"  " + sgr_color_2 + "It's map number one." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.map-1" + sgrReset + " (<map>)\n" +
+			"  " + sgrColor2 + "It's map number one." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.map-2" + sgr_reset + " (required)\n" +
-			"  " + sgr_color_2 + "It's map number two." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.map-2" + sgrReset + " (required)\n" +
+			"  " + sgrColor2 + "It's map number two." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.map-3" + sgr_reset + " (<map>)\n" +
-			"  " + sgr_color_2 + "" + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.map-3" + sgrReset + " (<map>)\n" +
+			"  " + sgrColor2 + "" + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.string-1" + sgr_reset + " (\"bar\")\n" +
-			"  " + sgr_color_2 + "It's string number one." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.string-1" + sgrReset + " (\"bar\")\n" +
+			"  " + sgrColor2 + "It's string number one." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.string-2" + sgr_reset + " (required)\n" +
-			"  " + sgr_color_2 + "It's string number two." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.string-2" + sgrReset + " (required)\n" +
+			"  " + sgrColor2 + "It's string number two." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.string-3" + sgr_reset + " (\"\")\n" +
-			"  " + sgr_color_2 + "" + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.string-3" + sgrReset + " (\"\")\n" +
+			"  " + sgrColor2 + "" + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.unquoted" + sgr_reset + " (required)\n" +
-			"  " + sgr_color_2 + "" + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.unquoted" + sgrReset + " (required)\n" +
+			"  " + sgrColor2 + "" + sgrReset + "\n" +
 			"\n" +
 			"\n" +
 			"\n" +
-			"  " + sgr_color_1 + "output.output-1" + sgr_reset + "\n" +
-			"  " + sgr_color_2 + "It's output number one." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "output.output-1" + sgrReset + "\n" +
+			"  " + sgrColor2 + "It's output number one." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "output.output-2" + sgr_reset + "\n" +
-			"  " + sgr_color_2 + "It's output number two." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "output.output-2" + sgrReset + "\n" +
+			"  " + sgrColor2 + "It's output number two." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "output.unquoted" + sgr_reset + "\n" +
-			"  " + sgr_color_2 + "It's unquoted output." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "output.unquoted" + sgrReset + "\n" +
+			"  " + sgrColor2 + "It's unquoted output." + sgrReset + "\n" +
 			"\n" +
 			"\n"
 
@@ -290,9 +290,9 @@ func TestPrettyWithSortInputsByRequired(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sgr_color_1 := "\x1b[36m"
-	sgr_color_2 := "\x1b[90m"
-	sgr_reset := "\x1b[0m"
+	sgrColor1 := "\x1b[36m"
+	sgrColor2 := "\x1b[90m"
+	sgrReset := "\x1b[0m"
 
 	expected :=
 		"\nUsage:\n" +
@@ -313,55 +313,55 @@ func TestPrettyWithSortInputsByRequired(t *testing.T) {
 			"}\n" +
 			"\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.input_with_underscores" + sgr_reset + " (required)\n" +
-			"  " + sgr_color_2 + "A variable with underscores." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.input_with_underscores" + sgrReset + " (required)\n" +
+			"  " + sgrColor2 + "A variable with underscores." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.list-2" + sgr_reset + " (required)\n" +
-			"  " + sgr_color_2 + "It's list number two." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.list-2" + sgrReset + " (required)\n" +
+			"  " + sgrColor2 + "It's list number two." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.map-2" + sgr_reset + " (required)\n" +
-			"  " + sgr_color_2 + "It's map number two." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.map-2" + sgrReset + " (required)\n" +
+			"  " + sgrColor2 + "It's map number two." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.string-2" + sgr_reset + " (required)\n" +
-			"  " + sgr_color_2 + "It's string number two." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.string-2" + sgrReset + " (required)\n" +
+			"  " + sgrColor2 + "It's string number two." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.unquoted" + sgr_reset + " (required)\n" +
-			"  " + sgr_color_2 + "" + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.unquoted" + sgrReset + " (required)\n" +
+			"  " + sgrColor2 + "" + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.input-with-code-block" + sgr_reset + " (<list>)\n" +
-			"  " + sgr_color_2 + "This is a complicated one. We need a newline.  \nAnd an example in a code block\n```\ndefault     = [\n  \"machine rack01:neptune\"\n]\n```\n" + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.input-with-code-block" + sgrReset + " (<list>)\n" +
+			"  " + sgrColor2 + "This is a complicated one. We need a newline.  \nAnd an example in a code block\n```\ndefault     = [\n  \"machine rack01:neptune\"\n]\n```\n" + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.input-with-pipe" + sgr_reset + " (\"v1\")\n" +
-			"  " + sgr_color_2 + "It includes v1 | v2 | v3" + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.input-with-pipe" + sgrReset + " (\"v1\")\n" +
+			"  " + sgrColor2 + "It includes v1 | v2 | v3" + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.list-1" + sgr_reset + " (<list>)\n" +
-			"  " + sgr_color_2 + "It's list number one." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.list-1" + sgrReset + " (<list>)\n" +
+			"  " + sgrColor2 + "It's list number one." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.list-3" + sgr_reset + " (<list>)\n" +
-			"  " + sgr_color_2 + "" + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.list-3" + sgrReset + " (<list>)\n" +
+			"  " + sgrColor2 + "" + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.map-1" + sgr_reset + " (<map>)\n" +
-			"  " + sgr_color_2 + "It's map number one." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.map-1" + sgrReset + " (<map>)\n" +
+			"  " + sgrColor2 + "It's map number one." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.map-3" + sgr_reset + " (<map>)\n" +
-			"  " + sgr_color_2 + "" + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.map-3" + sgrReset + " (<map>)\n" +
+			"  " + sgrColor2 + "" + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.string-1" + sgr_reset + " (\"bar\")\n" +
-			"  " + sgr_color_2 + "It's string number one." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.string-1" + sgrReset + " (\"bar\")\n" +
+			"  " + sgrColor2 + "It's string number one." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "var.string-3" + sgr_reset + " (\"\")\n" +
-			"  " + sgr_color_2 + "" + sgr_reset + "\n" +
+			"  " + sgrColor1 + "var.string-3" + sgrReset + " (\"\")\n" +
+			"  " + sgrColor2 + "" + sgrReset + "\n" +
 			"\n" +
 			"\n" +
 			"\n" +
-			"  " + sgr_color_1 + "output.output-1" + sgr_reset + "\n" +
-			"  " + sgr_color_2 + "It's output number one." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "output.output-1" + sgrReset + "\n" +
+			"  " + sgrColor2 + "It's output number one." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "output.output-2" + sgr_reset + "\n" +
-			"  " + sgr_color_2 + "It's output number two." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "output.output-2" + sgrReset + "\n" +
+			"  " + sgrColor2 + "It's output number two." + sgrReset + "\n" +
 			"\n" +
-			"  " + sgr_color_1 + "output.unquoted" + sgr_reset + "\n" +
-			"  " + sgr_color_2 + "It's unquoted output." + sgr_reset + "\n" +
+			"  " + sgrColor1 + "output.unquoted" + sgrReset + "\n" +
+			"  " + sgrColor2 + "It's unquoted output." + sgrReset + "\n" +
 			"\n" +
 			"\n"
 


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [x] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

This PR enables new go linters and fixes the existing issues for some of them. The list of enabled linters are:

- govet
- golint
- misspell
- varcheck
- structcheck
- staticcheck
- errcheck
- unconvert
- unused

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [ ] I have added tests to cover my changes.
- [ ] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
