### PR TITLE
Add '--no-color' flag to 'pretty' command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,10 +20,12 @@ var rootCmd = &cobra.Command{
 	Long:    "A utility to generate documentation from Terraform modules in various output formats",
 	Version: version.Version(),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		nocolor, _ := cmd.Flags().GetBool("no-color")
 		nosort, _ := cmd.Flags().GetBool("no-sort")
 		norequired, _ := cmd.Flags().GetBool("no-required")
 		noescape, _ := cmd.Flags().GetBool("no-escape")
 
+		settings.ShowColor = !nocolor
 		settings.SortByName = !nosort
 		settings.ShowRequired = !norequired
 		settings.EscapeMarkdown = !noescape
@@ -38,6 +40,8 @@ func init() {
 	markdownCmd.PersistentFlags().BoolVar(new(bool), "no-required", false, "omit \"Required\" column when generating Markdown")
 	markdownCmd.PersistentFlags().BoolVar(new(bool), "no-escape", false, "do not escape special characters")
 	markdownCmd.PersistentFlags().IntVar(&settings.MarkdownIndent, "indent", 2, "indention level of Markdown sections [1, 2, 3, 4, 5]")
+
+	prettyCmd.PersistentFlags().BoolVar(new(bool), "no-color", false, "do not colorize printed result")
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/internal/pkg/print/pretty/pretty.go
+++ b/internal/pkg/print/pretty/pretty.go
@@ -54,7 +54,12 @@ func printProviders(buffer *bytes.Buffer, providers []*tfconf.Provider, settings
 	buffer.WriteString("\n\n")
 
 	for _, provider := range providers {
-		format := "\033[36mprovider.%s\033[0m%s\n\n"
+		var format string
+		if settings.ShowColor {
+			format = "\033[36mprovider.%s\033[0m%s\n\n"
+		} else {
+			format = "provider.%s%s\n\n"
+		}
 		buffer.WriteString(
 			fmt.Sprintf(
 				format,
@@ -70,7 +75,12 @@ func printInputs(buffer *bytes.Buffer, inputs []*tfconf.Input, settings *print.S
 	buffer.WriteString("\n")
 
 	for _, input := range inputs {
-		format := "\033[36minput.%s\033[0m (%s)\n\033[90m%s\033[0m\n\n"
+		var format string
+		if settings.ShowColor {
+			format = "\033[36minput.%s\033[0m (%s)\n\033[90m%s\033[0m\n\n"
+		} else {
+			format = "input.%s (%s)\n%s\n\n"
+		}
 		buffer.WriteString(
 			fmt.Sprintf(
 				format,
@@ -88,7 +98,12 @@ func printOutputs(buffer *bytes.Buffer, outputs []*tfconf.Output, settings *prin
 	buffer.WriteString("\n")
 
 	for _, output := range outputs {
-		format := "\033[36moutput.%s\033[0m\n\033[90m%s\033[0m\n\n"
+		var format string
+		if settings.ShowColor {
+			format = "\033[36moutput.%s\033[0m\n\033[90m%s\033[0m\n\n"
+		} else {
+			format = "output.%s\n%s\n\n"
+		}
 		buffer.WriteString(
 			fmt.Sprintf(
 				format,

--- a/internal/pkg/print/pretty/pretty_test.go
+++ b/internal/pkg/print/pretty/pretty_test.go
@@ -10,7 +10,9 @@ import (
 
 func TestPretty(t *testing.T) {
 	assert := assert.New(t)
-	settings := &print.Settings{}
+	settings := &print.Settings{
+		ShowColor: true,
+	}
 
 	module, expected, err := testutil.GetExpected("pretty")
 	assert.Nil(err)
@@ -25,6 +27,7 @@ func TestPrettySortByName(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		SortByName: true,
+		ShowColor:  true,
 	}
 
 	module, expected, err := testutil.GetExpected("pretty-SortByName")
@@ -41,9 +44,25 @@ func TestPrettySortByRequired(t *testing.T) {
 	settings := &print.Settings{
 		SortByName:           true,
 		SortInputsByRequired: true,
+		ShowColor:            true,
 	}
 
 	module, expected, err := testutil.GetExpected("pretty-SortByRequired")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestPrettyNoColor(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowColor: false,
+	}
+
+	module, expected, err := testutil.GetExpected("pretty-NoColor")
 	assert.Nil(err)
 
 	actual, err := Print(module, settings)

--- a/internal/pkg/print/pretty/testdata/pretty-NoColor.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoColor.golden
@@ -1,0 +1,101 @@
+
+
+provider.tls
+
+provider.aws (>= 2.15.0)
+
+provider.aws.ident (>= 2.15.0)
+
+provider.null
+
+
+
+input.unquoted (required)
+n/a
+
+input.string-3 ("")
+n/a
+
+input.string-2 (required)
+It's string number two.
+
+input.string-1 ("bar")
+n/a
+
+input.map-3 ({})
+n/a
+
+input.map-2 (required)
+It's map number two.
+
+input.map-1 ({
+  "a": 1,
+  "b": 2,
+  "c": 3
+})
+n/a
+
+input.list-3 ([])
+n/a
+
+input.list-2 (required)
+It's list number two.
+
+input.list-1 ([
+  "a",
+  "b",
+  "c"
+])
+n/a
+
+input.input_with_underscores (required)
+n/a
+
+input.input-with-pipe ("v1")
+It includes v1 | v2 | v3
+
+input.input-with-code-block ([
+  "name rack:location"
+])
+This is a complicated one. We need a newline.  
+And an example in a code block
+```
+default     = [
+  "machine rack01:neptune"
+]
+```
+
+input.long_type ({
+  "bar": {
+    "bar": "bar",
+    "foo": "bar"
+  },
+  "buzz": [
+    "fizz",
+    "buzz"
+  ],
+  "fizz": [],
+  "foo": {
+    "bar": "foo",
+    "foo": "foo"
+  },
+  "name": "hello"
+})
+This description is itself markdown.
+
+It spans over multiple lines.
+
+
+
+output.unquoted
+It's unquoted output.
+
+output.output-2
+It's output number two.
+
+output.output-1
+n/a
+
+output.output-0.12
+terraform 0.12 only
+

--- a/internal/pkg/print/settings.go
+++ b/internal/pkg/print/settings.go
@@ -18,6 +18,10 @@ type Settings struct {
 	// scope: Markdown
 	ShowRequired bool
 
+	// ShowColor print "colorized" version of result in the terminal (default: true)
+	// scope: Pretty
+	ShowColor bool
+
 	// SortByName sorted rendering of inputs and outputs (default: true)
 	// scope: Global
 	SortByName bool
@@ -33,6 +37,7 @@ func NewSettings() *Settings {
 		AggregateTypeDefaults: false,
 		EscapeMarkdown:        true,
 		MarkdownIndent:        2,
+		ShowColor:             true,
 		ShowRequired:          true,
 		SortByName:            true,
 		SortInputsByRequired:  false,


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

This PR adds a new `--no-color` flag to `pretty` command. Using this flag results into a color-less output in the terminal, note that the output is completely plain text and color less and not using `\033[0m` (reset color character).

### Issues Resolved

Fixes #78 

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [x] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
