### PR TITLE
Mark '--with-aggregate-type-defaults' as deprecated

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -47,7 +47,7 @@ func init() {
 
 	rootCmd.PersistentFlags().BoolVar(new(bool), "no-sort", false, "omit sorted rendering of inputs and outputs")
 	rootCmd.PersistentFlags().BoolVar(&settings.SortInputsByRequired, "sort-inputs-by-required", false, "sort inputs by name and prints required inputs first")
-	rootCmd.PersistentFlags().BoolVar(&settings.AggregateTypeDefaults, "with-aggregate-type-defaults", false, "print default values of aggregate types")
+	rootCmd.PersistentFlags().BoolVar(new(bool), "with-aggregate-type-defaults", false, "[deprecated] print default values of aggregate types")
 
 	markdownCmd.PersistentFlags().BoolVar(new(bool), "no-required", false, "omit \"Required\" column when generating Markdown")
 	markdownCmd.PersistentFlags().BoolVar(new(bool), "no-escape", false, "do not escape special characters")

--- a/internal/pkg/print/settings.go
+++ b/internal/pkg/print/settings.go
@@ -2,10 +2,6 @@ package print
 
 // Settings represents all settings
 type Settings struct {
-	// AggregateTypeDefaults print default values of aggregate types (default: false)
-	// scope: Global
-	AggregateTypeDefaults bool
-
 	// EscapeCharacters escapes special characters (such as | _ * in Markdown and > < in JSON) (default: true)
 	// scope: Markdown
 	EscapeCharacters bool
@@ -46,15 +42,14 @@ type Settings struct {
 //NewSettings returns new instance of Settings
 func NewSettings() *Settings {
 	return &Settings{
-		AggregateTypeDefaults: false,
-		EscapeCharacters:      true,
-		MarkdownIndent:        2,
-		ShowColor:             true,
-		ShowInputs:            true,
-		ShowOutputs:           true,
-		ShowProviders:         true,
-		ShowRequired:          true,
-		SortByName:            true,
-		SortInputsByRequired:  false,
+		EscapeCharacters:     true,
+		MarkdownIndent:       2,
+		ShowColor:            true,
+		ShowInputs:           true,
+		ShowOutputs:          true,
+		ShowProviders:        true,
+		ShowRequired:         true,
+		SortByName:           true,
+		SortInputsByRequired: false,
 	}
 }


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [x] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

As of Terraform 0.12, the default value of input variables are shown in full JSON format (if available) and `--with-aggregate-type-defaults` is not needed anymore. The flag is marked as soft deprecated and will get removed in the second release from now.

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [ ] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
