### PR TITLE
Rename 'input' to Terraform known term 'variable'

### DIFF
--- a/cmd/json.go
+++ b/cmd/json.go
@@ -9,7 +9,7 @@ import (
 var jsonCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Use:   "json [PATH...]",
-	Short: "Generate a JSON of inputs and outputs",
+	Short: "Generate a JSON of variables and outputs",
 	Run: func(cmd *cobra.Command, args []string) {
 		doPrint(args, func(module *tfconf.Module) (string, error) {
 			return json.Print(module, settings)

--- a/cmd/markdown.go
+++ b/cmd/markdown.go
@@ -11,7 +11,7 @@ var markdownCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1),
 	Use:     "markdown [PATH...]",
 	Aliases: []string{"md"},
-	Short:   "Generate Markdown of inputs and outputs",
+	Short:   "Generate Markdown of variables and outputs",
 	Run: func(cmd *cobra.Command, args []string) {
 		doPrint(args, func(module *tfconf.Module) (string, error) {
 			return table.Print(module, settings)
@@ -23,7 +23,7 @@ var mdTableCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1),
 	Use:     "table [PATH...]",
 	Aliases: []string{"tbl"},
-	Short:   "Generate Markdown tables of inputs and outputs",
+	Short:   "Generate Markdown tables of variables and outputs",
 	Run: func(cmd *cobra.Command, args []string) {
 		doPrint(args, func(module *tfconf.Module) (string, error) {
 			return table.Print(module, settings)
@@ -35,7 +35,7 @@ var mdDocumentCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1),
 	Use:     "document [PATH...]",
 	Aliases: []string{"doc"},
-	Short:   "Generate Markdown document of inputs and outputs",
+	Short:   "Generate Markdown document of variables and outputs",
 	Run: func(cmd *cobra.Command, args []string) {
 		doPrint(args, func(module *tfconf.Module) (string, error) {
 			return document.Print(module, settings)

--- a/cmd/pretty.go
+++ b/cmd/pretty.go
@@ -9,7 +9,7 @@ import (
 var prettyCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Use:   "pretty [PATH...]",
-	Short: "Generate a colorized pretty of inputs and outputs",
+	Short: "Generate a colorized pretty of variables and outputs",
 	Run: func(cmd *cobra.Command, args []string) {
 		doPrint(args, func(module *tfconf.Module) (string, error) {
 			return pretty.Print(module, settings)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,8 +31,9 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.PersistentFlags().BoolVar(new(bool), "no-sort", false, "omit sorted rendering of inputs and outputs")
-	rootCmd.PersistentFlags().BoolVar(&settings.SortInputsByRequired, "sort-inputs-by-required", false, "sort inputs by name and prints required inputs first")
+	rootCmd.PersistentFlags().BoolVar(new(bool), "no-sort", false, "omit sorted rendering of variables and outputs")
+	rootCmd.PersistentFlags().BoolVar(&settings.SortVariablesByRequired, "sort-inputs-by-required", false, "[Deprecated] use --sort-by-required instead")
+	rootCmd.PersistentFlags().BoolVar(&settings.SortVariablesByRequired, "sort-by-required", false, "sort variables by name and prints required ones first")
 	rootCmd.PersistentFlags().BoolVar(&settings.AggregateTypeDefaults, "with-aggregate-type-defaults", false, "print default values of aggregate types")
 
 	markdownCmd.PersistentFlags().BoolVar(new(bool), "no-required", false, "omit \"Required\" column when generating Markdown")

--- a/internal/pkg/print/json/json_test.go
+++ b/internal/pkg/print/json/json_test.go
@@ -56,10 +56,10 @@ func TestPrintWithSortByName(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
-func TestPrintWithSortInputsByRequired(t *testing.T) {
+func TestPrintWithSortVariablesByRequired(t *testing.T) {
 	var settings = &print.Settings{
-		SortByName:           true,
-		SortInputsByRequired: true,
+		SortByName:              true,
+		SortVariablesByRequired: true,
 	}
 
 	module, err := tfconf.CreateModule("../../../../examples")
@@ -72,7 +72,7 @@ func TestPrintWithSortInputsByRequired(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected, err := print.ReadGoldenFile("json-WithSortInputsByRequired")
+	expected, err := print.ReadGoldenFile("json-WithSortVariablesByRequired")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pkg/print/json/testdata/json-WithSortByName.golden
+++ b/internal/pkg/print/json/testdata/json-WithSortByName.golden
@@ -1,5 +1,5 @@
 {
-  "inputs": [
+  "variables": [
     {
       "name": "input-with-code-block",
       "type": "list",

--- a/internal/pkg/print/json/testdata/json-WithSortVariablesByRequired.golden
+++ b/internal/pkg/print/json/testdata/json-WithSortVariablesByRequired.golden
@@ -1,5 +1,5 @@
 {
-  "inputs": [
+  "variables": [
     {
       "name": "input_with_underscores",
       "type": "any"

--- a/internal/pkg/print/json/testdata/json.golden
+++ b/internal/pkg/print/json/testdata/json.golden
@@ -1,5 +1,5 @@
 {
-  "inputs": [
+  "variables": [
     {
       "name": "input-with-code-block",
       "type": "list",

--- a/internal/pkg/print/markdown/document/document.go
+++ b/internal/pkg/print/markdown/document/document.go
@@ -16,7 +16,7 @@ func Print(module *tfconf.Module, settings *print.Settings) (string, error) {
 
 	module.Sort(settings)
 
-	printInputs(&buffer, module, settings)
+	printVariables(&buffer, module, settings)
 	printOutputs(&buffer, module.Outputs, settings)
 
 	out := strings.Replace(buffer.String(), "<br>```<br>", "\n```\n", -1)
@@ -44,90 +44,90 @@ func Print(module *tfconf.Module, settings *print.Settings) (string, error) {
 	return strings.Replace(buf.String(), " \n\n", "\n\n", -1), nil
 }
 
-func getInputType(input *tfconf.Input) string {
+func getVariableType(variable *tfconf.Variable) string {
 	var result = ""
 	var extraline = false
 
-	if result, extraline = markdown.PrintFencedCodeBlock(input.Type, "hcl"); !extraline {
+	if result, extraline = markdown.PrintFencedCodeBlock(variable.Type, "hcl"); !extraline {
 		result += "\n"
 	}
 	return result
 }
 
-func getInputValue(input *tfconf.Input) string {
+func getVariableValue(variable *tfconf.Variable) string {
 	var result = "n/a\n"
 	var extraline = false
 
-	if input.HasDefault() {
-		if result, extraline = markdown.PrintFencedCodeBlock(input.Default, "json"); !extraline {
+	if variable.HasDefault() {
+		if result, extraline = markdown.PrintFencedCodeBlock(variable.Default, "json"); !extraline {
 			result += "\n"
 		}
 	}
 	return result
 }
 
-func printInput(buffer *bytes.Buffer, input *tfconf.Input, settings *print.Settings) {
+func printVariable(buffer *bytes.Buffer, variable *tfconf.Variable, settings *print.Settings) {
 	buffer.WriteString("\n")
-	buffer.WriteString(fmt.Sprintf("%s %s\n\n", markdown.GenerateIndentation(1, settings), markdown.SanitizeName(input.Name, settings)))
-	buffer.WriteString(fmt.Sprintf("Description: %s\n\n", markdown.SanitizeItemForDocument(input.Description, settings)))
-	buffer.WriteString(fmt.Sprintf("Type: %s", getInputType(input)))
+	buffer.WriteString(fmt.Sprintf("%s %s\n\n", markdown.GenerateIndentation(1, settings), markdown.SanitizeName(variable.Name, settings)))
+	buffer.WriteString(fmt.Sprintf("Description: %s\n\n", markdown.SanitizeItemForDocument(variable.Description, settings)))
+	buffer.WriteString(fmt.Sprintf("Type: %s", getVariableType(variable)))
 
-	// Don't print defaults for required inputs when we're already explicit about it being required
-	if input.HasDefault() || !settings.ShowRequired {
-		buffer.WriteString(fmt.Sprintf("\nDefault: %s", getInputValue(input)))
+	// Don't print defaults for required variables when we're already explicit about it being required
+	if variable.HasDefault() || !settings.ShowRequired {
+		buffer.WriteString(fmt.Sprintf("\nDefault: %s", getVariableValue(variable)))
 	}
 }
 
-func printInputsRequired(buffer *bytes.Buffer, inputs []*tfconf.Input, settings *print.Settings) {
-	buffer.WriteString(fmt.Sprintf("%s Required Inputs\n\n", markdown.GenerateIndentation(0, settings)))
+func printVariablesRequired(buffer *bytes.Buffer, variables []*tfconf.Variable, settings *print.Settings) {
+	buffer.WriteString(fmt.Sprintf("%s Required Variables\n\n", markdown.GenerateIndentation(0, settings)))
 
-	if len(inputs) == 0 {
-		buffer.WriteString("No required input.\n\n")
+	if len(variables) == 0 {
+		buffer.WriteString("No required variable.\n\n")
 	} else {
-		buffer.WriteString("The following input variables are required:\n")
+		buffer.WriteString("The following variables are required:\n")
 
-		for _, input := range inputs {
-			printInput(buffer, input, settings)
+		for _, variable := range variables {
+			printVariable(buffer, variable, settings)
 		}
 	}
 }
 
-func printInputsOptional(buffer *bytes.Buffer, inputs []*tfconf.Input, settings *print.Settings) {
+func printVariablesOptional(buffer *bytes.Buffer, variables []*tfconf.Variable, settings *print.Settings) {
 	buffer.WriteString("\n")
-	buffer.WriteString(fmt.Sprintf("%s Optional Inputs\n\n", markdown.GenerateIndentation(0, settings)))
+	buffer.WriteString(fmt.Sprintf("%s Optional Variables\n\n", markdown.GenerateIndentation(0, settings)))
 
-	if len(inputs) == 0 {
-		buffer.WriteString("No optional input.\n\n")
+	if len(variables) == 0 {
+		buffer.WriteString("No optional variable.\n\n")
 	} else {
-		buffer.WriteString("The following input variables are optional (have default values):\n")
+		buffer.WriteString("The following variables are optional (have default values):\n")
 
-		for _, input := range inputs {
-			printInput(buffer, input, settings)
+		for _, variable := range variables {
+			printVariable(buffer, variable, settings)
 		}
 	}
 }
 
-func printInputsAll(buffer *bytes.Buffer, inputs []*tfconf.Input, settings *print.Settings) {
-	buffer.WriteString(fmt.Sprintf("%s Inputs\n\n", markdown.GenerateIndentation(0, settings)))
+func printVariablesAll(buffer *bytes.Buffer, variables []*tfconf.Variable, settings *print.Settings) {
+	buffer.WriteString(fmt.Sprintf("%s Variables\n\n", markdown.GenerateIndentation(0, settings)))
 
-	if len(inputs) == 0 {
-		buffer.WriteString("No input.\n\n")
+	if len(variables) == 0 {
+		buffer.WriteString("No variable.\n\n")
 		return
 	}
 
-	buffer.WriteString("The following input variables are supported:\n")
+	buffer.WriteString("The following variables are supported:\n")
 
-	for _, input := range inputs {
-		printInput(buffer, input, settings)
+	for _, variable := range variables {
+		printVariable(buffer, variable, settings)
 	}
 }
 
-func printInputs(buffer *bytes.Buffer, module *tfconf.Module, settings *print.Settings) {
+func printVariables(buffer *bytes.Buffer, module *tfconf.Module, settings *print.Settings) {
 	if settings.ShowRequired {
-		printInputsRequired(buffer, module.RequiredInputs, settings)
-		printInputsOptional(buffer, module.OptionalInputs, settings)
+		printVariablesRequired(buffer, module.RequiredVariables, settings)
+		printVariablesOptional(buffer, module.OptionalVariables, settings)
 	} else {
-		printInputsAll(buffer, module.Inputs, settings)
+		printVariablesAll(buffer, module.Variables, settings)
 	}
 }
 

--- a/internal/pkg/print/markdown/document/document_test.go
+++ b/internal/pkg/print/markdown/document/document_test.go
@@ -81,10 +81,10 @@ func TestPrintWithSortByName(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
-func TestPrintWithSortInputsByRequired(t *testing.T) {
+func TestPrintWithSortVariablesByRequired(t *testing.T) {
 	var settings = &print.Settings{
-		SortByName:           true,
-		SortInputsByRequired: true,
+		SortByName:              true,
+		SortVariablesByRequired: true,
 	}
 
 	module, err := tfconf.CreateModule("../../../../../examples")
@@ -97,7 +97,7 @@ func TestPrintWithSortInputsByRequired(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected, err := print.ReadGoldenFile("document-WithSortInputsByRequired")
+	expected, err := print.ReadGoldenFile("document-WithSortVariablesByRequired")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pkg/print/markdown/document/testdata/document-WithEscapeName.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-WithEscapeName.golden
@@ -1,6 +1,6 @@
-## Inputs
+## Variables
 
-The following input variables are supported:
+The following variables are supported:
 
 ### input-with-code-block
 

--- a/internal/pkg/print/markdown/document/testdata/document-WithIndentationAboveAllowed.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-WithIndentationAboveAllowed.golden
@@ -1,6 +1,6 @@
-## Inputs
+## Variables
 
-The following input variables are supported:
+The following variables are supported:
 
 ### input-with-code-block
 

--- a/internal/pkg/print/markdown/document/testdata/document-WithIndentationBellowAllowed.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-WithIndentationBellowAllowed.golden
@@ -1,6 +1,6 @@
-## Inputs
+## Variables
 
-The following input variables are supported:
+The following variables are supported:
 
 ### input-with-code-block
 

--- a/internal/pkg/print/markdown/document/testdata/document-WithIndentationOfFour.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-WithIndentationOfFour.golden
@@ -1,6 +1,6 @@
-#### Inputs
+#### Variables
 
-The following input variables are supported:
+The following variables are supported:
 
 ##### input-with-code-block
 

--- a/internal/pkg/print/markdown/document/testdata/document-WithRequired.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-WithRequired.golden
@@ -1,6 +1,6 @@
-## Required Inputs
+## Required Variables
 
-The following input variables are required:
+The following variables are required:
 
 ### input_with_underscores
 
@@ -32,9 +32,9 @@ Description: n/a
 
 Type: `any`
 
-## Optional Inputs
+## Optional Variables
 
-The following input variables are optional (have default values):
+The following variables are optional (have default values):
 
 ### input-with-code-block
 

--- a/internal/pkg/print/markdown/document/testdata/document-WithSortByName.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-WithSortByName.golden
@@ -1,6 +1,6 @@
-## Inputs
+## Variables
 
-The following input variables are supported:
+The following variables are supported:
 
 ### input-with-code-block
 

--- a/internal/pkg/print/markdown/document/testdata/document-WithSortVariablesByRequired.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-WithSortVariablesByRequired.golden
@@ -1,6 +1,6 @@
-## Inputs
+## Variables
 
-The following input variables are supported:
+The following variables are supported:
 
 ### input_with_underscores
 

--- a/internal/pkg/print/markdown/document/testdata/document.golden
+++ b/internal/pkg/print/markdown/document/testdata/document.golden
@@ -1,6 +1,6 @@
-## Inputs
+## Variables
 
-The following input variables are supported:
+The following variables are supported:
 
 ### input-with-code-block
 

--- a/internal/pkg/print/markdown/markdown.go
+++ b/internal/pkg/print/markdown/markdown.go
@@ -125,8 +125,8 @@ func EscapeIllegalCharacters(s string, settings *print.Settings) string {
 
 // GenerateIndentation generates indentation of Markdown headers
 // with base level of provided 'settings.MarkdownIndent' plus any
-// extra level needed for subsection (e.g. 'Required Inputs' which
-// is a subsection of 'Inputs' section)
+// extra level needed for subsection (e.g. 'Required Variables'
+// which is a subsection of 'Variables' section)
 func GenerateIndentation(extra int, settings *print.Settings) string {
 	var base = settings.MarkdownIndent
 	if base < 1 || base > 5 {

--- a/internal/pkg/print/markdown/table/table.go
+++ b/internal/pkg/print/markdown/table/table.go
@@ -15,38 +15,38 @@ func Print(module *tfconf.Module, settings *print.Settings) (string, error) {
 
 	module.Sort(settings)
 
-	printInputs(&buffer, module.Inputs, settings)
+	printVariables(&buffer, module.Variables, settings)
 	printOutputs(&buffer, module.Outputs, settings)
 
 	return markdown.Sanitize(buffer.String()), nil
 }
 
-func getInputType(input *tfconf.Input) string {
-	inputType, _ := markdown.PrintFencedCodeBlock(input.Type, "")
-	return inputType
+func getVariableType(variable *tfconf.Variable) string {
+	varType, _ := markdown.PrintFencedCodeBlock(variable.Type, "")
+	return varType
 }
 
-func getInputValue(input *tfconf.Input) string {
+func getVariableValue(variable *tfconf.Variable) string {
 	var result = "n/a"
 
-	if input.HasDefault() {
-		result, _ = markdown.PrintFencedCodeBlock(input.Default, "")
+	if variable.HasDefault() {
+		result, _ = markdown.PrintFencedCodeBlock(variable.Default, "")
 	}
 	return result
 }
 
-func printIsInputRequired(input *tfconf.Input) string {
-	if !input.HasDefault() {
+func printIsVariableRequired(variable *tfconf.Variable) string {
+	if !variable.HasDefault() {
 		return "yes"
 	}
 	return "no"
 }
 
-func printInputs(buffer *bytes.Buffer, inputs []*tfconf.Input, settings *print.Settings) {
-	buffer.WriteString(fmt.Sprintf("%s Inputs\n\n", markdown.GenerateIndentation(0, settings)))
+func printVariables(buffer *bytes.Buffer, variables []*tfconf.Variable, settings *print.Settings) {
+	buffer.WriteString(fmt.Sprintf("%s Variables\n\n", markdown.GenerateIndentation(0, settings)))
 
-	if len(inputs) == 0 {
-		buffer.WriteString("No input.\n\n")
+	if len(variables) == 0 {
+		buffer.WriteString("No variable.\n\n")
 		return
 	}
 
@@ -61,24 +61,24 @@ func printInputs(buffer *bytes.Buffer, inputs []*tfconf.Input, settings *print.S
 	buffer.WriteString("|------|-------------|------|---------|")
 
 	if settings.ShowRequired {
-		buffer.WriteString(":-----:|\n")
+		buffer.WriteString(":--------:|\n")
 	} else {
 		buffer.WriteString("\n")
 	}
 
-	for _, input := range inputs {
+	for _, variable := range variables {
 		buffer.WriteString(
 			fmt.Sprintf(
 				"| %s | %s | %s | %s |",
-				markdown.SanitizeName(input.Name, settings),
-				markdown.SanitizeItemForTable(input.Description, settings),
-				markdown.SanitizeItemForTable(getInputType(input), settings),
-				markdown.SanitizeItemForTable(getInputValue(input), settings),
+				markdown.SanitizeName(variable.Name, settings),
+				markdown.SanitizeItemForTable(variable.Description, settings),
+				markdown.SanitizeItemForTable(getVariableType(variable), settings),
+				markdown.SanitizeItemForTable(getVariableValue(variable), settings),
 			),
 		)
 
 		if settings.ShowRequired {
-			buffer.WriteString(fmt.Sprintf(" %v |\n", printIsInputRequired(input)))
+			buffer.WriteString(fmt.Sprintf(" %v |\n", printIsVariableRequired(variable)))
 		} else {
 			buffer.WriteString("\n")
 		}

--- a/internal/pkg/print/markdown/table/table_test.go
+++ b/internal/pkg/print/markdown/table/table_test.go
@@ -81,10 +81,10 @@ func TestPrintWithSortByName(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
-func TestPrintWithSortInputsByRequired(t *testing.T) {
+func TestPrintWithSortVariablesByRequired(t *testing.T) {
 	var settings = &print.Settings{
-		SortByName:           true,
-		SortInputsByRequired: true,
+		SortByName:              true,
+		SortVariablesByRequired: true,
 	}
 
 	module, err := tfconf.CreateModule("../../../../../examples")
@@ -97,7 +97,7 @@ func TestPrintWithSortInputsByRequired(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected, err := print.ReadGoldenFile("table-WithSortInputsByRequired")
+	expected, err := print.ReadGoldenFile("table-WithSortVariablesByRequired")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pkg/print/markdown/table/testdata/table-WithEscapeName.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-WithEscapeName.golden
@@ -1,4 +1,4 @@
-## Inputs
+## Variables
 
 | Name | Description | Type | Default |
 |------|-------------|------|---------|

--- a/internal/pkg/print/markdown/table/testdata/table-WithIndentationAboveAllowed.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-WithIndentationAboveAllowed.golden
@@ -1,4 +1,4 @@
-## Inputs
+## Variables
 
 | Name | Description | Type | Default |
 |------|-------------|------|---------|

--- a/internal/pkg/print/markdown/table/testdata/table-WithIndentationBellowAllowed.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-WithIndentationBellowAllowed.golden
@@ -1,4 +1,4 @@
-## Inputs
+## Variables
 
 | Name | Description | Type | Default |
 |------|-------------|------|---------|

--- a/internal/pkg/print/markdown/table/testdata/table-WithIndentationOfFour.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-WithIndentationOfFour.golden
@@ -1,4 +1,4 @@
-#### Inputs
+#### Variables
 
 | Name | Description | Type | Default |
 |------|-------------|------|---------|

--- a/internal/pkg/print/markdown/table/testdata/table-WithRequired.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-WithRequired.golden
@@ -1,7 +1,7 @@
-## Inputs
+## Variables
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> | no |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` | no |
 | input_with_underscores | n/a | `any` | n/a | yes |

--- a/internal/pkg/print/markdown/table/testdata/table-WithSortByName.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-WithSortByName.golden
@@ -1,4 +1,4 @@
-## Inputs
+## Variables
 
 | Name | Description | Type | Default |
 |------|-------------|------|---------|

--- a/internal/pkg/print/markdown/table/testdata/table-WithSortVariablesByRequired.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-WithSortVariablesByRequired.golden
@@ -1,4 +1,4 @@
-## Inputs
+## Variables
 
 | Name | Description | Type | Default |
 |------|-------------|------|---------|

--- a/internal/pkg/print/markdown/table/testdata/table.golden
+++ b/internal/pkg/print/markdown/table/testdata/table.golden
@@ -1,4 +1,4 @@
-## Inputs
+## Variables
 
 | Name | Description | Type | Default |
 |------|-------------|------|---------|

--- a/internal/pkg/print/pretty/pretty.go
+++ b/internal/pkg/print/pretty/pretty.go
@@ -15,17 +15,17 @@ func Print(module *tfconf.Module, settings *print.Settings) (string, error) {
 
 	module.Sort(settings)
 
-	printInputs(&buffer, module.Inputs, settings)
+	printVariables(&buffer, module.Variables, settings)
 	printOutputs(&buffer, module.Outputs, settings)
 
 	return buffer.String(), nil
 }
 
-func getInputDefaultValue(input *tfconf.Input, settings *print.Settings) string {
+func getVariableDefaultValue(variable *tfconf.Variable, settings *print.Settings) string {
 	var result = "required"
 
-	if input.HasDefault() {
-		result = input.Default
+	if variable.HasDefault() {
+		result = variable.Default
 	}
 
 	return result
@@ -41,17 +41,17 @@ func getDescription(description string) string {
 	return result
 }
 
-func printInputs(buffer *bytes.Buffer, inputs []*tfconf.Input, settings *print.Settings) {
+func printVariables(buffer *bytes.Buffer, variables []*tfconf.Variable, settings *print.Settings) {
 	buffer.WriteString("\n\n")
 
-	for _, input := range inputs {
-		format := "\033[36minput.%s\033[0m (%s)\n\033[90m%s\033[0m\n\n"
+	for _, variable := range variables {
+		format := "\033[36mvariable.%s\033[0m (%s)\n\033[90m%s\033[0m\n\n"
 		buffer.WriteString(
 			fmt.Sprintf(
 				format,
-				input.Name,
-				getInputDefaultValue(input, settings),
-				getDescription(input.Description),
+				variable.Name,
+				getVariableDefaultValue(variable, settings),
+				getDescription(variable.Description),
 			),
 		)
 	}

--- a/internal/pkg/print/pretty/pretty_test.go
+++ b/internal/pkg/print/pretty/pretty_test.go
@@ -56,10 +56,10 @@ func TestPrettyWithSortByName(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
-func TestPrettyWithSortInputsByRequired(t *testing.T) {
+func TestPrettyWithSortVariablesByRequired(t *testing.T) {
 	var settings = &print.Settings{
-		SortByName:           true,
-		SortInputsByRequired: true,
+		SortByName:              true,
+		SortVariablesByRequired: true,
 	}
 
 	module, err := tfconf.CreateModule("../../../../examples")
@@ -72,7 +72,7 @@ func TestPrettyWithSortInputsByRequired(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected, err := print.ReadGoldenFile("pretty-WithSortInputsByRequired")
+	expected, err := print.ReadGoldenFile("pretty-WithSortVariablesByRequired")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pkg/print/pretty/testdata/pretty-WithSortByName.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-WithSortByName.golden
@@ -1,6 +1,6 @@
 
 
-[36minput.input-with-code-block[0m ([
+[36mvariable.input-with-code-block[0m ([
   "name rack:location"
 ])
 [90mThis is a complicated one. We need a newline.  
@@ -11,26 +11,26 @@ default     = [
 ]
 ```[0m
 
-[36minput.input-with-pipe[0m ("v1")
+[36mvariable.input-with-pipe[0m ("v1")
 [90mIt includes v1 | v2 | v3[0m
 
-[36minput.input_with_underscores[0m (required)
+[36mvariable.input_with_underscores[0m (required)
 [90mn/a[0m
 
-[36minput.list-1[0m ([
+[36mvariable.list-1[0m ([
   "a",
   "b",
   "c"
 ])
 [90mn/a[0m
 
-[36minput.list-2[0m (required)
+[36mvariable.list-2[0m (required)
 [90mIt's list number two.[0m
 
-[36minput.list-3[0m ([])
+[36mvariable.list-3[0m ([])
 [90mn/a[0m
 
-[36minput.long_type[0m ({
+[36mvariable.long_type[0m ({
   "bar": {
     "bar": "bar",
     "foo": "bar"
@@ -50,29 +50,29 @@ default     = [
 
 It spans over multiple lines.[0m
 
-[36minput.map-1[0m ({
+[36mvariable.map-1[0m ({
   "a": 1,
   "b": 2,
   "c": 3
 })
 [90mn/a[0m
 
-[36minput.map-2[0m (required)
+[36mvariable.map-2[0m (required)
 [90mIt's map number two.[0m
 
-[36minput.map-3[0m ({})
+[36mvariable.map-3[0m ({})
 [90mn/a[0m
 
-[36minput.string-1[0m ("bar")
+[36mvariable.string-1[0m ("bar")
 [90mn/a[0m
 
-[36minput.string-2[0m (required)
+[36mvariable.string-2[0m (required)
 [90mIt's string number two.[0m
 
-[36minput.string-3[0m ("")
+[36mvariable.string-3[0m ("")
 [90mn/a[0m
 
-[36minput.unquoted[0m (required)
+[36mvariable.unquoted[0m (required)
 [90mn/a[0m
 
 

--- a/internal/pkg/print/pretty/testdata/pretty-WithSortVariablesByRequired.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-WithSortVariablesByRequired.golden
@@ -1,21 +1,21 @@
 
 
-[36minput.input_with_underscores[0m (required)
+[36mvariable.input_with_underscores[0m (required)
 [90mn/a[0m
 
-[36minput.list-2[0m (required)
+[36mvariable.list-2[0m (required)
 [90mIt's list number two.[0m
 
-[36minput.map-2[0m (required)
+[36mvariable.map-2[0m (required)
 [90mIt's map number two.[0m
 
-[36minput.string-2[0m (required)
+[36mvariable.string-2[0m (required)
 [90mIt's string number two.[0m
 
-[36minput.unquoted[0m (required)
+[36mvariable.unquoted[0m (required)
 [90mn/a[0m
 
-[36minput.input-with-code-block[0m ([
+[36mvariable.input-with-code-block[0m ([
   "name rack:location"
 ])
 [90mThis is a complicated one. We need a newline.  
@@ -26,20 +26,20 @@ default     = [
 ]
 ```[0m
 
-[36minput.input-with-pipe[0m ("v1")
+[36mvariable.input-with-pipe[0m ("v1")
 [90mIt includes v1 | v2 | v3[0m
 
-[36minput.list-1[0m ([
+[36mvariable.list-1[0m ([
   "a",
   "b",
   "c"
 ])
 [90mn/a[0m
 
-[36minput.list-3[0m ([])
+[36mvariable.list-3[0m ([])
 [90mn/a[0m
 
-[36minput.long_type[0m ({
+[36mvariable.long_type[0m ({
   "bar": {
     "bar": "bar",
     "foo": "bar"
@@ -59,20 +59,20 @@ default     = [
 
 It spans over multiple lines.[0m
 
-[36minput.map-1[0m ({
+[36mvariable.map-1[0m ({
   "a": 1,
   "b": 2,
   "c": 3
 })
 [90mn/a[0m
 
-[36minput.map-3[0m ({})
+[36mvariable.map-3[0m ({})
 [90mn/a[0m
 
-[36minput.string-1[0m ("bar")
+[36mvariable.string-1[0m ("bar")
 [90mn/a[0m
 
-[36minput.string-3[0m ("")
+[36mvariable.string-3[0m ("")
 [90mn/a[0m
 
 

--- a/internal/pkg/print/pretty/testdata/pretty.golden
+++ b/internal/pkg/print/pretty/testdata/pretty.golden
@@ -1,6 +1,6 @@
 
 
-[36minput.input-with-code-block[0m ([
+[36mvariable.input-with-code-block[0m ([
   "name rack:location"
 ])
 [90mThis is a complicated one. We need a newline.  
@@ -11,26 +11,26 @@ default     = [
 ]
 ```[0m
 
-[36minput.input-with-pipe[0m ("v1")
+[36mvariable.input-with-pipe[0m ("v1")
 [90mIt includes v1 | v2 | v3[0m
 
-[36minput.input_with_underscores[0m (required)
+[36mvariable.input_with_underscores[0m (required)
 [90mn/a[0m
 
-[36minput.list-1[0m ([
+[36mvariable.list-1[0m ([
   "a",
   "b",
   "c"
 ])
 [90mn/a[0m
 
-[36minput.list-2[0m (required)
+[36mvariable.list-2[0m (required)
 [90mIt's list number two.[0m
 
-[36minput.list-3[0m ([])
+[36mvariable.list-3[0m ([])
 [90mn/a[0m
 
-[36minput.long_type[0m ({
+[36mvariable.long_type[0m ({
   "bar": {
     "bar": "bar",
     "foo": "bar"
@@ -50,29 +50,29 @@ default     = [
 
 It spans over multiple lines.[0m
 
-[36minput.map-1[0m ({
+[36mvariable.map-1[0m ({
   "a": 1,
   "b": 2,
   "c": 3
 })
 [90mn/a[0m
 
-[36minput.map-2[0m (required)
+[36mvariable.map-2[0m (required)
 [90mIt's map number two.[0m
 
-[36minput.map-3[0m ({})
+[36mvariable.map-3[0m ({})
 [90mn/a[0m
 
-[36minput.string-1[0m ("bar")
+[36mvariable.string-1[0m ("bar")
 [90mn/a[0m
 
-[36minput.string-2[0m (required)
+[36mvariable.string-2[0m (required)
 [90mIt's string number two.[0m
 
-[36minput.string-3[0m ("")
+[36mvariable.string-3[0m ("")
 [90mn/a[0m
 
-[36minput.unquoted[0m (required)
+[36mvariable.unquoted[0m (required)
 [90mn/a[0m
 
 

--- a/internal/pkg/print/settings.go
+++ b/internal/pkg/print/settings.go
@@ -18,23 +18,23 @@ type Settings struct {
 	// scope: Markdown
 	ShowRequired bool
 
-	// SortByName sorted rendering of inputs and outputs (default: true)
+	// SortByName sorted rendering of variables and outputs (default: true)
 	// scope: Global
 	SortByName bool
 
-	// SortInputsByRequired sort inputs by name and prints required inputs first (default: false)
+	// SortVariablesByRequired sort variables by name and prints required variables first (default: false)
 	// scope: Global
-	SortInputsByRequired bool
+	SortVariablesByRequired bool
 }
 
 //NewSettings returns new instance of Settings
 func NewSettings() *Settings {
 	return &Settings{
-		AggregateTypeDefaults: false,
-		EscapeMarkdown:        true,
-		MarkdownIndent:        2,
-		ShowRequired:          true,
-		SortByName:            true,
-		SortInputsByRequired:  false,
+		AggregateTypeDefaults:   false,
+		EscapeMarkdown:          true,
+		MarkdownIndent:          2,
+		ShowRequired:            true,
+		SortByName:              true,
+		SortVariablesByRequired: false,
 	}
 }

--- a/internal/pkg/tfconf/variable.go
+++ b/internal/pkg/tfconf/variable.go
@@ -1,7 +1,7 @@
 package tfconf
 
-// Input represents a Terraform input.
-type Input struct {
+// Variable represents a Terraform variable.
+type Variable struct {
 	Name        string `json:"name"`
 	Type        string `json:"type,omitempty"`
 	Description string `json:"description,omitempty"`
@@ -9,35 +9,35 @@ type Input struct {
 }
 
 // HasDefault indicates if a Terraform variable has a default value set.
-func (i *Input) HasDefault() bool {
+func (i *Variable) HasDefault() bool {
 	return len(i.Default) > 0
 }
 
-type inputsSortedByName []*Input
+type variablesSortedByName []*Variable
 
-func (a inputsSortedByName) Len() int {
+func (a variablesSortedByName) Len() int {
 	return len(a)
 }
 
-func (a inputsSortedByName) Swap(i, j int) {
+func (a variablesSortedByName) Swap(i, j int) {
 	a[i], a[j] = a[j], a[i]
 }
 
-func (a inputsSortedByName) Less(i, j int) bool {
+func (a variablesSortedByName) Less(i, j int) bool {
 	return a[i].Name < a[j].Name
 }
 
-type inputsSortedByRequired []*Input
+type variablesSortedByRequired []*Variable
 
-func (a inputsSortedByRequired) Len() int {
+func (a variablesSortedByRequired) Len() int {
 	return len(a)
 }
 
-func (a inputsSortedByRequired) Swap(i, j int) {
+func (a variablesSortedByRequired) Swap(i, j int) {
 	a[i], a[j] = a[j], a[i]
 }
 
-func (a inputsSortedByRequired) Less(i, j int) bool {
+func (a variablesSortedByRequired) Less(i, j int) bool {
 	switch {
 	// i required, j not: i gets priority
 	case !a[i].HasDefault() && a[j].HasDefault():


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [x] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

BREAKING CHANGE:
- We've decided to rename `input` to `variable` which is a known terminology in Terraform configuration. The affected parts
are:
  1) markdown titles have been changed to `## Variables`
  2) json item has been renamed to `variables`.
- Also flag `--sort-inputs-by-required` has been deprecated in favor of `--sort-by-required`. The depracted flag will be completely removed in the second release from now.

Originally-Authored-By: @moatra 
Original-Pull-Request: #113

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [x] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
