### PR TITLE
Add flags to not show different sections

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,10 +20,18 @@ var rootCmd = &cobra.Command{
 	Long:    "A utility to generate documentation from Terraform modules in various output formats",
 	Version: version.Version(),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		noproviders, _ := cmd.Flags().GetBool("no-providers")
+		noinputs, _ := cmd.Flags().GetBool("no-inputs")
+		nooutputs, _ := cmd.Flags().GetBool("no-outputs")
+
 		nocolor, _ := cmd.Flags().GetBool("no-color")
 		nosort, _ := cmd.Flags().GetBool("no-sort")
 		norequired, _ := cmd.Flags().GetBool("no-required")
 		noescape, _ := cmd.Flags().GetBool("no-escape")
+
+		settings.ShowProviders = !noproviders
+		settings.ShowInputs = !noinputs
+		settings.ShowOutputs = !nooutputs
 
 		settings.ShowColor = !nocolor
 		settings.SortByName = !nosort
@@ -33,6 +41,10 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
+	rootCmd.PersistentFlags().BoolVar(new(bool), "no-providers", false, "do not show providers information")
+	rootCmd.PersistentFlags().BoolVar(new(bool), "no-inputs", false, "do not show inputs information")
+	rootCmd.PersistentFlags().BoolVar(new(bool), "no-outputs", false, "do not show outputs information")
+
 	rootCmd.PersistentFlags().BoolVar(new(bool), "no-sort", false, "omit sorted rendering of inputs and outputs")
 	rootCmd.PersistentFlags().BoolVar(&settings.SortInputsByRequired, "sort-inputs-by-required", false, "sort inputs by name and prints required inputs first")
 	rootCmd.PersistentFlags().BoolVar(&settings.AggregateTypeDefaults, "with-aggregate-type-defaults", false, "print default values of aggregate types")

--- a/internal/pkg/print/json/json.go
+++ b/internal/pkg/print/json/json.go
@@ -16,7 +16,23 @@ const (
 func Print(module *tfconf.Module, settings *print.Settings) (string, error) {
 	module.Sort(settings)
 
-	buffer, err := json.MarshalIndent(module, prefix, indent)
+	copy := &tfconf.Module{
+		Providers: make([]*tfconf.Provider, 0),
+		Inputs:    make([]*tfconf.Input, 0),
+		Outputs:   make([]*tfconf.Output, 0),
+	}
+
+	if settings.ShowProviders {
+		copy.Providers = module.Providers
+	}
+	if settings.ShowInputs {
+		copy.Inputs = module.Inputs
+	}
+	if settings.ShowOutputs {
+		copy.Outputs = module.Outputs
+	}
+
+	buffer, err := json.MarshalIndent(copy, prefix, indent)
 	if err != nil {
 		return "", err
 	}

--- a/internal/pkg/print/json/json_test.go
+++ b/internal/pkg/print/json/json_test.go
@@ -10,7 +10,11 @@ import (
 
 func TestJson(t *testing.T) {
 	assert := assert.New(t)
-	settings := &print.Settings{}
+	settings := &print.Settings{
+		ShowProviders: true,
+		ShowInputs:    true,
+		ShowOutputs:   true,
+	}
 
 	module, expected, err := testutil.GetExpected("json")
 	assert.Nil(err)
@@ -24,7 +28,10 @@ func TestJson(t *testing.T) {
 func TestJsonSortByName(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
-		SortByName: true,
+		SortByName:    true,
+		ShowProviders: true,
+		ShowInputs:    true,
+		ShowOutputs:   true,
 	}
 
 	module, expected, err := testutil.GetExpected("json-SortByName")
@@ -41,9 +48,114 @@ func TestJsonSortByRequired(t *testing.T) {
 	settings := &print.Settings{
 		SortByName:           true,
 		SortInputsByRequired: true,
+		ShowProviders:        true,
+		ShowInputs:           true,
+		ShowOutputs:          true,
 	}
 
 	module, expected, err := testutil.GetExpected("json-SortByRequired")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestJsonNoProviders(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: false,
+		ShowInputs:    true,
+		ShowOutputs:   true,
+	}
+
+	module, expected, err := testutil.GetExpected("json-NoProviders")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestJsonNoInputs(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: true,
+		ShowInputs:    false,
+		ShowOutputs:   true,
+	}
+
+	module, expected, err := testutil.GetExpected("json-NoInputs")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestJsonNoOutputs(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: true,
+		ShowInputs:    true,
+		ShowOutputs:   false,
+	}
+
+	module, expected, err := testutil.GetExpected("json-NoOutputs")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestJsonOnlyProviders(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: true,
+		ShowInputs:    false,
+		ShowOutputs:   false,
+	}
+
+	module, expected, err := testutil.GetExpected("json-OnlyProviders")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestJsonOnlyInputs(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: false,
+		ShowInputs:    true,
+		ShowOutputs:   false,
+	}
+
+	module, expected, err := testutil.GetExpected("json-OnlyInputs")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestJsonOnlyOutputs(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: false,
+		ShowInputs:    false,
+		ShowOutputs:   true,
+	}
+
+	module, expected, err := testutil.GetExpected("json-OnlyOutputs")
 	assert.Nil(err)
 
 	actual, err := Print(module, settings)

--- a/internal/pkg/print/json/testdata/json-NoInputs.golden
+++ b/internal/pkg/print/json/testdata/json-NoInputs.golden
@@ -1,0 +1,37 @@
+{
+  "inputs": [],
+  "outputs": [
+    {
+      "name": "unquoted",
+      "description": "It's unquoted output."
+    },
+    {
+      "name": "output-2",
+      "description": "It's output number two."
+    },
+    {
+      "name": "output-1"
+    },
+    {
+      "name": "output-0.12",
+      "description": "terraform 0.12 only"
+    }
+  ],
+  "providers": [
+    {
+      "name": "tls"
+    },
+    {
+      "name": "aws",
+      "version": "\u003e= 2.15.0"
+    },
+    {
+      "name": "aws",
+      "alias": "ident",
+      "version": "\u003e= 2.15.0"
+    },
+    {
+      "name": "null"
+    }
+  ]
+}

--- a/internal/pkg/print/json/testdata/json-NoOutputs.golden
+++ b/internal/pkg/print/json/testdata/json-NoOutputs.golden
@@ -1,0 +1,93 @@
+{
+  "inputs": [
+    {
+      "name": "unquoted",
+      "type": "any"
+    },
+    {
+      "name": "string-3",
+      "type": "string",
+      "default": "\"\""
+    },
+    {
+      "name": "string-2",
+      "type": "string",
+      "description": "It's string number two."
+    },
+    {
+      "name": "string-1",
+      "type": "string",
+      "default": "\"bar\""
+    },
+    {
+      "name": "map-3",
+      "type": "map",
+      "default": "{}"
+    },
+    {
+      "name": "map-2",
+      "type": "map",
+      "description": "It's map number two."
+    },
+    {
+      "name": "map-1",
+      "type": "map",
+      "default": "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3\n}"
+    },
+    {
+      "name": "list-3",
+      "type": "list",
+      "default": "[]"
+    },
+    {
+      "name": "list-2",
+      "type": "list",
+      "description": "It's list number two."
+    },
+    {
+      "name": "list-1",
+      "type": "list",
+      "default": "[\n  \"a\",\n  \"b\",\n  \"c\"\n]"
+    },
+    {
+      "name": "input_with_underscores",
+      "type": "any"
+    },
+    {
+      "name": "input-with-pipe",
+      "type": "string",
+      "description": "It includes v1 | v2 | v3",
+      "default": "\"v1\""
+    },
+    {
+      "name": "input-with-code-block",
+      "type": "list",
+      "description": "This is a complicated one. We need a newline.  \nAnd an example in a code block\n```\ndefault     = [\n  \"machine rack01:neptune\"\n]\n```\n",
+      "default": "[\n  \"name rack:location\"\n]"
+    },
+    {
+      "name": "long_type",
+      "type": "object({\n    name = string,\n    foo  = object({ foo = string, bar = string }),\n    bar  = object({ foo = string, bar = string }),\n    fizz = list(string),\n    buzz = list(string)\n  })",
+      "description": "This description is itself markdown.\n\nIt spans over multiple lines.\n",
+      "default": "{\n  \"bar\": {\n    \"bar\": \"bar\",\n    \"foo\": \"bar\"\n  },\n  \"buzz\": [\n    \"fizz\",\n    \"buzz\"\n  ],\n  \"fizz\": [],\n  \"foo\": {\n    \"bar\": \"foo\",\n    \"foo\": \"foo\"\n  },\n  \"name\": \"hello\"\n}"
+    }
+  ],
+  "outputs": [],
+  "providers": [
+    {
+      "name": "tls"
+    },
+    {
+      "name": "aws",
+      "version": "\u003e= 2.15.0"
+    },
+    {
+      "name": "aws",
+      "alias": "ident",
+      "version": "\u003e= 2.15.0"
+    },
+    {
+      "name": "null"
+    }
+  ]
+}

--- a/internal/pkg/print/json/testdata/json-NoProviders.golden
+++ b/internal/pkg/print/json/testdata/json-NoProviders.golden
@@ -1,0 +1,93 @@
+{
+  "inputs": [
+    {
+      "name": "unquoted",
+      "type": "any"
+    },
+    {
+      "name": "string-3",
+      "type": "string",
+      "default": "\"\""
+    },
+    {
+      "name": "string-2",
+      "type": "string",
+      "description": "It's string number two."
+    },
+    {
+      "name": "string-1",
+      "type": "string",
+      "default": "\"bar\""
+    },
+    {
+      "name": "map-3",
+      "type": "map",
+      "default": "{}"
+    },
+    {
+      "name": "map-2",
+      "type": "map",
+      "description": "It's map number two."
+    },
+    {
+      "name": "map-1",
+      "type": "map",
+      "default": "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3\n}"
+    },
+    {
+      "name": "list-3",
+      "type": "list",
+      "default": "[]"
+    },
+    {
+      "name": "list-2",
+      "type": "list",
+      "description": "It's list number two."
+    },
+    {
+      "name": "list-1",
+      "type": "list",
+      "default": "[\n  \"a\",\n  \"b\",\n  \"c\"\n]"
+    },
+    {
+      "name": "input_with_underscores",
+      "type": "any"
+    },
+    {
+      "name": "input-with-pipe",
+      "type": "string",
+      "description": "It includes v1 | v2 | v3",
+      "default": "\"v1\""
+    },
+    {
+      "name": "input-with-code-block",
+      "type": "list",
+      "description": "This is a complicated one. We need a newline.  \nAnd an example in a code block\n```\ndefault     = [\n  \"machine rack01:neptune\"\n]\n```\n",
+      "default": "[\n  \"name rack:location\"\n]"
+    },
+    {
+      "name": "long_type",
+      "type": "object({\n    name = string,\n    foo  = object({ foo = string, bar = string }),\n    bar  = object({ foo = string, bar = string }),\n    fizz = list(string),\n    buzz = list(string)\n  })",
+      "description": "This description is itself markdown.\n\nIt spans over multiple lines.\n",
+      "default": "{\n  \"bar\": {\n    \"bar\": \"bar\",\n    \"foo\": \"bar\"\n  },\n  \"buzz\": [\n    \"fizz\",\n    \"buzz\"\n  ],\n  \"fizz\": [],\n  \"foo\": {\n    \"bar\": \"foo\",\n    \"foo\": \"foo\"\n  },\n  \"name\": \"hello\"\n}"
+    }
+  ],
+  "outputs": [
+    {
+      "name": "unquoted",
+      "description": "It's unquoted output."
+    },
+    {
+      "name": "output-2",
+      "description": "It's output number two."
+    },
+    {
+      "name": "output-1"
+    },
+    {
+      "name": "output-0.12",
+      "description": "terraform 0.12 only"
+    }
+  ],
+  "providers": []
+}

--- a/internal/pkg/print/json/testdata/json-OnlyInputs.golden
+++ b/internal/pkg/print/json/testdata/json-OnlyInputs.golden
@@ -1,0 +1,77 @@
+{
+  "inputs": [
+    {
+      "name": "unquoted",
+      "type": "any"
+    },
+    {
+      "name": "string-3",
+      "type": "string",
+      "default": "\"\""
+    },
+    {
+      "name": "string-2",
+      "type": "string",
+      "description": "It's string number two."
+    },
+    {
+      "name": "string-1",
+      "type": "string",
+      "default": "\"bar\""
+    },
+    {
+      "name": "map-3",
+      "type": "map",
+      "default": "{}"
+    },
+    {
+      "name": "map-2",
+      "type": "map",
+      "description": "It's map number two."
+    },
+    {
+      "name": "map-1",
+      "type": "map",
+      "default": "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3\n}"
+    },
+    {
+      "name": "list-3",
+      "type": "list",
+      "default": "[]"
+    },
+    {
+      "name": "list-2",
+      "type": "list",
+      "description": "It's list number two."
+    },
+    {
+      "name": "list-1",
+      "type": "list",
+      "default": "[\n  \"a\",\n  \"b\",\n  \"c\"\n]"
+    },
+    {
+      "name": "input_with_underscores",
+      "type": "any"
+    },
+    {
+      "name": "input-with-pipe",
+      "type": "string",
+      "description": "It includes v1 | v2 | v3",
+      "default": "\"v1\""
+    },
+    {
+      "name": "input-with-code-block",
+      "type": "list",
+      "description": "This is a complicated one. We need a newline.  \nAnd an example in a code block\n```\ndefault     = [\n  \"machine rack01:neptune\"\n]\n```\n",
+      "default": "[\n  \"name rack:location\"\n]"
+    },
+    {
+      "name": "long_type",
+      "type": "object({\n    name = string,\n    foo  = object({ foo = string, bar = string }),\n    bar  = object({ foo = string, bar = string }),\n    fizz = list(string),\n    buzz = list(string)\n  })",
+      "description": "This description is itself markdown.\n\nIt spans over multiple lines.\n",
+      "default": "{\n  \"bar\": {\n    \"bar\": \"bar\",\n    \"foo\": \"bar\"\n  },\n  \"buzz\": [\n    \"fizz\",\n    \"buzz\"\n  ],\n  \"fizz\": [],\n  \"foo\": {\n    \"bar\": \"foo\",\n    \"foo\": \"foo\"\n  },\n  \"name\": \"hello\"\n}"
+    }
+  ],
+  "outputs": [],
+  "providers": []
+}

--- a/internal/pkg/print/json/testdata/json-OnlyOutputs.golden
+++ b/internal/pkg/print/json/testdata/json-OnlyOutputs.golden
@@ -1,0 +1,21 @@
+{
+  "inputs": [],
+  "outputs": [
+    {
+      "name": "unquoted",
+      "description": "It's unquoted output."
+    },
+    {
+      "name": "output-2",
+      "description": "It's output number two."
+    },
+    {
+      "name": "output-1"
+    },
+    {
+      "name": "output-0.12",
+      "description": "terraform 0.12 only"
+    }
+  ],
+  "providers": []
+}

--- a/internal/pkg/print/json/testdata/json-OnlyProviders.golden
+++ b/internal/pkg/print/json/testdata/json-OnlyProviders.golden
@@ -1,0 +1,21 @@
+{
+  "inputs": [],
+  "outputs": [],
+  "providers": [
+    {
+      "name": "tls"
+    },
+    {
+      "name": "aws",
+      "version": "\u003e= 2.15.0"
+    },
+    {
+      "name": "aws",
+      "alias": "ident",
+      "version": "\u003e= 2.15.0"
+    },
+    {
+      "name": "null"
+    }
+  ]
+}

--- a/internal/pkg/print/markdown/document/document_test.go
+++ b/internal/pkg/print/markdown/document/document_test.go
@@ -10,7 +10,11 @@ import (
 
 func TestDocument(t *testing.T) {
 	assert := assert.New(t)
-	settings := &print.Settings{}
+	settings := &print.Settings{
+		ShowProviders: true,
+		ShowInputs:    true,
+		ShowOutputs:   true,
+	}
 
 	module, expected, err := testutil.GetExpected("document")
 	assert.Nil(err)
@@ -24,7 +28,10 @@ func TestDocument(t *testing.T) {
 func TestDocumentWithRequired(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
-		ShowRequired: true,
+		ShowRequired:  true,
+		ShowProviders: true,
+		ShowInputs:    true,
+		ShowOutputs:   true,
 	}
 
 	module, expected, err := testutil.GetExpected("document-WithRequired")
@@ -39,7 +46,10 @@ func TestDocumentWithRequired(t *testing.T) {
 func TestDocumentSortByName(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
-		SortByName: true,
+		SortByName:    true,
+		ShowProviders: true,
+		ShowInputs:    true,
+		ShowOutputs:   true,
 	}
 
 	module, expected, err := testutil.GetExpected("document-SortByName")
@@ -56,9 +66,114 @@ func TestDocumentSortByRequired(t *testing.T) {
 	settings := &print.Settings{
 		SortByName:           true,
 		SortInputsByRequired: true,
+		ShowProviders:        true,
+		ShowInputs:           true,
+		ShowOutputs:          true,
 	}
 
 	module, expected, err := testutil.GetExpected("document-SortByRequired")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestDocumentNoProviders(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: false,
+		ShowInputs:    true,
+		ShowOutputs:   true,
+	}
+
+	module, expected, err := testutil.GetExpected("document-NoProviders")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestDocumentNoInputs(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: true,
+		ShowInputs:    false,
+		ShowOutputs:   true,
+	}
+
+	module, expected, err := testutil.GetExpected("document-NoInputs")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestDocumentNoOutputs(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: true,
+		ShowInputs:    true,
+		ShowOutputs:   false,
+	}
+
+	module, expected, err := testutil.GetExpected("document-NoOutputs")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestDocumentOnlyProviders(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: true,
+		ShowInputs:    false,
+		ShowOutputs:   false,
+	}
+
+	module, expected, err := testutil.GetExpected("document-OnlyProviders")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestDocumentOnlyInputs(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: false,
+		ShowInputs:    true,
+		ShowOutputs:   false,
+	}
+
+	module, expected, err := testutil.GetExpected("document-OnlyInputs")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestDocumentOnlyOutputs(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: false,
+		ShowInputs:    false,
+		ShowOutputs:   true,
+	}
+
+	module, expected, err := testutil.GetExpected("document-OnlyOutputs")
 	assert.Nil(err)
 
 	actual, err := Print(module, settings)
@@ -71,6 +186,9 @@ func TestDocumentEscapeMarkdown(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		EscapeMarkdown: true,
+		ShowProviders:  true,
+		ShowInputs:     true,
+		ShowOutputs:    true,
 	}
 
 	module, expected, err := testutil.GetExpected("document-EscapeMarkdown")
@@ -86,6 +204,9 @@ func TestDocumentIndentationBellowAllowed(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		MarkdownIndent: 0,
+		ShowProviders:  true,
+		ShowInputs:     true,
+		ShowOutputs:    true,
 	}
 
 	module, expected, err := testutil.GetExpected("document-IndentationBellowAllowed")
@@ -101,6 +222,9 @@ func TestDocumentIndentationAboveAllowed(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		MarkdownIndent: 10,
+		ShowProviders:  true,
+		ShowInputs:     true,
+		ShowOutputs:    true,
 	}
 
 	module, expected, err := testutil.GetExpected("document-IndentationAboveAllowed")
@@ -116,6 +240,9 @@ func TestDocumentIndentationOfFour(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		MarkdownIndent: 4,
+		ShowProviders:  true,
+		ShowInputs:     true,
+		ShowOutputs:    true,
 	}
 
 	module, expected, err := testutil.GetExpected("document-IndentationOfFour")

--- a/internal/pkg/print/markdown/document/testdata/document-NoInputs.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-NoInputs.golden
@@ -1,0 +1,31 @@
+## Providers
+
+The following providers are used by this module:
+
+- tls
+
+- aws (>= 2.15.0)
+
+- aws.ident (>= 2.15.0)
+
+- null
+
+## Outputs
+
+The following outputs are exported:
+
+### unquoted
+
+Description: It's unquoted output.
+
+### output-2
+
+Description: It's output number two.
+
+### output-1
+
+Description: n/a
+
+### output-0.12
+
+Description: terraform 0.12 only

--- a/internal/pkg/print/markdown/document/testdata/document-NoOutputs.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-NoOutputs.golden
@@ -1,0 +1,186 @@
+## Providers
+
+The following providers are used by this module:
+
+- tls
+
+- aws (>= 2.15.0)
+
+- aws.ident (>= 2.15.0)
+
+- null
+
+## Inputs
+
+The following input variables are supported:
+
+### unquoted
+
+Description: n/a
+
+Type: `any`
+
+Default: n/a
+
+### string-3
+
+Description: n/a
+
+Type: `string`
+
+Default: `""`
+
+### string-2
+
+Description: It's string number two.
+
+Type: `string`
+
+Default: n/a
+
+### string-1
+
+Description: n/a
+
+Type: `string`
+
+Default: `"bar"`
+
+### map-3
+
+Description: n/a
+
+Type: `map`
+
+Default: `{}`
+
+### map-2
+
+Description: It's map number two.
+
+Type: `map`
+
+Default: n/a
+
+### map-1
+
+Description: n/a
+
+Type: `map`
+
+Default:
+
+```json
+{
+  "a": 1,
+  "b": 2,
+  "c": 3
+}
+```
+
+### list-3
+
+Description: n/a
+
+Type: `list`
+
+Default: `[]`
+
+### list-2
+
+Description: It's list number two.
+
+Type: `list`
+
+Default: n/a
+
+### list-1
+
+Description: n/a
+
+Type: `list`
+
+Default:
+
+```json
+[
+  "a",
+  "b",
+  "c"
+]
+```
+
+### input_with_underscores
+
+Description: n/a
+
+Type: `any`
+
+Default: n/a
+
+### input-with-pipe
+
+Description: It includes v1 \| v2 \| v3
+
+Type: `string`
+
+Default: `"v1"`
+
+### input-with-code-block
+
+Description: This is a complicated one. We need a newline.  
+And an example in a code block
+```
+default     = [
+  "machine rack01:neptune"
+]
+```
+
+Type: `list`
+
+Default:
+
+```json
+[
+  "name rack:location"
+]
+```
+
+### long_type
+
+Description: This description is itself markdown.
+
+It spans over multiple lines.
+
+Type:
+
+```hcl
+object({
+    name = string,
+    foo  = object({ foo = string, bar = string }),
+    bar  = object({ foo = string, bar = string }),
+    fizz = list(string),
+    buzz = list(string)
+  })
+```
+
+Default:
+
+```json
+{
+  "bar": {
+    "bar": "bar",
+    "foo": "bar"
+  },
+  "buzz": [
+    "fizz",
+    "buzz"
+  ],
+  "fizz": [],
+  "foo": {
+    "bar": "foo",
+    "foo": "foo"
+  },
+  "name": "hello"
+}
+```

--- a/internal/pkg/print/markdown/document/testdata/document-NoProviders.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-NoProviders.golden
@@ -1,0 +1,194 @@
+## Inputs
+
+The following input variables are supported:
+
+### unquoted
+
+Description: n/a
+
+Type: `any`
+
+Default: n/a
+
+### string-3
+
+Description: n/a
+
+Type: `string`
+
+Default: `""`
+
+### string-2
+
+Description: It's string number two.
+
+Type: `string`
+
+Default: n/a
+
+### string-1
+
+Description: n/a
+
+Type: `string`
+
+Default: `"bar"`
+
+### map-3
+
+Description: n/a
+
+Type: `map`
+
+Default: `{}`
+
+### map-2
+
+Description: It's map number two.
+
+Type: `map`
+
+Default: n/a
+
+### map-1
+
+Description: n/a
+
+Type: `map`
+
+Default:
+
+```json
+{
+  "a": 1,
+  "b": 2,
+  "c": 3
+}
+```
+
+### list-3
+
+Description: n/a
+
+Type: `list`
+
+Default: `[]`
+
+### list-2
+
+Description: It's list number two.
+
+Type: `list`
+
+Default: n/a
+
+### list-1
+
+Description: n/a
+
+Type: `list`
+
+Default:
+
+```json
+[
+  "a",
+  "b",
+  "c"
+]
+```
+
+### input_with_underscores
+
+Description: n/a
+
+Type: `any`
+
+Default: n/a
+
+### input-with-pipe
+
+Description: It includes v1 \| v2 \| v3
+
+Type: `string`
+
+Default: `"v1"`
+
+### input-with-code-block
+
+Description: This is a complicated one. We need a newline.  
+And an example in a code block
+```
+default     = [
+  "machine rack01:neptune"
+]
+```
+
+Type: `list`
+
+Default:
+
+```json
+[
+  "name rack:location"
+]
+```
+
+### long_type
+
+Description: This description is itself markdown.
+
+It spans over multiple lines.
+
+Type:
+
+```hcl
+object({
+    name = string,
+    foo  = object({ foo = string, bar = string }),
+    bar  = object({ foo = string, bar = string }),
+    fizz = list(string),
+    buzz = list(string)
+  })
+```
+
+Default:
+
+```json
+{
+  "bar": {
+    "bar": "bar",
+    "foo": "bar"
+  },
+  "buzz": [
+    "fizz",
+    "buzz"
+  ],
+  "fizz": [],
+  "foo": {
+    "bar": "foo",
+    "foo": "foo"
+  },
+  "name": "hello"
+}
+```
+
+## Outputs
+
+The following outputs are exported:
+
+### unquoted
+
+Description: It's unquoted output.
+
+### output-2
+
+Description: It's output number two.
+
+### output-1
+
+Description: n/a
+
+### output-0.12
+
+Description: terraform 0.12 only

--- a/internal/pkg/print/markdown/document/testdata/document-OnlyInputs.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-OnlyInputs.golden
@@ -1,0 +1,174 @@
+## Inputs
+
+The following input variables are supported:
+
+### unquoted
+
+Description: n/a
+
+Type: `any`
+
+Default: n/a
+
+### string-3
+
+Description: n/a
+
+Type: `string`
+
+Default: `""`
+
+### string-2
+
+Description: It's string number two.
+
+Type: `string`
+
+Default: n/a
+
+### string-1
+
+Description: n/a
+
+Type: `string`
+
+Default: `"bar"`
+
+### map-3
+
+Description: n/a
+
+Type: `map`
+
+Default: `{}`
+
+### map-2
+
+Description: It's map number two.
+
+Type: `map`
+
+Default: n/a
+
+### map-1
+
+Description: n/a
+
+Type: `map`
+
+Default:
+
+```json
+{
+  "a": 1,
+  "b": 2,
+  "c": 3
+}
+```
+
+### list-3
+
+Description: n/a
+
+Type: `list`
+
+Default: `[]`
+
+### list-2
+
+Description: It's list number two.
+
+Type: `list`
+
+Default: n/a
+
+### list-1
+
+Description: n/a
+
+Type: `list`
+
+Default:
+
+```json
+[
+  "a",
+  "b",
+  "c"
+]
+```
+
+### input_with_underscores
+
+Description: n/a
+
+Type: `any`
+
+Default: n/a
+
+### input-with-pipe
+
+Description: It includes v1 \| v2 \| v3
+
+Type: `string`
+
+Default: `"v1"`
+
+### input-with-code-block
+
+Description: This is a complicated one. We need a newline.  
+And an example in a code block
+```
+default     = [
+  "machine rack01:neptune"
+]
+```
+
+Type: `list`
+
+Default:
+
+```json
+[
+  "name rack:location"
+]
+```
+
+### long_type
+
+Description: This description is itself markdown.
+
+It spans over multiple lines.
+
+Type:
+
+```hcl
+object({
+    name = string,
+    foo  = object({ foo = string, bar = string }),
+    bar  = object({ foo = string, bar = string }),
+    fizz = list(string),
+    buzz = list(string)
+  })
+```
+
+Default:
+
+```json
+{
+  "bar": {
+    "bar": "bar",
+    "foo": "bar"
+  },
+  "buzz": [
+    "fizz",
+    "buzz"
+  ],
+  "fizz": [],
+  "foo": {
+    "bar": "foo",
+    "foo": "foo"
+  },
+  "name": "hello"
+}
+```

--- a/internal/pkg/print/markdown/document/testdata/document-OnlyOutputs.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-OnlyOutputs.golden
@@ -1,0 +1,19 @@
+## Outputs
+
+The following outputs are exported:
+
+### unquoted
+
+Description: It's unquoted output.
+
+### output-2
+
+Description: It's output number two.
+
+### output-1
+
+Description: n/a
+
+### output-0.12
+
+Description: terraform 0.12 only

--- a/internal/pkg/print/markdown/document/testdata/document-OnlyProviders.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-OnlyProviders.golden
@@ -1,0 +1,11 @@
+## Providers
+
+The following providers are used by this module:
+
+- tls
+
+- aws (>= 2.15.0)
+
+- aws.ident (>= 2.15.0)
+
+- null

--- a/internal/pkg/print/markdown/table/table.go
+++ b/internal/pkg/print/markdown/table/table.go
@@ -15,9 +15,15 @@ func Print(module *tfconf.Module, settings *print.Settings) (string, error) {
 
 	module.Sort(settings)
 
-	printProviders(&buffer, module.Providers, settings)
-	printInputs(&buffer, module.Inputs, settings)
-	printOutputs(&buffer, module.Outputs, settings)
+	if settings.ShowProviders {
+		printProviders(&buffer, module.Providers, settings)
+	}
+	if settings.ShowInputs {
+		printInputs(&buffer, module.Inputs, settings)
+	}
+	if settings.ShowOutputs {
+		printOutputs(&buffer, module.Outputs, settings)
+	}
 
 	return markdown.Sanitize(buffer.String()), nil
 }
@@ -115,11 +121,11 @@ func printInputs(buffer *bytes.Buffer, inputs []*tfconf.Input, settings *print.S
 			buffer.WriteString("\n")
 		}
 	}
-
+	buffer.WriteString("\n")
 }
 
 func printOutputs(buffer *bytes.Buffer, outputs []*tfconf.Output, settings *print.Settings) {
-	buffer.WriteString(fmt.Sprintf("\n%s Outputs\n\n", markdown.GenerateIndentation(0, settings)))
+	buffer.WriteString(fmt.Sprintf("%s Outputs\n\n", markdown.GenerateIndentation(0, settings)))
 
 	if len(outputs) == 0 {
 		buffer.WriteString("No output.\n\n")

--- a/internal/pkg/print/markdown/table/table_test.go
+++ b/internal/pkg/print/markdown/table/table_test.go
@@ -10,7 +10,11 @@ import (
 
 func TestTable(t *testing.T) {
 	assert := assert.New(t)
-	settings := &print.Settings{}
+	settings := &print.Settings{
+		ShowProviders: true,
+		ShowInputs:    true,
+		ShowOutputs:   true,
+	}
 
 	module, expected, err := testutil.GetExpected("table")
 	assert.Nil(err)
@@ -24,7 +28,10 @@ func TestTable(t *testing.T) {
 func TestTableWithRequired(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
-		ShowRequired: true,
+		ShowRequired:  true,
+		ShowProviders: true,
+		ShowInputs:    true,
+		ShowOutputs:   true,
 	}
 
 	module, expected, err := testutil.GetExpected("table-WithRequired")
@@ -39,7 +46,10 @@ func TestTableWithRequired(t *testing.T) {
 func TestTableSortByName(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
-		SortByName: true,
+		SortByName:    true,
+		ShowProviders: true,
+		ShowInputs:    true,
+		ShowOutputs:   true,
 	}
 
 	module, expected, err := testutil.GetExpected("table-SortByName")
@@ -56,9 +66,114 @@ func TestTableSortByRequired(t *testing.T) {
 	settings := &print.Settings{
 		SortByName:           true,
 		SortInputsByRequired: true,
+		ShowProviders:        true,
+		ShowInputs:           true,
+		ShowOutputs:          true,
 	}
 
 	module, expected, err := testutil.GetExpected("table-SortByRequired")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestTableNoProviders(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: false,
+		ShowInputs:    true,
+		ShowOutputs:   true,
+	}
+
+	module, expected, err := testutil.GetExpected("table-NoProviders")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestTableNoInputs(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: true,
+		ShowInputs:    false,
+		ShowOutputs:   true,
+	}
+
+	module, expected, err := testutil.GetExpected("table-NoInputs")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestTableNoOutputs(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: true,
+		ShowInputs:    true,
+		ShowOutputs:   false,
+	}
+
+	module, expected, err := testutil.GetExpected("table-NoOutputs")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestTableOnlyProviders(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: true,
+		ShowInputs:    false,
+		ShowOutputs:   false,
+	}
+
+	module, expected, err := testutil.GetExpected("table-OnlyProviders")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestTableOnlyInputs(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: false,
+		ShowInputs:    true,
+		ShowOutputs:   false,
+	}
+
+	module, expected, err := testutil.GetExpected("table-OnlyInputs")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestTableOnlyOutputs(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: false,
+		ShowInputs:    false,
+		ShowOutputs:   true,
+	}
+
+	module, expected, err := testutil.GetExpected("table-OnlyOutputs")
 	assert.Nil(err)
 
 	actual, err := Print(module, settings)
@@ -71,6 +186,9 @@ func TestTableEscapeMarkdown(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		EscapeMarkdown: true,
+		ShowProviders:  true,
+		ShowInputs:     true,
+		ShowOutputs:    true,
 	}
 
 	module, expected, err := testutil.GetExpected("table-EscapeMarkdown")
@@ -86,6 +204,9 @@ func TestTableIndentationBellowAllowed(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		MarkdownIndent: 0,
+		ShowProviders:  true,
+		ShowInputs:     true,
+		ShowOutputs:    true,
 	}
 
 	module, expected, err := testutil.GetExpected("table-IndentationBellowAllowed")
@@ -101,6 +222,9 @@ func TestTableIndentationAboveAllowed(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		MarkdownIndent: 10,
+		ShowProviders:  true,
+		ShowInputs:     true,
+		ShowOutputs:    true,
 	}
 
 	module, expected, err := testutil.GetExpected("table-IndentationAboveAllowed")
@@ -116,6 +240,9 @@ func TestTableIndentationOfFour(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		MarkdownIndent: 4,
+		ShowProviders:  true,
+		ShowInputs:     true,
+		ShowOutputs:    true,
 	}
 
 	module, expected, err := testutil.GetExpected("table-IndentationOfFour")

--- a/internal/pkg/print/markdown/table/testdata/table-NoInputs.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoInputs.golden
@@ -1,0 +1,17 @@
+## Providers
+
+| Name | Version |
+|------|---------|
+| tls | n/a |
+| aws | >= 2.15.0 |
+| aws.ident | >= 2.15.0 |
+| null | n/a |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| unquoted | It's unquoted output. |
+| output-2 | It's output number two. |
+| output-1 | n/a |
+| output-0.12 | terraform 0.12 only |

--- a/internal/pkg/print/markdown/table/testdata/table-NoOutputs.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoOutputs.golden
@@ -1,0 +1,27 @@
+## Providers
+
+| Name | Version |
+|------|---------|
+| tls | n/a |
+| aws | >= 2.15.0 |
+| aws.ident | >= 2.15.0 |
+| null | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| unquoted | n/a | `any` | n/a |
+| string-3 | n/a | `string` | `""` |
+| string-2 | It's string number two. | `string` | n/a |
+| string-1 | n/a | `string` | `"bar"` |
+| map-3 | n/a | `map` | `{}` |
+| map-2 | It's map number two. | `map` | n/a |
+| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| list-3 | n/a | `list` | `[]` |
+| list-2 | It's list number two. | `list` | n/a |
+| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| input_with_underscores | n/a | `any` | n/a |
+| input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |

--- a/internal/pkg/print/markdown/table/testdata/table-NoProviders.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoProviders.golden
@@ -1,0 +1,27 @@
+## Inputs
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| unquoted | n/a | `any` | n/a |
+| string-3 | n/a | `string` | `""` |
+| string-2 | It's string number two. | `string` | n/a |
+| string-1 | n/a | `string` | `"bar"` |
+| map-3 | n/a | `map` | `{}` |
+| map-2 | It's map number two. | `map` | n/a |
+| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| list-3 | n/a | `list` | `[]` |
+| list-2 | It's list number two. | `list` | n/a |
+| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| input_with_underscores | n/a | `any` | n/a |
+| input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| unquoted | It's unquoted output. |
+| output-2 | It's output number two. |
+| output-1 | n/a |
+| output-0.12 | terraform 0.12 only |

--- a/internal/pkg/print/markdown/table/testdata/table-OnlyInputs.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-OnlyInputs.golden
@@ -1,0 +1,18 @@
+## Inputs
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| unquoted | n/a | `any` | n/a |
+| string-3 | n/a | `string` | `""` |
+| string-2 | It's string number two. | `string` | n/a |
+| string-1 | n/a | `string` | `"bar"` |
+| map-3 | n/a | `map` | `{}` |
+| map-2 | It's map number two. | `map` | n/a |
+| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| list-3 | n/a | `list` | `[]` |
+| list-2 | It's list number two. | `list` | n/a |
+| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| input_with_underscores | n/a | `any` | n/a |
+| input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |

--- a/internal/pkg/print/markdown/table/testdata/table-OnlyOutputs.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-OnlyOutputs.golden
@@ -1,0 +1,8 @@
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| unquoted | It's unquoted output. |
+| output-2 | It's output number two. |
+| output-1 | n/a |
+| output-0.12 | terraform 0.12 only |

--- a/internal/pkg/print/markdown/table/testdata/table-OnlyProviders.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-OnlyProviders.golden
@@ -1,0 +1,8 @@
+## Providers
+
+| Name | Version |
+|------|---------|
+| tls | n/a |
+| aws | >= 2.15.0 |
+| aws.ident | >= 2.15.0 |
+| null | n/a |

--- a/internal/pkg/print/pretty/pretty.go
+++ b/internal/pkg/print/pretty/pretty.go
@@ -15,9 +15,15 @@ func Print(module *tfconf.Module, settings *print.Settings) (string, error) {
 
 	module.Sort(settings)
 
-	printProviders(&buffer, module.Providers, settings)
-	printInputs(&buffer, module.Inputs, settings)
-	printOutputs(&buffer, module.Outputs, settings)
+	if settings.ShowProviders {
+		printProviders(&buffer, module.Providers, settings)
+	}
+	if settings.ShowInputs {
+		printInputs(&buffer, module.Inputs, settings)
+	}
+	if settings.ShowOutputs {
+		printOutputs(&buffer, module.Outputs, settings)
+	}
 
 	return buffer.String(), nil
 }
@@ -68,11 +74,10 @@ func printProviders(buffer *bytes.Buffer, providers []*tfconf.Provider, settings
 			),
 		)
 	}
-	buffer.WriteString("\n")
 }
 
 func printInputs(buffer *bytes.Buffer, inputs []*tfconf.Input, settings *print.Settings) {
-	buffer.WriteString("\n")
+	buffer.WriteString("\n\n")
 
 	for _, input := range inputs {
 		var format string
@@ -90,12 +95,10 @@ func printInputs(buffer *bytes.Buffer, inputs []*tfconf.Input, settings *print.S
 			),
 		)
 	}
-
-	buffer.WriteString("\n")
 }
 
 func printOutputs(buffer *bytes.Buffer, outputs []*tfconf.Output, settings *print.Settings) {
-	buffer.WriteString("\n")
+	buffer.WriteString("\n\n")
 
 	for _, output := range outputs {
 		var format string

--- a/internal/pkg/print/pretty/pretty_test.go
+++ b/internal/pkg/print/pretty/pretty_test.go
@@ -11,7 +11,10 @@ import (
 func TestPretty(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
-		ShowColor: true,
+		ShowProviders: true,
+		ShowInputs:    true,
+		ShowOutputs:   true,
+		ShowColor:     true,
 	}
 
 	module, expected, err := testutil.GetExpected("pretty")
@@ -26,8 +29,11 @@ func TestPretty(t *testing.T) {
 func TestPrettySortByName(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
-		SortByName: true,
-		ShowColor:  true,
+		SortByName:    true,
+		ShowProviders: true,
+		ShowInputs:    true,
+		ShowOutputs:   true,
+		ShowColor:     true,
 	}
 
 	module, expected, err := testutil.GetExpected("pretty-SortByName")
@@ -44,6 +50,9 @@ func TestPrettySortByRequired(t *testing.T) {
 	settings := &print.Settings{
 		SortByName:           true,
 		SortInputsByRequired: true,
+		ShowProviders:        true,
+		ShowInputs:           true,
+		ShowOutputs:          true,
 		ShowColor:            true,
 	}
 
@@ -56,10 +65,121 @@ func TestPrettySortByRequired(t *testing.T) {
 	assert.Equal(expected, actual)
 }
 
+func TestPrettyNoProviders(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: false,
+		ShowInputs:    true,
+		ShowOutputs:   true,
+		ShowColor:     true,
+	}
+
+	module, expected, err := testutil.GetExpected("pretty-NoProviders")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestPrettyNoInputs(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: true,
+		ShowInputs:    false,
+		ShowOutputs:   true,
+		ShowColor:     true,
+	}
+
+	module, expected, err := testutil.GetExpected("pretty-NoInputs")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestPrettyNoOutputs(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: true,
+		ShowInputs:    true,
+		ShowOutputs:   false,
+		ShowColor:     true,
+	}
+
+	module, expected, err := testutil.GetExpected("pretty-NoOutputs")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestPrettyOnlyProviders(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: true,
+		ShowInputs:    false,
+		ShowOutputs:   false,
+		ShowColor:     true,
+	}
+
+	module, expected, err := testutil.GetExpected("pretty-OnlyProviders")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestPrettyOnlyInputs(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: false,
+		ShowInputs:    true,
+		ShowOutputs:   false,
+		ShowColor:     true,
+	}
+
+	module, expected, err := testutil.GetExpected("pretty-OnlyInputs")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestPrettyOnlyOutputs(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: false,
+		ShowInputs:    false,
+		ShowOutputs:   true,
+		ShowColor:     true,
+	}
+
+	module, expected, err := testutil.GetExpected("pretty-OnlyOutputs")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
 func TestPrettyNoColor(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
-		ShowColor: false,
+		ShowProviders: true,
+		ShowInputs:    true,
+		ShowOutputs:   true,
+		ShowColor:     false,
 	}
 
 	module, expected, err := testutil.GetExpected("pretty-NoColor")

--- a/internal/pkg/print/pretty/testdata/pretty-NoInputs.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoInputs.golden
@@ -1,0 +1,24 @@
+
+
+[36mprovider.tls[0m
+
+[36mprovider.aws[0m (>= 2.15.0)
+
+[36mprovider.aws.ident[0m (>= 2.15.0)
+
+[36mprovider.null[0m
+
+
+
+[36moutput.unquoted[0m
+[90mIt's unquoted output.[0m
+
+[36moutput.output-2[0m
+[90mIt's output number two.[0m
+
+[36moutput.output-1[0m
+[90mn/a[0m
+
+[36moutput.output-0.12[0m
+[90mterraform 0.12 only[0m
+

--- a/internal/pkg/print/pretty/testdata/pretty-NoOutputs.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoOutputs.golden
@@ -1,0 +1,87 @@
+
+
+[36mprovider.tls[0m
+
+[36mprovider.aws[0m (>= 2.15.0)
+
+[36mprovider.aws.ident[0m (>= 2.15.0)
+
+[36mprovider.null[0m
+
+
+
+[36minput.unquoted[0m (required)
+[90mn/a[0m
+
+[36minput.string-3[0m ("")
+[90mn/a[0m
+
+[36minput.string-2[0m (required)
+[90mIt's string number two.[0m
+
+[36minput.string-1[0m ("bar")
+[90mn/a[0m
+
+[36minput.map-3[0m ({})
+[90mn/a[0m
+
+[36minput.map-2[0m (required)
+[90mIt's map number two.[0m
+
+[36minput.map-1[0m ({
+  "a": 1,
+  "b": 2,
+  "c": 3
+})
+[90mn/a[0m
+
+[36minput.list-3[0m ([])
+[90mn/a[0m
+
+[36minput.list-2[0m (required)
+[90mIt's list number two.[0m
+
+[36minput.list-1[0m ([
+  "a",
+  "b",
+  "c"
+])
+[90mn/a[0m
+
+[36minput.input_with_underscores[0m (required)
+[90mn/a[0m
+
+[36minput.input-with-pipe[0m ("v1")
+[90mIt includes v1 | v2 | v3[0m
+
+[36minput.input-with-code-block[0m ([
+  "name rack:location"
+])
+[90mThis is a complicated one. We need a newline.  
+And an example in a code block
+```
+default     = [
+  "machine rack01:neptune"
+]
+```[0m
+
+[36minput.long_type[0m ({
+  "bar": {
+    "bar": "bar",
+    "foo": "bar"
+  },
+  "buzz": [
+    "fizz",
+    "buzz"
+  ],
+  "fizz": [],
+  "foo": {
+    "bar": "foo",
+    "foo": "foo"
+  },
+  "name": "hello"
+})
+[90mThis description is itself markdown.
+
+It spans over multiple lines.[0m
+

--- a/internal/pkg/print/pretty/testdata/pretty-NoProviders.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoProviders.golden
@@ -1,0 +1,91 @@
+
+
+[36minput.unquoted[0m (required)
+[90mn/a[0m
+
+[36minput.string-3[0m ("")
+[90mn/a[0m
+
+[36minput.string-2[0m (required)
+[90mIt's string number two.[0m
+
+[36minput.string-1[0m ("bar")
+[90mn/a[0m
+
+[36minput.map-3[0m ({})
+[90mn/a[0m
+
+[36minput.map-2[0m (required)
+[90mIt's map number two.[0m
+
+[36minput.map-1[0m ({
+  "a": 1,
+  "b": 2,
+  "c": 3
+})
+[90mn/a[0m
+
+[36minput.list-3[0m ([])
+[90mn/a[0m
+
+[36minput.list-2[0m (required)
+[90mIt's list number two.[0m
+
+[36minput.list-1[0m ([
+  "a",
+  "b",
+  "c"
+])
+[90mn/a[0m
+
+[36minput.input_with_underscores[0m (required)
+[90mn/a[0m
+
+[36minput.input-with-pipe[0m ("v1")
+[90mIt includes v1 | v2 | v3[0m
+
+[36minput.input-with-code-block[0m ([
+  "name rack:location"
+])
+[90mThis is a complicated one. We need a newline.  
+And an example in a code block
+```
+default     = [
+  "machine rack01:neptune"
+]
+```[0m
+
+[36minput.long_type[0m ({
+  "bar": {
+    "bar": "bar",
+    "foo": "bar"
+  },
+  "buzz": [
+    "fizz",
+    "buzz"
+  ],
+  "fizz": [],
+  "foo": {
+    "bar": "foo",
+    "foo": "foo"
+  },
+  "name": "hello"
+})
+[90mThis description is itself markdown.
+
+It spans over multiple lines.[0m
+
+
+
+[36moutput.unquoted[0m
+[90mIt's unquoted output.[0m
+
+[36moutput.output-2[0m
+[90mIt's output number two.[0m
+
+[36moutput.output-1[0m
+[90mn/a[0m
+
+[36moutput.output-0.12[0m
+[90mterraform 0.12 only[0m
+

--- a/internal/pkg/print/pretty/testdata/pretty-OnlyInputs.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-OnlyInputs.golden
@@ -1,0 +1,77 @@
+
+
+[36minput.unquoted[0m (required)
+[90mn/a[0m
+
+[36minput.string-3[0m ("")
+[90mn/a[0m
+
+[36minput.string-2[0m (required)
+[90mIt's string number two.[0m
+
+[36minput.string-1[0m ("bar")
+[90mn/a[0m
+
+[36minput.map-3[0m ({})
+[90mn/a[0m
+
+[36minput.map-2[0m (required)
+[90mIt's map number two.[0m
+
+[36minput.map-1[0m ({
+  "a": 1,
+  "b": 2,
+  "c": 3
+})
+[90mn/a[0m
+
+[36minput.list-3[0m ([])
+[90mn/a[0m
+
+[36minput.list-2[0m (required)
+[90mIt's list number two.[0m
+
+[36minput.list-1[0m ([
+  "a",
+  "b",
+  "c"
+])
+[90mn/a[0m
+
+[36minput.input_with_underscores[0m (required)
+[90mn/a[0m
+
+[36minput.input-with-pipe[0m ("v1")
+[90mIt includes v1 | v2 | v3[0m
+
+[36minput.input-with-code-block[0m ([
+  "name rack:location"
+])
+[90mThis is a complicated one. We need a newline.  
+And an example in a code block
+```
+default     = [
+  "machine rack01:neptune"
+]
+```[0m
+
+[36minput.long_type[0m ({
+  "bar": {
+    "bar": "bar",
+    "foo": "bar"
+  },
+  "buzz": [
+    "fizz",
+    "buzz"
+  ],
+  "fizz": [],
+  "foo": {
+    "bar": "foo",
+    "foo": "foo"
+  },
+  "name": "hello"
+})
+[90mThis description is itself markdown.
+
+It spans over multiple lines.[0m
+

--- a/internal/pkg/print/pretty/testdata/pretty-OnlyOutputs.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-OnlyOutputs.golden
@@ -1,0 +1,14 @@
+
+
+[36moutput.unquoted[0m
+[90mIt's unquoted output.[0m
+
+[36moutput.output-2[0m
+[90mIt's output number two.[0m
+
+[36moutput.output-1[0m
+[90mn/a[0m
+
+[36moutput.output-0.12[0m
+[90mterraform 0.12 only[0m
+

--- a/internal/pkg/print/pretty/testdata/pretty-OnlyProviders.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-OnlyProviders.golden
@@ -1,0 +1,10 @@
+
+
+[36mprovider.tls[0m
+
+[36mprovider.aws[0m (>= 2.15.0)
+
+[36mprovider.aws.ident[0m (>= 2.15.0)
+
+[36mprovider.null[0m
+

--- a/internal/pkg/print/settings.go
+++ b/internal/pkg/print/settings.go
@@ -14,13 +14,25 @@ type Settings struct {
 	// scope: Markdown
 	MarkdownIndent int
 
-	// ShowRequired show "Required" column when generating Markdown (default: true)
-	// scope: Markdown
-	ShowRequired bool
-
 	// ShowColor print "colorized" version of result in the terminal (default: true)
 	// scope: Pretty
 	ShowColor bool
+
+	// ShowInputs show "Inputs" information (default: true)
+	// scope: Global
+	ShowInputs bool
+
+	// ShowOutputs show "Outputs" information (default: true)
+	// scope: Global
+	ShowOutputs bool
+
+	// ShowProviders show "Providers" information (default: true)
+	// scope: Global
+	ShowProviders bool
+
+	// ShowRequired show "Required" column when generating Markdown (default: true)
+	// scope: Markdown
+	ShowRequired bool
 
 	// SortByName sorted rendering of inputs and outputs (default: true)
 	// scope: Global
@@ -38,6 +50,9 @@ func NewSettings() *Settings {
 		EscapeMarkdown:        true,
 		MarkdownIndent:        2,
 		ShowColor:             true,
+		ShowInputs:            true,
+		ShowOutputs:           true,
+		ShowProviders:         true,
 		ShowRequired:          true,
 		SortByName:            true,
 		SortInputsByRequired:  false,


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

#140 added supports of showing Providers information, that is a slight breaking change, and as such this PR adds new flags to not show specific sections of the result if users choose to do so. The newly added flags are:

- `--no-providers`: do not show providers information
- `--no-inputs`: do not show inputs information
- `--no-outputs`: do not show outputs information

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [x] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
