### PR TITLE
Rename flag to '--sort-by-required'

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,8 +46,14 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(new(bool), "no-outputs", false, "do not show outputs information")
 
 	rootCmd.PersistentFlags().BoolVar(new(bool), "no-sort", false, "omit sorted rendering of inputs and outputs")
-	rootCmd.PersistentFlags().BoolVar(&settings.SortInputsByRequired, "sort-inputs-by-required", false, "sort inputs by name and prints required inputs first")
+	rootCmd.PersistentFlags().BoolVar(&settings.SortByRequired, "sort-by-required", false, "sort items by name and print required ones first")
+
+	//-----------------------------
+	// deprecated - will be removed
+	//-----------------------------
+	rootCmd.PersistentFlags().BoolVar(&settings.SortByRequired, "sort-inputs-by-required", false, "[deprecated] use '--sort-by-required' instead")
 	rootCmd.PersistentFlags().BoolVar(new(bool), "with-aggregate-type-defaults", false, "[deprecated] print default values of aggregate types")
+	//-----------------------------
 
 	markdownCmd.PersistentFlags().BoolVar(new(bool), "no-required", false, "omit \"Required\" column when generating Markdown")
 	markdownCmd.PersistentFlags().BoolVar(new(bool), "no-escape", false, "do not escape special characters")

--- a/internal/pkg/print/json/json_test.go
+++ b/internal/pkg/print/json/json_test.go
@@ -46,11 +46,11 @@ func TestJsonSortByName(t *testing.T) {
 func TestJsonSortByRequired(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
-		SortByName:           true,
-		SortInputsByRequired: true,
-		ShowProviders:        true,
-		ShowInputs:           true,
-		ShowOutputs:          true,
+		SortByName:     true,
+		SortByRequired: true,
+		ShowProviders:  true,
+		ShowInputs:     true,
+		ShowOutputs:    true,
 	}
 
 	module, expected, err := testutil.GetExpected("json-SortByRequired")

--- a/internal/pkg/print/markdown/document/document_test.go
+++ b/internal/pkg/print/markdown/document/document_test.go
@@ -64,11 +64,11 @@ func TestDocumentSortByName(t *testing.T) {
 func TestDocumentSortByRequired(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
-		SortByName:           true,
-		SortInputsByRequired: true,
-		ShowProviders:        true,
-		ShowInputs:           true,
-		ShowOutputs:          true,
+		SortByName:     true,
+		SortByRequired: true,
+		ShowProviders:  true,
+		ShowInputs:     true,
+		ShowOutputs:    true,
 	}
 
 	module, expected, err := testutil.GetExpected("document-SortByRequired")

--- a/internal/pkg/print/markdown/table/table_test.go
+++ b/internal/pkg/print/markdown/table/table_test.go
@@ -64,11 +64,11 @@ func TestTableSortByName(t *testing.T) {
 func TestTableSortByRequired(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
-		SortByName:           true,
-		SortInputsByRequired: true,
-		ShowProviders:        true,
-		ShowInputs:           true,
-		ShowOutputs:          true,
+		SortByName:     true,
+		SortByRequired: true,
+		ShowProviders:  true,
+		ShowInputs:     true,
+		ShowOutputs:    true,
 	}
 
 	module, expected, err := testutil.GetExpected("table-SortByRequired")

--- a/internal/pkg/print/pretty/pretty_test.go
+++ b/internal/pkg/print/pretty/pretty_test.go
@@ -48,12 +48,12 @@ func TestPrettySortByName(t *testing.T) {
 func TestPrettySortByRequired(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
-		SortByName:           true,
-		SortInputsByRequired: true,
-		ShowProviders:        true,
-		ShowInputs:           true,
-		ShowOutputs:          true,
-		ShowColor:            true,
+		SortByName:     true,
+		SortByRequired: true,
+		ShowProviders:  true,
+		ShowInputs:     true,
+		ShowOutputs:    true,
+		ShowColor:      true,
 	}
 
 	module, expected, err := testutil.GetExpected("pretty-SortByRequired")

--- a/internal/pkg/print/settings.go
+++ b/internal/pkg/print/settings.go
@@ -34,22 +34,22 @@ type Settings struct {
 	// scope: Global
 	SortByName bool
 
-	// SortInputsByRequired sort inputs by name and prints required inputs first (default: false)
+	// SortByRequired sort items (inputs, providers) by name and prints required ones first (default: false)
 	// scope: Global
-	SortInputsByRequired bool
+	SortByRequired bool
 }
 
 //NewSettings returns new instance of Settings
 func NewSettings() *Settings {
 	return &Settings{
-		EscapeCharacters:     true,
-		MarkdownIndent:       2,
-		ShowColor:            true,
-		ShowInputs:           true,
-		ShowOutputs:          true,
-		ShowProviders:        true,
-		ShowRequired:         true,
-		SortByName:           true,
-		SortInputsByRequired: false,
+		EscapeCharacters: true,
+		MarkdownIndent:   2,
+		ShowColor:        true,
+		ShowInputs:       true,
+		ShowOutputs:      true,
+		ShowProviders:    true,
+		ShowRequired:     true,
+		SortByName:       true,
+		SortByRequired:   false,
 	}
 }

--- a/internal/pkg/tfconf/module.go
+++ b/internal/pkg/tfconf/module.go
@@ -39,7 +39,7 @@ func (m *Module) Sort(settings *print.Settings) {
 	}
 
 	if settings.SortByName {
-		if settings.SortInputsByRequired {
+		if settings.SortByRequired {
 			sort.Sort(inputsSortedByRequired(m.Inputs))
 			sort.Sort(inputsSortedByRequired(m.RequiredInputs))
 			sort.Sort(inputsSortedByRequired(m.OptionalInputs))


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [x] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

For simplicity we've decided to deprecated the old `--sort-inputs-by-required` flag to the simpler and more generic `--sort--by-required`. The deprecated flags will get removed second release from now.

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [ ] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
