### PR TITLE
Reimplement '--no-sort' to be compatible with Terraform 0.12 configuration

### DIFF
--- a/internal/pkg/print/json/json_test.go
+++ b/internal/pkg/print/json/json_test.go
@@ -10,10 +10,7 @@ import (
 )
 
 func TestPrint(t *testing.T) {
-	// TODO remove SortByName when --no-sort for Terraform 0.12 is implemented
-	var settings = &print.Settings{
-		SortByName: true,
-	}
+	var settings = &print.Settings{}
 
 	module, err := tfconf.CreateModule("../../../../examples")
 	if err != nil {

--- a/internal/pkg/print/json/testdata/json.golden
+++ b/internal/pkg/print/json/testdata/json.golden
@@ -1,10 +1,57 @@
 {
   "inputs": [
     {
-      "name": "input-with-code-block",
+      "name": "unquoted",
+      "type": "any"
+    },
+    {
+      "name": "string-3",
+      "type": "string",
+      "default": "\"\""
+    },
+    {
+      "name": "string-2",
+      "type": "string",
+      "description": "It's string number two."
+    },
+    {
+      "name": "string-1",
+      "type": "string",
+      "default": "\"bar\""
+    },
+    {
+      "name": "map-3",
+      "type": "map",
+      "default": "{}"
+    },
+    {
+      "name": "map-2",
+      "type": "map",
+      "description": "It's map number two."
+    },
+    {
+      "name": "map-1",
+      "type": "map",
+      "default": "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3\n}"
+    },
+    {
+      "name": "list-3",
       "type": "list",
-      "description": "This is a complicated one. We need a newline.  \nAnd an example in a code block\n```\ndefault     = [\n  \"machine rack01:neptune\"\n]\n```\n",
-      "default": "[\n  \"name rack:location\"\n]"
+      "default": "[]"
+    },
+    {
+      "name": "list-2",
+      "type": "list",
+      "description": "It's list number two."
+    },
+    {
+      "name": "list-1",
+      "type": "list",
+      "default": "[\n  \"a\",\n  \"b\",\n  \"c\"\n]"
+    },
+    {
+      "name": "input_with_underscores",
+      "type": "any"
     },
     {
       "name": "input-with-pipe",
@@ -13,80 +60,33 @@
       "default": "\"v1\""
     },
     {
-      "name": "input_with_underscores",
-      "type": "any"
-    },
-    {
-      "name": "list-1",
+      "name": "input-with-code-block",
       "type": "list",
-      "default": "[\n  \"a\",\n  \"b\",\n  \"c\"\n]"
-    },
-    {
-      "name": "list-2",
-      "type": "list",
-      "description": "It's list number two."
-    },
-    {
-      "name": "list-3",
-      "type": "list",
-      "default": "[]"
+      "description": "This is a complicated one. We need a newline.  \nAnd an example in a code block\n```\ndefault     = [\n  \"machine rack01:neptune\"\n]\n```\n",
+      "default": "[\n  \"name rack:location\"\n]"
     },
     {
       "name": "long_type",
       "type": "object({\n    name = string,\n    foo  = object({ foo = string, bar = string }),\n    bar  = object({ foo = string, bar = string }),\n    fizz = list(string),\n    buzz = list(string)\n  })",
       "description": "This description is itself markdown.\n\nIt spans over multiple lines.\n",
       "default": "{\n  \"bar\": {\n    \"bar\": \"bar\",\n    \"foo\": \"bar\"\n  },\n  \"buzz\": [\n    \"fizz\",\n    \"buzz\"\n  ],\n  \"fizz\": [],\n  \"foo\": {\n    \"bar\": \"foo\",\n    \"foo\": \"foo\"\n  },\n  \"name\": \"hello\"\n}"
-    },
-    {
-      "name": "map-1",
-      "type": "map",
-      "default": "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3\n}"
-    },
-    {
-      "name": "map-2",
-      "type": "map",
-      "description": "It's map number two."
-    },
-    {
-      "name": "map-3",
-      "type": "map",
-      "default": "{}"
-    },
-    {
-      "name": "string-1",
-      "type": "string",
-      "default": "\"bar\""
-    },
-    {
-      "name": "string-2",
-      "type": "string",
-      "description": "It's string number two."
-    },
-    {
-      "name": "string-3",
-      "type": "string",
-      "default": "\"\""
-    },
-    {
-      "name": "unquoted",
-      "type": "any"
     }
   ],
   "outputs": [
     {
-      "name": "output-0.12",
-      "description": "terraform 0.12 only"
-    },
-    {
-      "name": "output-1"
+      "name": "unquoted",
+      "description": "It's unquoted output."
     },
     {
       "name": "output-2",
       "description": "It's output number two."
     },
     {
-      "name": "unquoted",
-      "description": "It's unquoted output."
+      "name": "output-1"
+    },
+    {
+      "name": "output-0.12",
+      "description": "terraform 0.12 only"
     }
   ]
 }

--- a/internal/pkg/print/markdown/document/document_test.go
+++ b/internal/pkg/print/markdown/document/document_test.go
@@ -10,10 +10,7 @@ import (
 )
 
 func TestPrint(t *testing.T) {
-	// TODO remove SortByName when --no-sort for Terraform 0.12 is implemented
-	var settings = &print.Settings{
-		SortByName: true,
-	}
+	var settings = &print.Settings{}
 
 	module, err := tfconf.CreateModule("../../../../../examples")
 	if err != nil {
@@ -34,9 +31,7 @@ func TestPrint(t *testing.T) {
 }
 
 func TestPrintWithRequired(t *testing.T) {
-	// TODO remove SortByName when --no-sort for Terraform 0.12 is implemented
 	var settings = &print.Settings{
-		SortByName:   true,
 		ShowRequired: true,
 	}
 
@@ -106,9 +101,7 @@ func TestPrintWithSortInputsByRequired(t *testing.T) {
 }
 
 func TestPrintWithEscapeName(t *testing.T) {
-	// TODO remove SortByName when --no-sort for Terraform 0.12 is implemented
 	var settings = &print.Settings{
-		SortByName:     true,
 		EscapeMarkdown: true,
 	}
 
@@ -131,9 +124,7 @@ func TestPrintWithEscapeName(t *testing.T) {
 }
 
 func TestPrintWithIndentationBellowAllowed(t *testing.T) {
-	// TODO remove SortByName when --no-sort for Terraform 0.12 is implemented
 	var settings = &print.Settings{
-		SortByName:     true,
 		MarkdownIndent: 0,
 	}
 
@@ -156,9 +147,7 @@ func TestPrintWithIndentationBellowAllowed(t *testing.T) {
 }
 
 func TestPrintWithIndentationAboveAllowed(t *testing.T) {
-	// TODO remove SortByName when --no-sort for Terraform 0.12 is implemented
 	var settings = &print.Settings{
-		SortByName:     true,
 		MarkdownIndent: 10,
 	}
 
@@ -181,9 +170,7 @@ func TestPrintWithIndentationAboveAllowed(t *testing.T) {
 }
 
 func TestPrintWithIndentationOfFour(t *testing.T) {
-	// TODO remove SortByName when --no-sort for Terraform 0.12 is implemented
 	var settings = &print.Settings{
-		SortByName:     true,
 		MarkdownIndent: 4,
 	}
 

--- a/internal/pkg/print/markdown/document/testdata/document-WithEscapeName.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-WithEscapeName.golden
@@ -2,39 +2,83 @@
 
 The following input variables are supported:
 
-### input-with-code-block
-
-Description: This is a complicated one. We need a newline.  
-And an example in a code block
-```
-default     = [
-  "machine rack01:neptune"
-]
-```
-
-Type: `list`
-
-Default:
-
-```json
-[
-  "name rack:location"
-]
-```
-
-### input-with-pipe
-
-Description: It includes v1 \| v2 \| v3
-
-Type: `string`
-
-Default: `"v1"`
-
-### input\_with\_underscores
+### unquoted
 
 Description: n/a
 
 Type: `any`
+
+Default: n/a
+
+### string-3
+
+Description: n/a
+
+Type: `string`
+
+Default: `""`
+
+### string-2
+
+Description: It's string number two.
+
+Type: `string`
+
+Default: n/a
+
+### string-1
+
+Description: n/a
+
+Type: `string`
+
+Default: `"bar"`
+
+### map-3
+
+Description: n/a
+
+Type: `map`
+
+Default: `{}`
+
+### map-2
+
+Description: It's map number two.
+
+Type: `map`
+
+Default: n/a
+
+### map-1
+
+Description: n/a
+
+Type: `map`
+
+Default:
+
+```json
+{
+  "a": 1,
+  "b": 2,
+  "c": 3
+}
+```
+
+### list-3
+
+Description: n/a
+
+Type: `list`
+
+Default: `[]`
+
+### list-2
+
+Description: It's list number two.
+
+Type: `list`
 
 Default: n/a
 
@@ -54,21 +98,41 @@ Default:
 ]
 ```
 
-### list-2
-
-Description: It's list number two.
-
-Type: `list`
-
-Default: n/a
-
-### list-3
+### input\_with\_underscores
 
 Description: n/a
 
+Type: `any`
+
+Default: n/a
+
+### input-with-pipe
+
+Description: It includes v1 \| v2 \| v3
+
+Type: `string`
+
+Default: `"v1"`
+
+### input-with-code-block
+
+Description: This is a complicated one. We need a newline.  
+And an example in a code block
+```
+default     = [
+  "machine rack01:neptune"
+]
+```
+
 Type: `list`
 
-Default: `[]`
+Default:
+
+```json
+[
+  "name rack:location"
+]
+```
 
 ### long\_type
 
@@ -109,86 +173,22 @@ Default:
 }
 ```
 
-### map-1
-
-Description: n/a
-
-Type: `map`
-
-Default:
-
-```json
-{
-  "a": 1,
-  "b": 2,
-  "c": 3
-}
-```
-
-### map-2
-
-Description: It's map number two.
-
-Type: `map`
-
-Default: n/a
-
-### map-3
-
-Description: n/a
-
-Type: `map`
-
-Default: `{}`
-
-### string-1
-
-Description: n/a
-
-Type: `string`
-
-Default: `"bar"`
-
-### string-2
-
-Description: It's string number two.
-
-Type: `string`
-
-Default: n/a
-
-### string-3
-
-Description: n/a
-
-Type: `string`
-
-Default: `""`
-
-### unquoted
-
-Description: n/a
-
-Type: `any`
-
-Default: n/a
-
 ## Outputs
 
 The following outputs are exported:
 
-### output-0.12
+### unquoted
 
-Description: terraform 0.12 only
-
-### output-1
-
-Description: n/a
+Description: It's unquoted output.
 
 ### output-2
 
 Description: It's output number two.
 
-### unquoted
+### output-1
 
-Description: It's unquoted output.
+Description: n/a
+
+### output-0.12
+
+Description: terraform 0.12 only

--- a/internal/pkg/print/markdown/document/testdata/document-WithIndentationAboveAllowed.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-WithIndentationAboveAllowed.golden
@@ -2,39 +2,83 @@
 
 The following input variables are supported:
 
-### input-with-code-block
-
-Description: This is a complicated one. We need a newline.  
-And an example in a code block
-```
-default     = [
-  "machine rack01:neptune"
-]
-```
-
-Type: `list`
-
-Default:
-
-```json
-[
-  "name rack:location"
-]
-```
-
-### input-with-pipe
-
-Description: It includes v1 \| v2 \| v3
-
-Type: `string`
-
-Default: `"v1"`
-
-### input_with_underscores
+### unquoted
 
 Description: n/a
 
 Type: `any`
+
+Default: n/a
+
+### string-3
+
+Description: n/a
+
+Type: `string`
+
+Default: `""`
+
+### string-2
+
+Description: It's string number two.
+
+Type: `string`
+
+Default: n/a
+
+### string-1
+
+Description: n/a
+
+Type: `string`
+
+Default: `"bar"`
+
+### map-3
+
+Description: n/a
+
+Type: `map`
+
+Default: `{}`
+
+### map-2
+
+Description: It's map number two.
+
+Type: `map`
+
+Default: n/a
+
+### map-1
+
+Description: n/a
+
+Type: `map`
+
+Default:
+
+```json
+{
+  "a": 1,
+  "b": 2,
+  "c": 3
+}
+```
+
+### list-3
+
+Description: n/a
+
+Type: `list`
+
+Default: `[]`
+
+### list-2
+
+Description: It's list number two.
+
+Type: `list`
 
 Default: n/a
 
@@ -54,21 +98,41 @@ Default:
 ]
 ```
 
-### list-2
-
-Description: It's list number two.
-
-Type: `list`
-
-Default: n/a
-
-### list-3
+### input_with_underscores
 
 Description: n/a
 
+Type: `any`
+
+Default: n/a
+
+### input-with-pipe
+
+Description: It includes v1 \| v2 \| v3
+
+Type: `string`
+
+Default: `"v1"`
+
+### input-with-code-block
+
+Description: This is a complicated one. We need a newline.  
+And an example in a code block
+```
+default     = [
+  "machine rack01:neptune"
+]
+```
+
 Type: `list`
 
-Default: `[]`
+Default:
+
+```json
+[
+  "name rack:location"
+]
+```
 
 ### long_type
 
@@ -109,86 +173,22 @@ Default:
 }
 ```
 
-### map-1
-
-Description: n/a
-
-Type: `map`
-
-Default:
-
-```json
-{
-  "a": 1,
-  "b": 2,
-  "c": 3
-}
-```
-
-### map-2
-
-Description: It's map number two.
-
-Type: `map`
-
-Default: n/a
-
-### map-3
-
-Description: n/a
-
-Type: `map`
-
-Default: `{}`
-
-### string-1
-
-Description: n/a
-
-Type: `string`
-
-Default: `"bar"`
-
-### string-2
-
-Description: It's string number two.
-
-Type: `string`
-
-Default: n/a
-
-### string-3
-
-Description: n/a
-
-Type: `string`
-
-Default: `""`
-
-### unquoted
-
-Description: n/a
-
-Type: `any`
-
-Default: n/a
-
 ## Outputs
 
 The following outputs are exported:
 
-### output-0.12
+### unquoted
 
-Description: terraform 0.12 only
-
-### output-1
-
-Description: n/a
+Description: It's unquoted output.
 
 ### output-2
 
 Description: It's output number two.
 
-### unquoted
+### output-1
 
-Description: It's unquoted output.
+Description: n/a
+
+### output-0.12
+
+Description: terraform 0.12 only

--- a/internal/pkg/print/markdown/document/testdata/document-WithIndentationBellowAllowed.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-WithIndentationBellowAllowed.golden
@@ -2,39 +2,83 @@
 
 The following input variables are supported:
 
-### input-with-code-block
-
-Description: This is a complicated one. We need a newline.  
-And an example in a code block
-```
-default     = [
-  "machine rack01:neptune"
-]
-```
-
-Type: `list`
-
-Default:
-
-```json
-[
-  "name rack:location"
-]
-```
-
-### input-with-pipe
-
-Description: It includes v1 \| v2 \| v3
-
-Type: `string`
-
-Default: `"v1"`
-
-### input_with_underscores
+### unquoted
 
 Description: n/a
 
 Type: `any`
+
+Default: n/a
+
+### string-3
+
+Description: n/a
+
+Type: `string`
+
+Default: `""`
+
+### string-2
+
+Description: It's string number two.
+
+Type: `string`
+
+Default: n/a
+
+### string-1
+
+Description: n/a
+
+Type: `string`
+
+Default: `"bar"`
+
+### map-3
+
+Description: n/a
+
+Type: `map`
+
+Default: `{}`
+
+### map-2
+
+Description: It's map number two.
+
+Type: `map`
+
+Default: n/a
+
+### map-1
+
+Description: n/a
+
+Type: `map`
+
+Default:
+
+```json
+{
+  "a": 1,
+  "b": 2,
+  "c": 3
+}
+```
+
+### list-3
+
+Description: n/a
+
+Type: `list`
+
+Default: `[]`
+
+### list-2
+
+Description: It's list number two.
+
+Type: `list`
 
 Default: n/a
 
@@ -54,21 +98,41 @@ Default:
 ]
 ```
 
-### list-2
-
-Description: It's list number two.
-
-Type: `list`
-
-Default: n/a
-
-### list-3
+### input_with_underscores
 
 Description: n/a
 
+Type: `any`
+
+Default: n/a
+
+### input-with-pipe
+
+Description: It includes v1 \| v2 \| v3
+
+Type: `string`
+
+Default: `"v1"`
+
+### input-with-code-block
+
+Description: This is a complicated one. We need a newline.  
+And an example in a code block
+```
+default     = [
+  "machine rack01:neptune"
+]
+```
+
 Type: `list`
 
-Default: `[]`
+Default:
+
+```json
+[
+  "name rack:location"
+]
+```
 
 ### long_type
 
@@ -109,86 +173,22 @@ Default:
 }
 ```
 
-### map-1
-
-Description: n/a
-
-Type: `map`
-
-Default:
-
-```json
-{
-  "a": 1,
-  "b": 2,
-  "c": 3
-}
-```
-
-### map-2
-
-Description: It's map number two.
-
-Type: `map`
-
-Default: n/a
-
-### map-3
-
-Description: n/a
-
-Type: `map`
-
-Default: `{}`
-
-### string-1
-
-Description: n/a
-
-Type: `string`
-
-Default: `"bar"`
-
-### string-2
-
-Description: It's string number two.
-
-Type: `string`
-
-Default: n/a
-
-### string-3
-
-Description: n/a
-
-Type: `string`
-
-Default: `""`
-
-### unquoted
-
-Description: n/a
-
-Type: `any`
-
-Default: n/a
-
 ## Outputs
 
 The following outputs are exported:
 
-### output-0.12
+### unquoted
 
-Description: terraform 0.12 only
-
-### output-1
-
-Description: n/a
+Description: It's unquoted output.
 
 ### output-2
 
 Description: It's output number two.
 
-### unquoted
+### output-1
 
-Description: It's unquoted output.
+Description: n/a
+
+### output-0.12
+
+Description: terraform 0.12 only

--- a/internal/pkg/print/markdown/document/testdata/document-WithIndentationOfFour.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-WithIndentationOfFour.golden
@@ -2,39 +2,83 @@
 
 The following input variables are supported:
 
-##### input-with-code-block
-
-Description: This is a complicated one. We need a newline.  
-And an example in a code block
-```
-default     = [
-  "machine rack01:neptune"
-]
-```
-
-Type: `list`
-
-Default:
-
-```json
-[
-  "name rack:location"
-]
-```
-
-##### input-with-pipe
-
-Description: It includes v1 \| v2 \| v3
-
-Type: `string`
-
-Default: `"v1"`
-
-##### input_with_underscores
+##### unquoted
 
 Description: n/a
 
 Type: `any`
+
+Default: n/a
+
+##### string-3
+
+Description: n/a
+
+Type: `string`
+
+Default: `""`
+
+##### string-2
+
+Description: It's string number two.
+
+Type: `string`
+
+Default: n/a
+
+##### string-1
+
+Description: n/a
+
+Type: `string`
+
+Default: `"bar"`
+
+##### map-3
+
+Description: n/a
+
+Type: `map`
+
+Default: `{}`
+
+##### map-2
+
+Description: It's map number two.
+
+Type: `map`
+
+Default: n/a
+
+##### map-1
+
+Description: n/a
+
+Type: `map`
+
+Default:
+
+```json
+{
+  "a": 1,
+  "b": 2,
+  "c": 3
+}
+```
+
+##### list-3
+
+Description: n/a
+
+Type: `list`
+
+Default: `[]`
+
+##### list-2
+
+Description: It's list number two.
+
+Type: `list`
 
 Default: n/a
 
@@ -54,21 +98,41 @@ Default:
 ]
 ```
 
-##### list-2
-
-Description: It's list number two.
-
-Type: `list`
-
-Default: n/a
-
-##### list-3
+##### input_with_underscores
 
 Description: n/a
 
+Type: `any`
+
+Default: n/a
+
+##### input-with-pipe
+
+Description: It includes v1 \| v2 \| v3
+
+Type: `string`
+
+Default: `"v1"`
+
+##### input-with-code-block
+
+Description: This is a complicated one. We need a newline.  
+And an example in a code block
+```
+default     = [
+  "machine rack01:neptune"
+]
+```
+
 Type: `list`
 
-Default: `[]`
+Default:
+
+```json
+[
+  "name rack:location"
+]
+```
 
 ##### long_type
 
@@ -109,86 +173,22 @@ Default:
 }
 ```
 
-##### map-1
-
-Description: n/a
-
-Type: `map`
-
-Default:
-
-```json
-{
-  "a": 1,
-  "b": 2,
-  "c": 3
-}
-```
-
-##### map-2
-
-Description: It's map number two.
-
-Type: `map`
-
-Default: n/a
-
-##### map-3
-
-Description: n/a
-
-Type: `map`
-
-Default: `{}`
-
-##### string-1
-
-Description: n/a
-
-Type: `string`
-
-Default: `"bar"`
-
-##### string-2
-
-Description: It's string number two.
-
-Type: `string`
-
-Default: n/a
-
-##### string-3
-
-Description: n/a
-
-Type: `string`
-
-Default: `""`
-
-##### unquoted
-
-Description: n/a
-
-Type: `any`
-
-Default: n/a
-
 #### Outputs
 
 The following outputs are exported:
 
-##### output-0.12
+##### unquoted
 
-Description: terraform 0.12 only
-
-##### output-1
-
-Description: n/a
+Description: It's unquoted output.
 
 ##### output-2
 
 Description: It's output number two.
 
-##### unquoted
+##### output-1
 
-Description: It's unquoted output.
+Description: n/a
+
+##### output-0.12
+
+Description: terraform 0.12 only

--- a/internal/pkg/print/markdown/document/testdata/document-WithRequired.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-WithRequired.golden
@@ -2,23 +2,11 @@
 
 The following input variables are required:
 
-### input_with_underscores
+### unquoted
 
 Description: n/a
 
 Type: `any`
-
-### list-2
-
-Description: It's list number two.
-
-Type: `list`
-
-### map-2
-
-Description: It's map number two.
-
-Type: `map`
 
 ### string-2
 
@@ -26,7 +14,19 @@ Description: It's string number two.
 
 Type: `string`
 
-### unquoted
+### map-2
+
+Description: It's map number two.
+
+Type: `map`
+
+### list-2
+
+Description: It's list number two.
+
+Type: `list`
+
+### input_with_underscores
 
 Description: n/a
 
@@ -35,6 +35,78 @@ Type: `any`
 ## Optional Inputs
 
 The following input variables are optional (have default values):
+
+### string-3
+
+Description: n/a
+
+Type: `string`
+
+Default: `""`
+
+### string-1
+
+Description: n/a
+
+Type: `string`
+
+Default: `"bar"`
+
+### map-3
+
+Description: n/a
+
+Type: `map`
+
+Default: `{}`
+
+### map-1
+
+Description: n/a
+
+Type: `map`
+
+Default:
+
+```json
+{
+  "a": 1,
+  "b": 2,
+  "c": 3
+}
+```
+
+### list-3
+
+Description: n/a
+
+Type: `list`
+
+Default: `[]`
+
+### list-1
+
+Description: n/a
+
+Type: `list`
+
+Default:
+
+```json
+[
+  "a",
+  "b",
+  "c"
+]
+```
+
+### input-with-pipe
+
+Description: It includes v1 \| v2 \| v3
+
+Type: `string`
+
+Default: `"v1"`
 
 ### input-with-code-block
 
@@ -55,38 +127,6 @@ Default:
   "name rack:location"
 ]
 ```
-
-### input-with-pipe
-
-Description: It includes v1 \| v2 \| v3
-
-Type: `string`
-
-Default: `"v1"`
-
-### list-1
-
-Description: n/a
-
-Type: `list`
-
-Default:
-
-```json
-[
-  "a",
-  "b",
-  "c"
-]
-```
-
-### list-3
-
-Description: n/a
-
-Type: `list`
-
-Default: `[]`
 
 ### long_type
 
@@ -127,62 +167,22 @@ Default:
 }
 ```
 
-### map-1
-
-Description: n/a
-
-Type: `map`
-
-Default:
-
-```json
-{
-  "a": 1,
-  "b": 2,
-  "c": 3
-}
-```
-
-### map-3
-
-Description: n/a
-
-Type: `map`
-
-Default: `{}`
-
-### string-1
-
-Description: n/a
-
-Type: `string`
-
-Default: `"bar"`
-
-### string-3
-
-Description: n/a
-
-Type: `string`
-
-Default: `""`
-
 ## Outputs
 
 The following outputs are exported:
 
-### output-0.12
+### unquoted
 
-Description: terraform 0.12 only
-
-### output-1
-
-Description: n/a
+Description: It's unquoted output.
 
 ### output-2
 
 Description: It's output number two.
 
-### unquoted
+### output-1
 
-Description: It's unquoted output.
+Description: n/a
+
+### output-0.12
+
+Description: terraform 0.12 only

--- a/internal/pkg/print/markdown/document/testdata/document.golden
+++ b/internal/pkg/print/markdown/document/testdata/document.golden
@@ -2,39 +2,83 @@
 
 The following input variables are supported:
 
-### input-with-code-block
-
-Description: This is a complicated one. We need a newline.  
-And an example in a code block
-```
-default     = [
-  "machine rack01:neptune"
-]
-```
-
-Type: `list`
-
-Default:
-
-```json
-[
-  "name rack:location"
-]
-```
-
-### input-with-pipe
-
-Description: It includes v1 \| v2 \| v3
-
-Type: `string`
-
-Default: `"v1"`
-
-### input_with_underscores
+### unquoted
 
 Description: n/a
 
 Type: `any`
+
+Default: n/a
+
+### string-3
+
+Description: n/a
+
+Type: `string`
+
+Default: `""`
+
+### string-2
+
+Description: It's string number two.
+
+Type: `string`
+
+Default: n/a
+
+### string-1
+
+Description: n/a
+
+Type: `string`
+
+Default: `"bar"`
+
+### map-3
+
+Description: n/a
+
+Type: `map`
+
+Default: `{}`
+
+### map-2
+
+Description: It's map number two.
+
+Type: `map`
+
+Default: n/a
+
+### map-1
+
+Description: n/a
+
+Type: `map`
+
+Default:
+
+```json
+{
+  "a": 1,
+  "b": 2,
+  "c": 3
+}
+```
+
+### list-3
+
+Description: n/a
+
+Type: `list`
+
+Default: `[]`
+
+### list-2
+
+Description: It's list number two.
+
+Type: `list`
 
 Default: n/a
 
@@ -54,21 +98,41 @@ Default:
 ]
 ```
 
-### list-2
-
-Description: It's list number two.
-
-Type: `list`
-
-Default: n/a
-
-### list-3
+### input_with_underscores
 
 Description: n/a
 
+Type: `any`
+
+Default: n/a
+
+### input-with-pipe
+
+Description: It includes v1 \| v2 \| v3
+
+Type: `string`
+
+Default: `"v1"`
+
+### input-with-code-block
+
+Description: This is a complicated one. We need a newline.  
+And an example in a code block
+```
+default     = [
+  "machine rack01:neptune"
+]
+```
+
 Type: `list`
 
-Default: `[]`
+Default:
+
+```json
+[
+  "name rack:location"
+]
+```
 
 ### long_type
 
@@ -109,86 +173,22 @@ Default:
 }
 ```
 
-### map-1
-
-Description: n/a
-
-Type: `map`
-
-Default:
-
-```json
-{
-  "a": 1,
-  "b": 2,
-  "c": 3
-}
-```
-
-### map-2
-
-Description: It's map number two.
-
-Type: `map`
-
-Default: n/a
-
-### map-3
-
-Description: n/a
-
-Type: `map`
-
-Default: `{}`
-
-### string-1
-
-Description: n/a
-
-Type: `string`
-
-Default: `"bar"`
-
-### string-2
-
-Description: It's string number two.
-
-Type: `string`
-
-Default: n/a
-
-### string-3
-
-Description: n/a
-
-Type: `string`
-
-Default: `""`
-
-### unquoted
-
-Description: n/a
-
-Type: `any`
-
-Default: n/a
-
 ## Outputs
 
 The following outputs are exported:
 
-### output-0.12
+### unquoted
 
-Description: terraform 0.12 only
-
-### output-1
-
-Description: n/a
+Description: It's unquoted output.
 
 ### output-2
 
 Description: It's output number two.
 
-### unquoted
+### output-1
 
-Description: It's unquoted output.
+Description: n/a
+
+### output-0.12
+
+Description: terraform 0.12 only

--- a/internal/pkg/print/markdown/table/table_test.go
+++ b/internal/pkg/print/markdown/table/table_test.go
@@ -10,10 +10,7 @@ import (
 )
 
 func TestPrint(t *testing.T) {
-	// TODO remove SortByName when --no-sort for Terraform 0.12 is implemented
-	var settings = &print.Settings{
-		SortByName: true,
-	}
+	var settings = &print.Settings{}
 
 	module, err := tfconf.CreateModule("../../../../../examples")
 	if err != nil {
@@ -34,9 +31,7 @@ func TestPrint(t *testing.T) {
 }
 
 func TestPrintWithRequired(t *testing.T) {
-	// TODO remove SortByName when --no-sort for Terraform 0.12 is implemented
 	var settings = &print.Settings{
-		SortByName:   true,
 		ShowRequired: true,
 	}
 
@@ -106,9 +101,7 @@ func TestPrintWithSortInputsByRequired(t *testing.T) {
 }
 
 func TestPrintWithEscapeName(t *testing.T) {
-	// TODO remove SortByName when --no-sort for Terraform 0.12 is implemented
 	var settings = &print.Settings{
-		SortByName:     true,
 		EscapeMarkdown: true,
 	}
 
@@ -131,9 +124,7 @@ func TestPrintWithEscapeName(t *testing.T) {
 }
 
 func TestPrintWithIndentationBellowAllowed(t *testing.T) {
-	// TODO remove SortByName when --no-sort for Terraform 0.12 is implemented
 	var settings = &print.Settings{
-		SortByName:     true,
 		MarkdownIndent: 0,
 	}
 
@@ -156,9 +147,7 @@ func TestPrintWithIndentationBellowAllowed(t *testing.T) {
 }
 
 func TestPrintWithIndentationAboveAllowed(t *testing.T) {
-	// TODO remove SortByName when --no-sort for Terraform 0.12 is implemented
 	var settings = &print.Settings{
-		SortByName:     true,
 		MarkdownIndent: 10,
 	}
 
@@ -181,9 +170,7 @@ func TestPrintWithIndentationAboveAllowed(t *testing.T) {
 }
 
 func TestPrintWithIndentationOfFour(t *testing.T) {
-	// TODO remove SortByName when --no-sort for Terraform 0.12 is implemented
 	var settings = &print.Settings{
-		SortByName:     true,
 		MarkdownIndent: 4,
 	}
 

--- a/internal/pkg/print/markdown/table/testdata/table-WithEscapeName.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-WithEscapeName.golden
@@ -2,26 +2,26 @@
 
 | Name | Description | Type | Default |
 |------|-------------|------|---------|
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
-| input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| input\_with\_underscores | n/a | `any` | n/a |
-| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
-| list-2 | It's list number two. | `list` | n/a |
-| list-3 | n/a | `list` | `[]` |
-| long\_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
-| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
-| map-2 | It's map number two. | `map` | n/a |
-| map-3 | n/a | `map` | `{}` |
-| string-1 | n/a | `string` | `"bar"` |
-| string-2 | It's string number two. | `string` | n/a |
-| string-3 | n/a | `string` | `""` |
 | unquoted | n/a | `any` | n/a |
+| string-3 | n/a | `string` | `""` |
+| string-2 | It's string number two. | `string` | n/a |
+| string-1 | n/a | `string` | `"bar"` |
+| map-3 | n/a | `map` | `{}` |
+| map-2 | It's map number two. | `map` | n/a |
+| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| list-3 | n/a | `list` | `[]` |
+| list-2 | It's list number two. | `list` | n/a |
+| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| input\_with\_underscores | n/a | `any` | n/a |
+| input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
+| long\_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| output-0.12 | terraform 0.12 only |
-| output-1 | n/a |
-| output-2 | It's output number two. |
 | unquoted | It's unquoted output. |
+| output-2 | It's output number two. |
+| output-1 | n/a |
+| output-0.12 | terraform 0.12 only |

--- a/internal/pkg/print/markdown/table/testdata/table-WithIndentationAboveAllowed.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-WithIndentationAboveAllowed.golden
@@ -2,26 +2,26 @@
 
 | Name | Description | Type | Default |
 |------|-------------|------|---------|
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
-| input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| input_with_underscores | n/a | `any` | n/a |
-| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
-| list-2 | It's list number two. | `list` | n/a |
-| list-3 | n/a | `list` | `[]` |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
-| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
-| map-2 | It's map number two. | `map` | n/a |
-| map-3 | n/a | `map` | `{}` |
-| string-1 | n/a | `string` | `"bar"` |
-| string-2 | It's string number two. | `string` | n/a |
-| string-3 | n/a | `string` | `""` |
 | unquoted | n/a | `any` | n/a |
+| string-3 | n/a | `string` | `""` |
+| string-2 | It's string number two. | `string` | n/a |
+| string-1 | n/a | `string` | `"bar"` |
+| map-3 | n/a | `map` | `{}` |
+| map-2 | It's map number two. | `map` | n/a |
+| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| list-3 | n/a | `list` | `[]` |
+| list-2 | It's list number two. | `list` | n/a |
+| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| input_with_underscores | n/a | `any` | n/a |
+| input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| output-0.12 | terraform 0.12 only |
-| output-1 | n/a |
-| output-2 | It's output number two. |
 | unquoted | It's unquoted output. |
+| output-2 | It's output number two. |
+| output-1 | n/a |
+| output-0.12 | terraform 0.12 only |

--- a/internal/pkg/print/markdown/table/testdata/table-WithIndentationBellowAllowed.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-WithIndentationBellowAllowed.golden
@@ -2,26 +2,26 @@
 
 | Name | Description | Type | Default |
 |------|-------------|------|---------|
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
-| input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| input_with_underscores | n/a | `any` | n/a |
-| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
-| list-2 | It's list number two. | `list` | n/a |
-| list-3 | n/a | `list` | `[]` |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
-| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
-| map-2 | It's map number two. | `map` | n/a |
-| map-3 | n/a | `map` | `{}` |
-| string-1 | n/a | `string` | `"bar"` |
-| string-2 | It's string number two. | `string` | n/a |
-| string-3 | n/a | `string` | `""` |
 | unquoted | n/a | `any` | n/a |
+| string-3 | n/a | `string` | `""` |
+| string-2 | It's string number two. | `string` | n/a |
+| string-1 | n/a | `string` | `"bar"` |
+| map-3 | n/a | `map` | `{}` |
+| map-2 | It's map number two. | `map` | n/a |
+| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| list-3 | n/a | `list` | `[]` |
+| list-2 | It's list number two. | `list` | n/a |
+| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| input_with_underscores | n/a | `any` | n/a |
+| input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| output-0.12 | terraform 0.12 only |
-| output-1 | n/a |
-| output-2 | It's output number two. |
 | unquoted | It's unquoted output. |
+| output-2 | It's output number two. |
+| output-1 | n/a |
+| output-0.12 | terraform 0.12 only |

--- a/internal/pkg/print/markdown/table/testdata/table-WithIndentationOfFour.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-WithIndentationOfFour.golden
@@ -2,26 +2,26 @@
 
 | Name | Description | Type | Default |
 |------|-------------|------|---------|
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
-| input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| input_with_underscores | n/a | `any` | n/a |
-| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
-| list-2 | It's list number two. | `list` | n/a |
-| list-3 | n/a | `list` | `[]` |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
-| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
-| map-2 | It's map number two. | `map` | n/a |
-| map-3 | n/a | `map` | `{}` |
-| string-1 | n/a | `string` | `"bar"` |
-| string-2 | It's string number two. | `string` | n/a |
-| string-3 | n/a | `string` | `""` |
 | unquoted | n/a | `any` | n/a |
+| string-3 | n/a | `string` | `""` |
+| string-2 | It's string number two. | `string` | n/a |
+| string-1 | n/a | `string` | `"bar"` |
+| map-3 | n/a | `map` | `{}` |
+| map-2 | It's map number two. | `map` | n/a |
+| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| list-3 | n/a | `list` | `[]` |
+| list-2 | It's list number two. | `list` | n/a |
+| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| input_with_underscores | n/a | `any` | n/a |
+| input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
 
 #### Outputs
 
 | Name | Description |
 |------|-------------|
-| output-0.12 | terraform 0.12 only |
-| output-1 | n/a |
-| output-2 | It's output number two. |
 | unquoted | It's unquoted output. |
+| output-2 | It's output number two. |
+| output-1 | n/a |
+| output-0.12 | terraform 0.12 only |

--- a/internal/pkg/print/markdown/table/testdata/table-WithRequired.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-WithRequired.golden
@@ -2,26 +2,26 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> | no |
-| input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` | no |
-| input_with_underscores | n/a | `any` | n/a | yes |
-| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> | no |
-| list-2 | It's list number two. | `list` | n/a | yes |
-| list-3 | n/a | `list` | `[]` | no |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> | no |
-| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> | no |
-| map-2 | It's map number two. | `map` | n/a | yes |
-| map-3 | n/a | `map` | `{}` | no |
-| string-1 | n/a | `string` | `"bar"` | no |
-| string-2 | It's string number two. | `string` | n/a | yes |
-| string-3 | n/a | `string` | `""` | no |
 | unquoted | n/a | `any` | n/a | yes |
+| string-3 | n/a | `string` | `""` | no |
+| string-2 | It's string number two. | `string` | n/a | yes |
+| string-1 | n/a | `string` | `"bar"` | no |
+| map-3 | n/a | `map` | `{}` | no |
+| map-2 | It's map number two. | `map` | n/a | yes |
+| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> | no |
+| list-3 | n/a | `list` | `[]` | no |
+| list-2 | It's list number two. | `list` | n/a | yes |
+| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> | no |
+| input_with_underscores | n/a | `any` | n/a | yes |
+| input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` | no |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> | no |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| output-0.12 | terraform 0.12 only |
-| output-1 | n/a |
-| output-2 | It's output number two. |
 | unquoted | It's unquoted output. |
+| output-2 | It's output number two. |
+| output-1 | n/a |
+| output-0.12 | terraform 0.12 only |

--- a/internal/pkg/print/markdown/table/testdata/table.golden
+++ b/internal/pkg/print/markdown/table/testdata/table.golden
@@ -2,26 +2,26 @@
 
 | Name | Description | Type | Default |
 |------|-------------|------|---------|
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
-| input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| input_with_underscores | n/a | `any` | n/a |
-| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
-| list-2 | It's list number two. | `list` | n/a |
-| list-3 | n/a | `list` | `[]` |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
-| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
-| map-2 | It's map number two. | `map` | n/a |
-| map-3 | n/a | `map` | `{}` |
-| string-1 | n/a | `string` | `"bar"` |
-| string-2 | It's string number two. | `string` | n/a |
-| string-3 | n/a | `string` | `""` |
 | unquoted | n/a | `any` | n/a |
+| string-3 | n/a | `string` | `""` |
+| string-2 | It's string number two. | `string` | n/a |
+| string-1 | n/a | `string` | `"bar"` |
+| map-3 | n/a | `map` | `{}` |
+| map-2 | It's map number two. | `map` | n/a |
+| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| list-3 | n/a | `list` | `[]` |
+| list-2 | It's list number two. | `list` | n/a |
+| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| input_with_underscores | n/a | `any` | n/a |
+| input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| output-0.12 | terraform 0.12 only |
-| output-1 | n/a |
-| output-2 | It's output number two. |
 | unquoted | It's unquoted output. |
+| output-2 | It's output number two. |
+| output-1 | n/a |
+| output-0.12 | terraform 0.12 only |

--- a/internal/pkg/print/pretty/pretty_test.go
+++ b/internal/pkg/print/pretty/pretty_test.go
@@ -10,10 +10,7 @@ import (
 )
 
 func TestPretty(t *testing.T) {
-	// TODO remove SortByName when --no-sort for Terraform 0.12 is implemented
-	var settings = &print.Settings{
-		SortByName: true,
-	}
+	var settings = &print.Settings{}
 
 	module, err := tfconf.CreateModule("../../../../examples")
 	if err != nil {

--- a/internal/pkg/print/pretty/testdata/pretty.golden
+++ b/internal/pkg/print/pretty/testdata/pretty.golden
@@ -1,5 +1,49 @@
 
 
+[36minput.unquoted[0m (required)
+[90mn/a[0m
+
+[36minput.string-3[0m ("")
+[90mn/a[0m
+
+[36minput.string-2[0m (required)
+[90mIt's string number two.[0m
+
+[36minput.string-1[0m ("bar")
+[90mn/a[0m
+
+[36minput.map-3[0m ({})
+[90mn/a[0m
+
+[36minput.map-2[0m (required)
+[90mIt's map number two.[0m
+
+[36minput.map-1[0m ({
+  "a": 1,
+  "b": 2,
+  "c": 3
+})
+[90mn/a[0m
+
+[36minput.list-3[0m ([])
+[90mn/a[0m
+
+[36minput.list-2[0m (required)
+[90mIt's list number two.[0m
+
+[36minput.list-1[0m ([
+  "a",
+  "b",
+  "c"
+])
+[90mn/a[0m
+
+[36minput.input_with_underscores[0m (required)
+[90mn/a[0m
+
+[36minput.input-with-pipe[0m ("v1")
+[90mIt includes v1 | v2 | v3[0m
+
 [36minput.input-with-code-block[0m ([
   "name rack:location"
 ])
@@ -10,25 +54,6 @@ default     = [
   "machine rack01:neptune"
 ]
 ```[0m
-
-[36minput.input-with-pipe[0m ("v1")
-[90mIt includes v1 | v2 | v3[0m
-
-[36minput.input_with_underscores[0m (required)
-[90mn/a[0m
-
-[36minput.list-1[0m ([
-  "a",
-  "b",
-  "c"
-])
-[90mn/a[0m
-
-[36minput.list-2[0m (required)
-[90mIt's list number two.[0m
-
-[36minput.list-3[0m ([])
-[90mn/a[0m
 
 [36minput.long_type[0m ({
   "bar": {
@@ -50,42 +75,17 @@ default     = [
 
 It spans over multiple lines.[0m
 
-[36minput.map-1[0m ({
-  "a": 1,
-  "b": 2,
-  "c": 3
-})
-[90mn/a[0m
-
-[36minput.map-2[0m (required)
-[90mIt's map number two.[0m
-
-[36minput.map-3[0m ({})
-[90mn/a[0m
-
-[36minput.string-1[0m ("bar")
-[90mn/a[0m
-
-[36minput.string-2[0m (required)
-[90mIt's string number two.[0m
-
-[36minput.string-3[0m ("")
-[90mn/a[0m
-
-[36minput.unquoted[0m (required)
-[90mn/a[0m
 
 
-
-[36moutput.output-0.12[0m
-[90mterraform 0.12 only[0m
-
-[36moutput.output-1[0m
-[90mn/a[0m
+[36moutput.unquoted[0m
+[90mIt's unquoted output.[0m
 
 [36moutput.output-2[0m
 [90mIt's output number two.[0m
 
-[36moutput.unquoted[0m
-[90mIt's unquoted output.[0m
+[36moutput.output-1[0m
+[90mn/a[0m
+
+[36moutput.output-0.12[0m
+[90mterraform 0.12 only[0m
 

--- a/internal/pkg/tfconf/input.go
+++ b/internal/pkg/tfconf/input.go
@@ -2,10 +2,11 @@ package tfconf
 
 // Input represents a Terraform input.
 type Input struct {
-	Name        string `json:"name"`
-	Type        string `json:"type,omitempty"`
-	Description string `json:"description,omitempty"`
-	Default     string `json:"default,omitempty"`
+	Name        string   `json:"name"`
+	Type        string   `json:"type,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Default     string   `json:"default,omitempty"`
+	Position    Position `json:"-"`
 }
 
 // HasDefault indicates if a Terraform variable has a default value set.
@@ -49,4 +50,18 @@ func (a inputsSortedByRequired) Less(i, j int) bool {
 	default:
 		return a[i].Name < a[j].Name
 	}
+}
+
+type inputsSortedByPosition []*Input
+
+func (a inputsSortedByPosition) Len() int {
+	return len(a)
+}
+
+func (a inputsSortedByPosition) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+func (a inputsSortedByPosition) Less(i, j int) bool {
+	return a[i].Position.Filename < a[j].Position.Filename || a[i].Position.Line < a[j].Position.Line
 }

--- a/internal/pkg/tfconf/module.go
+++ b/internal/pkg/tfconf/module.go
@@ -28,36 +28,29 @@ func (m *Module) HasOutputs() bool {
 	return len(m.Outputs) > 0
 }
 
-func (m *Module) sortInputsByName() {
-	sort.Sort(inputsSortedByName(m.Inputs))
-	sort.Sort(inputsSortedByName(m.RequiredInputs))
-	sort.Sort(inputsSortedByName(m.OptionalInputs))
-}
-
-func (m *Module) sortInputsByRequired() {
-	sort.Sort(inputsSortedByRequired(m.Inputs))
-	sort.Sort(inputsSortedByRequired(m.RequiredInputs))
-	sort.Sort(inputsSortedByRequired(m.OptionalInputs))
-}
-
-func (m *Module) sortOutputsByName() {
-	sort.Sort(outputsSortedByName(m.Outputs))
-}
-
 // Sort sorts list of inputs and outputs based on provided flags (name, required, etc)
 func (m *Module) Sort(settings *print.Settings) {
 	if settings.SortByName {
 		if settings.SortInputsByRequired {
-			m.sortInputsByRequired()
+			sort.Sort(inputsSortedByRequired(m.Inputs))
+			sort.Sort(inputsSortedByRequired(m.RequiredInputs))
+			sort.Sort(inputsSortedByRequired(m.OptionalInputs))
 		} else {
-			m.sortInputsByName()
+			sort.Sort(inputsSortedByName(m.Inputs))
+			sort.Sort(inputsSortedByName(m.RequiredInputs))
+			sort.Sort(inputsSortedByName(m.OptionalInputs))
 		}
+	} else {
+		sort.Sort(inputsSortedByPosition(m.Inputs))
+		sort.Sort(inputsSortedByPosition(m.RequiredInputs))
+		sort.Sort(inputsSortedByPosition(m.OptionalInputs))
 	}
 
 	if settings.SortByName {
-		m.sortOutputsByName()
+		sort.Sort(outputsSortedByName(m.Outputs))
+	} else {
+		sort.Sort(outputsSortedByPosition(m.Outputs))
 	}
-
 }
 
 // CreateModule returns new instance of Module with all the inputs and
@@ -104,6 +97,10 @@ func CreateModule(path string) (*Module, error) {
 			Type:        inputType,
 			Description: input.Description,
 			Default:     defaultValue,
+			Position: Position{
+				Filename: input.Pos.Filename,
+				Line:     input.Pos.Line,
+			},
 		}
 
 		inputs = append(inputs, i)
@@ -119,6 +116,10 @@ func CreateModule(path string) (*Module, error) {
 		outputs = append(outputs, &Output{
 			Name:        output.Name,
 			Description: output.Description,
+			Position: Position{
+				Filename: output.Pos.Filename,
+				Line:     output.Pos.Line,
+			},
 		})
 	}
 

--- a/internal/pkg/tfconf/output.go
+++ b/internal/pkg/tfconf/output.go
@@ -2,8 +2,9 @@ package tfconf
 
 // Output represents a Terraform output.
 type Output struct {
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Position    Position `json:"-"`
 }
 
 type outputsSortedByName []*Output
@@ -18,4 +19,18 @@ func (a outputsSortedByName) Swap(i, j int) {
 
 func (a outputsSortedByName) Less(i, j int) bool {
 	return a[i].Name < a[j].Name
+}
+
+type outputsSortedByPosition []*Output
+
+func (a outputsSortedByPosition) Len() int {
+	return len(a)
+}
+
+func (a outputsSortedByPosition) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+func (a outputsSortedByPosition) Less(i, j int) bool {
+	return a[i].Position.Filename < a[j].Position.Filename || a[i].Position.Line < a[j].Position.Line
 }

--- a/internal/pkg/tfconf/position.go
+++ b/internal/pkg/tfconf/position.go
@@ -1,0 +1,7 @@
+package tfconf
+
+// Position represents position of Terraform input or output in a file.
+type Position struct {
+	Filename string `json:"-"`
+	Line     int    `json:"-"`
+}


### PR DESCRIPTION
## Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

While adding the support for Terraform 0.12 configuration in #113 we lost support for `--no-sort` functionality, this PR fixes that and adds it back and also removes the temporary hack we had to do for tests to not constantly failing.

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [ ] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
