### PR TITLE
Read leading comment lines if description is not provided

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -3,12 +3,15 @@ resource "tls_private_key" "baz" {}
 data "aws_caller_identity" "current" {
   provider = "aws"
 }
+
 data "aws_caller_identity" "ident" {
   provider = "aws.ident"
 }
+
 terraform {
   required_providers {
     aws = ">= 2.15.0"
   }
 }
+
 resource "null_resource" "foo" {}

--- a/internal/pkg/print/json/testdata/json-EscapeCharacters.golden
+++ b/internal/pkg/print/json/testdata/json-EscapeCharacters.golden
@@ -17,6 +17,7 @@
     {
       "name": "string-1",
       "type": "string",
+      "description": "It's string number one.",
       "default": "\"bar\""
     },
     {
@@ -32,6 +33,7 @@
     {
       "name": "map-1",
       "type": "map",
+      "description": "It's map number one.",
       "default": "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3\n}"
     },
     {
@@ -47,11 +49,13 @@
     {
       "name": "list-1",
       "type": "list",
+      "description": "It's list number one.",
       "default": "[\n  \"a\",\n  \"b\",\n  \"c\"\n]"
     },
     {
       "name": "input_with_underscores",
-      "type": "any"
+      "type": "any",
+      "description": "A variable with underscores."
     },
     {
       "name": "input-with-pipe",
@@ -82,7 +86,8 @@
       "description": "It's output number two."
     },
     {
-      "name": "output-1"
+      "name": "output-1",
+      "description": "It's output number one."
     },
     {
       "name": "output-0.12",

--- a/internal/pkg/print/json/testdata/json-NoInputs.golden
+++ b/internal/pkg/print/json/testdata/json-NoInputs.golden
@@ -10,7 +10,8 @@
       "description": "It's output number two."
     },
     {
-      "name": "output-1"
+      "name": "output-1",
+      "description": "It's output number one."
     },
     {
       "name": "output-0.12",

--- a/internal/pkg/print/json/testdata/json-NoOutputs.golden
+++ b/internal/pkg/print/json/testdata/json-NoOutputs.golden
@@ -17,6 +17,7 @@
     {
       "name": "string-1",
       "type": "string",
+      "description": "It's string number one.",
       "default": "\"bar\""
     },
     {
@@ -32,6 +33,7 @@
     {
       "name": "map-1",
       "type": "map",
+      "description": "It's map number one.",
       "default": "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3\n}"
     },
     {
@@ -47,11 +49,13 @@
     {
       "name": "list-1",
       "type": "list",
+      "description": "It's list number one.",
       "default": "[\n  \"a\",\n  \"b\",\n  \"c\"\n]"
     },
     {
       "name": "input_with_underscores",
-      "type": "any"
+      "type": "any",
+      "description": "A variable with underscores."
     },
     {
       "name": "input-with-pipe",

--- a/internal/pkg/print/json/testdata/json-NoProviders.golden
+++ b/internal/pkg/print/json/testdata/json-NoProviders.golden
@@ -17,6 +17,7 @@
     {
       "name": "string-1",
       "type": "string",
+      "description": "It's string number one.",
       "default": "\"bar\""
     },
     {
@@ -32,6 +33,7 @@
     {
       "name": "map-1",
       "type": "map",
+      "description": "It's map number one.",
       "default": "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3\n}"
     },
     {
@@ -47,11 +49,13 @@
     {
       "name": "list-1",
       "type": "list",
+      "description": "It's list number one.",
       "default": "[\n  \"a\",\n  \"b\",\n  \"c\"\n]"
     },
     {
       "name": "input_with_underscores",
-      "type": "any"
+      "type": "any",
+      "description": "A variable with underscores."
     },
     {
       "name": "input-with-pipe",
@@ -82,7 +86,8 @@
       "description": "It's output number two."
     },
     {
-      "name": "output-1"
+      "name": "output-1",
+      "description": "It's output number one."
     },
     {
       "name": "output-0.12",

--- a/internal/pkg/print/json/testdata/json-OnlyInputs.golden
+++ b/internal/pkg/print/json/testdata/json-OnlyInputs.golden
@@ -17,6 +17,7 @@
     {
       "name": "string-1",
       "type": "string",
+      "description": "It's string number one.",
       "default": "\"bar\""
     },
     {
@@ -32,6 +33,7 @@
     {
       "name": "map-1",
       "type": "map",
+      "description": "It's map number one.",
       "default": "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3\n}"
     },
     {
@@ -47,11 +49,13 @@
     {
       "name": "list-1",
       "type": "list",
+      "description": "It's list number one.",
       "default": "[\n  \"a\",\n  \"b\",\n  \"c\"\n]"
     },
     {
       "name": "input_with_underscores",
-      "type": "any"
+      "type": "any",
+      "description": "A variable with underscores."
     },
     {
       "name": "input-with-pipe",

--- a/internal/pkg/print/json/testdata/json-OnlyOutputs.golden
+++ b/internal/pkg/print/json/testdata/json-OnlyOutputs.golden
@@ -10,7 +10,8 @@
       "description": "It's output number two."
     },
     {
-      "name": "output-1"
+      "name": "output-1",
+      "description": "It's output number one."
     },
     {
       "name": "output-0.12",

--- a/internal/pkg/print/json/testdata/json-SortByName.golden
+++ b/internal/pkg/print/json/testdata/json-SortByName.golden
@@ -14,11 +14,13 @@
     },
     {
       "name": "input_with_underscores",
-      "type": "any"
+      "type": "any",
+      "description": "A variable with underscores."
     },
     {
       "name": "list-1",
       "type": "list",
+      "description": "It's list number one.",
       "default": "[\n  \"a\",\n  \"b\",\n  \"c\"\n]"
     },
     {
@@ -40,6 +42,7 @@
     {
       "name": "map-1",
       "type": "map",
+      "description": "It's map number one.",
       "default": "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3\n}"
     },
     {
@@ -55,6 +58,7 @@
     {
       "name": "string-1",
       "type": "string",
+      "description": "It's string number one.",
       "default": "\"bar\""
     },
     {
@@ -78,7 +82,8 @@
       "description": "terraform 0.12 only"
     },
     {
-      "name": "output-1"
+      "name": "output-1",
+      "description": "It's output number one."
     },
     {
       "name": "output-2",

--- a/internal/pkg/print/json/testdata/json-SortByRequired.golden
+++ b/internal/pkg/print/json/testdata/json-SortByRequired.golden
@@ -2,7 +2,8 @@
   "inputs": [
     {
       "name": "input_with_underscores",
-      "type": "any"
+      "type": "any",
+      "description": "A variable with underscores."
     },
     {
       "name": "list-2",
@@ -38,6 +39,7 @@
     {
       "name": "list-1",
       "type": "list",
+      "description": "It's list number one.",
       "default": "[\n  \"a\",\n  \"b\",\n  \"c\"\n]"
     },
     {
@@ -54,6 +56,7 @@
     {
       "name": "map-1",
       "type": "map",
+      "description": "It's map number one.",
       "default": "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3\n}"
     },
     {
@@ -64,6 +67,7 @@
     {
       "name": "string-1",
       "type": "string",
+      "description": "It's string number one.",
       "default": "\"bar\""
     },
     {
@@ -78,7 +82,8 @@
       "description": "terraform 0.12 only"
     },
     {
-      "name": "output-1"
+      "name": "output-1",
+      "description": "It's output number one."
     },
     {
       "name": "output-2",

--- a/internal/pkg/print/json/testdata/json.golden
+++ b/internal/pkg/print/json/testdata/json.golden
@@ -17,6 +17,7 @@
     {
       "name": "string-1",
       "type": "string",
+      "description": "It's string number one.",
       "default": "\"bar\""
     },
     {
@@ -32,6 +33,7 @@
     {
       "name": "map-1",
       "type": "map",
+      "description": "It's map number one.",
       "default": "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3\n}"
     },
     {
@@ -47,11 +49,13 @@
     {
       "name": "list-1",
       "type": "list",
+      "description": "It's list number one.",
       "default": "[\n  \"a\",\n  \"b\",\n  \"c\"\n]"
     },
     {
       "name": "input_with_underscores",
-      "type": "any"
+      "type": "any",
+      "description": "A variable with underscores."
     },
     {
       "name": "input-with-pipe",
@@ -82,7 +86,8 @@
       "description": "It's output number two."
     },
     {
-      "name": "output-1"
+      "name": "output-1",
+      "description": "It's output number one."
     },
     {
       "name": "output-0.12",

--- a/internal/pkg/print/markdown/document/testdata/document-EscapeCharacters.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-EscapeCharacters.golden
@@ -40,7 +40,7 @@ Default: n/a
 
 ### string-1
 
-Description: n/a
+Description: It's string number one.
 
 Type: `string`
 
@@ -64,7 +64,7 @@ Default: n/a
 
 ### map-1
 
-Description: n/a
+Description: It's map number one.
 
 Type: `map`
 
@@ -96,7 +96,7 @@ Default: n/a
 
 ### list-1
 
-Description: n/a
+Description: It's list number one.
 
 Type: `list`
 
@@ -112,7 +112,7 @@ Default:
 
 ### input\_with\_underscores
 
-Description: n/a
+Description: A variable with underscores.
 
 Type: `any`
 
@@ -199,7 +199,7 @@ Description: It's output number two.
 
 ### output-1
 
-Description: n/a
+Description: It's output number one.
 
 ### output-0.12
 

--- a/internal/pkg/print/markdown/document/testdata/document-IndentationAboveAllowed.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-IndentationAboveAllowed.golden
@@ -40,7 +40,7 @@ Default: n/a
 
 ### string-1
 
-Description: n/a
+Description: It's string number one.
 
 Type: `string`
 
@@ -64,7 +64,7 @@ Default: n/a
 
 ### map-1
 
-Description: n/a
+Description: It's map number one.
 
 Type: `map`
 
@@ -96,7 +96,7 @@ Default: n/a
 
 ### list-1
 
-Description: n/a
+Description: It's list number one.
 
 Type: `list`
 
@@ -112,7 +112,7 @@ Default:
 
 ### input_with_underscores
 
-Description: n/a
+Description: A variable with underscores.
 
 Type: `any`
 
@@ -199,7 +199,7 @@ Description: It's output number two.
 
 ### output-1
 
-Description: n/a
+Description: It's output number one.
 
 ### output-0.12
 

--- a/internal/pkg/print/markdown/document/testdata/document-IndentationBellowAllowed.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-IndentationBellowAllowed.golden
@@ -40,7 +40,7 @@ Default: n/a
 
 ### string-1
 
-Description: n/a
+Description: It's string number one.
 
 Type: `string`
 
@@ -64,7 +64,7 @@ Default: n/a
 
 ### map-1
 
-Description: n/a
+Description: It's map number one.
 
 Type: `map`
 
@@ -96,7 +96,7 @@ Default: n/a
 
 ### list-1
 
-Description: n/a
+Description: It's list number one.
 
 Type: `list`
 
@@ -112,7 +112,7 @@ Default:
 
 ### input_with_underscores
 
-Description: n/a
+Description: A variable with underscores.
 
 Type: `any`
 
@@ -199,7 +199,7 @@ Description: It's output number two.
 
 ### output-1
 
-Description: n/a
+Description: It's output number one.
 
 ### output-0.12
 

--- a/internal/pkg/print/markdown/document/testdata/document-IndentationOfFour.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-IndentationOfFour.golden
@@ -40,7 +40,7 @@ Default: n/a
 
 ##### string-1
 
-Description: n/a
+Description: It's string number one.
 
 Type: `string`
 
@@ -64,7 +64,7 @@ Default: n/a
 
 ##### map-1
 
-Description: n/a
+Description: It's map number one.
 
 Type: `map`
 
@@ -96,7 +96,7 @@ Default: n/a
 
 ##### list-1
 
-Description: n/a
+Description: It's list number one.
 
 Type: `list`
 
@@ -112,7 +112,7 @@ Default:
 
 ##### input_with_underscores
 
-Description: n/a
+Description: A variable with underscores.
 
 Type: `any`
 
@@ -199,7 +199,7 @@ Description: It's output number two.
 
 ##### output-1
 
-Description: n/a
+Description: It's output number one.
 
 ##### output-0.12
 

--- a/internal/pkg/print/markdown/document/testdata/document-NoInputs.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-NoInputs.golden
@@ -24,7 +24,7 @@ Description: It's output number two.
 
 ### output-1
 
-Description: n/a
+Description: It's output number one.
 
 ### output-0.12
 

--- a/internal/pkg/print/markdown/document/testdata/document-NoOutputs.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-NoOutputs.golden
@@ -40,7 +40,7 @@ Default: n/a
 
 ### string-1
 
-Description: n/a
+Description: It's string number one.
 
 Type: `string`
 
@@ -64,7 +64,7 @@ Default: n/a
 
 ### map-1
 
-Description: n/a
+Description: It's map number one.
 
 Type: `map`
 
@@ -96,7 +96,7 @@ Default: n/a
 
 ### list-1
 
-Description: n/a
+Description: It's list number one.
 
 Type: `list`
 
@@ -112,7 +112,7 @@ Default:
 
 ### input_with_underscores
 
-Description: n/a
+Description: A variable with underscores.
 
 Type: `any`
 

--- a/internal/pkg/print/markdown/document/testdata/document-NoProviders.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-NoProviders.golden
@@ -28,7 +28,7 @@ Default: n/a
 
 ### string-1
 
-Description: n/a
+Description: It's string number one.
 
 Type: `string`
 
@@ -52,7 +52,7 @@ Default: n/a
 
 ### map-1
 
-Description: n/a
+Description: It's map number one.
 
 Type: `map`
 
@@ -84,7 +84,7 @@ Default: n/a
 
 ### list-1
 
-Description: n/a
+Description: It's list number one.
 
 Type: `list`
 
@@ -100,7 +100,7 @@ Default:
 
 ### input_with_underscores
 
-Description: n/a
+Description: A variable with underscores.
 
 Type: `any`
 
@@ -187,7 +187,7 @@ Description: It's output number two.
 
 ### output-1
 
-Description: n/a
+Description: It's output number one.
 
 ### output-0.12
 

--- a/internal/pkg/print/markdown/document/testdata/document-OnlyInputs.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-OnlyInputs.golden
@@ -28,7 +28,7 @@ Default: n/a
 
 ### string-1
 
-Description: n/a
+Description: It's string number one.
 
 Type: `string`
 
@@ -52,7 +52,7 @@ Default: n/a
 
 ### map-1
 
-Description: n/a
+Description: It's map number one.
 
 Type: `map`
 
@@ -84,7 +84,7 @@ Default: n/a
 
 ### list-1
 
-Description: n/a
+Description: It's list number one.
 
 Type: `list`
 
@@ -100,7 +100,7 @@ Default:
 
 ### input_with_underscores
 
-Description: n/a
+Description: A variable with underscores.
 
 Type: `any`
 

--- a/internal/pkg/print/markdown/document/testdata/document-OnlyOutputs.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-OnlyOutputs.golden
@@ -12,7 +12,7 @@ Description: It's output number two.
 
 ### output-1
 
-Description: n/a
+Description: It's output number one.
 
 ### output-0.12
 

--- a/internal/pkg/print/markdown/document/testdata/document-SortByName.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-SortByName.golden
@@ -44,7 +44,7 @@ Default: `"v1"`
 
 ### input_with_underscores
 
-Description: n/a
+Description: A variable with underscores.
 
 Type: `any`
 
@@ -52,7 +52,7 @@ Default: n/a
 
 ### list-1
 
-Description: n/a
+Description: It's list number one.
 
 Type: `list`
 
@@ -123,7 +123,7 @@ Default:
 
 ### map-1
 
-Description: n/a
+Description: It's map number one.
 
 Type: `map`
 
@@ -155,7 +155,7 @@ Default: `{}`
 
 ### string-1
 
-Description: n/a
+Description: It's string number one.
 
 Type: `string`
 
@@ -195,7 +195,7 @@ Description: terraform 0.12 only
 
 ### output-1
 
-Description: n/a
+Description: It's output number one.
 
 ### output-2
 

--- a/internal/pkg/print/markdown/document/testdata/document-SortByRequired.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-SortByRequired.golden
@@ -16,7 +16,7 @@ The following input variables are supported:
 
 ### input_with_underscores
 
-Description: n/a
+Description: A variable with underscores.
 
 Type: `any`
 
@@ -84,7 +84,7 @@ Default: `"v1"`
 
 ### list-1
 
-Description: n/a
+Description: It's list number one.
 
 Type: `list`
 
@@ -147,7 +147,7 @@ Default:
 
 ### map-1
 
-Description: n/a
+Description: It's map number one.
 
 Type: `map`
 
@@ -171,7 +171,7 @@ Default: `{}`
 
 ### string-1
 
-Description: n/a
+Description: It's string number one.
 
 Type: `string`
 
@@ -195,7 +195,7 @@ Description: terraform 0.12 only
 
 ### output-1
 
-Description: n/a
+Description: It's output number one.
 
 ### output-2
 

--- a/internal/pkg/print/markdown/document/testdata/document-WithRequired.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-WithRequired.golden
@@ -40,7 +40,7 @@ Type: `list`
 
 ### input_with_underscores
 
-Description: n/a
+Description: A variable with underscores.
 
 Type: `any`
 
@@ -58,7 +58,7 @@ Default: `""`
 
 ### string-1
 
-Description: n/a
+Description: It's string number one.
 
 Type: `string`
 
@@ -74,7 +74,7 @@ Default: `{}`
 
 ### map-1
 
-Description: n/a
+Description: It's map number one.
 
 Type: `map`
 
@@ -98,7 +98,7 @@ Default: `[]`
 
 ### list-1
 
-Description: n/a
+Description: It's list number one.
 
 Type: `list`
 
@@ -193,7 +193,7 @@ Description: It's output number two.
 
 ### output-1
 
-Description: n/a
+Description: It's output number one.
 
 ### output-0.12
 

--- a/internal/pkg/print/markdown/document/testdata/document.golden
+++ b/internal/pkg/print/markdown/document/testdata/document.golden
@@ -40,7 +40,7 @@ Default: n/a
 
 ### string-1
 
-Description: n/a
+Description: It's string number one.
 
 Type: `string`
 
@@ -64,7 +64,7 @@ Default: n/a
 
 ### map-1
 
-Description: n/a
+Description: It's map number one.
 
 Type: `map`
 
@@ -96,7 +96,7 @@ Default: n/a
 
 ### list-1
 
-Description: n/a
+Description: It's list number one.
 
 Type: `list`
 
@@ -112,7 +112,7 @@ Default:
 
 ### input_with_underscores
 
-Description: n/a
+Description: A variable with underscores.
 
 Type: `any`
 
@@ -199,7 +199,7 @@ Description: It's output number two.
 
 ### output-1
 
-Description: n/a
+Description: It's output number one.
 
 ### output-0.12
 

--- a/internal/pkg/print/markdown/table/testdata/table-EscapeCharacters.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-EscapeCharacters.golden
@@ -14,14 +14,14 @@
 | unquoted | n/a | `any` | n/a |
 | string-3 | n/a | `string` | `""` |
 | string-2 | It's string number two. | `string` | n/a |
-| string-1 | n/a | `string` | `"bar"` |
+| string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| map-1 | It's map number one. | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
-| input\_with\_underscores | n/a | `any` | n/a |
+| list-1 | It's list number one. | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| input\_with\_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
 | input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
 | long\_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
@@ -32,5 +32,5 @@
 |------|-------------|
 | unquoted | It's unquoted output. |
 | output-2 | It's output number two. |
-| output-1 | n/a |
+| output-1 | It's output number one. |
 | output-0.12 | terraform 0.12 only |

--- a/internal/pkg/print/markdown/table/testdata/table-IndentationAboveAllowed.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-IndentationAboveAllowed.golden
@@ -14,14 +14,14 @@
 | unquoted | n/a | `any` | n/a |
 | string-3 | n/a | `string` | `""` |
 | string-2 | It's string number two. | `string` | n/a |
-| string-1 | n/a | `string` | `"bar"` |
+| string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| map-1 | It's map number one. | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
-| input_with_underscores | n/a | `any` | n/a |
+| list-1 | It's list number one. | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| input_with_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
 | input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
 | long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
@@ -32,5 +32,5 @@
 |------|-------------|
 | unquoted | It's unquoted output. |
 | output-2 | It's output number two. |
-| output-1 | n/a |
+| output-1 | It's output number one. |
 | output-0.12 | terraform 0.12 only |

--- a/internal/pkg/print/markdown/table/testdata/table-IndentationBellowAllowed.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-IndentationBellowAllowed.golden
@@ -14,14 +14,14 @@
 | unquoted | n/a | `any` | n/a |
 | string-3 | n/a | `string` | `""` |
 | string-2 | It's string number two. | `string` | n/a |
-| string-1 | n/a | `string` | `"bar"` |
+| string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| map-1 | It's map number one. | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
-| input_with_underscores | n/a | `any` | n/a |
+| list-1 | It's list number one. | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| input_with_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
 | input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
 | long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
@@ -32,5 +32,5 @@
 |------|-------------|
 | unquoted | It's unquoted output. |
 | output-2 | It's output number two. |
-| output-1 | n/a |
+| output-1 | It's output number one. |
 | output-0.12 | terraform 0.12 only |

--- a/internal/pkg/print/markdown/table/testdata/table-IndentationOfFour.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-IndentationOfFour.golden
@@ -14,14 +14,14 @@
 | unquoted | n/a | `any` | n/a |
 | string-3 | n/a | `string` | `""` |
 | string-2 | It's string number two. | `string` | n/a |
-| string-1 | n/a | `string` | `"bar"` |
+| string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| map-1 | It's map number one. | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
-| input_with_underscores | n/a | `any` | n/a |
+| list-1 | It's list number one. | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| input_with_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
 | input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
 | long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
@@ -32,5 +32,5 @@
 |------|-------------|
 | unquoted | It's unquoted output. |
 | output-2 | It's output number two. |
-| output-1 | n/a |
+| output-1 | It's output number one. |
 | output-0.12 | terraform 0.12 only |

--- a/internal/pkg/print/markdown/table/testdata/table-NoInputs.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoInputs.golden
@@ -13,5 +13,5 @@
 |------|-------------|
 | unquoted | It's unquoted output. |
 | output-2 | It's output number two. |
-| output-1 | n/a |
+| output-1 | It's output number one. |
 | output-0.12 | terraform 0.12 only |

--- a/internal/pkg/print/markdown/table/testdata/table-NoOutputs.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoOutputs.golden
@@ -14,14 +14,14 @@
 | unquoted | n/a | `any` | n/a |
 | string-3 | n/a | `string` | `""` |
 | string-2 | It's string number two. | `string` | n/a |
-| string-1 | n/a | `string` | `"bar"` |
+| string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| map-1 | It's map number one. | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
-| input_with_underscores | n/a | `any` | n/a |
+| list-1 | It's list number one. | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| input_with_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
 | input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
 | long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |

--- a/internal/pkg/print/markdown/table/testdata/table-NoProviders.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoProviders.golden
@@ -5,14 +5,14 @@
 | unquoted | n/a | `any` | n/a |
 | string-3 | n/a | `string` | `""` |
 | string-2 | It's string number two. | `string` | n/a |
-| string-1 | n/a | `string` | `"bar"` |
+| string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| map-1 | It's map number one. | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
-| input_with_underscores | n/a | `any` | n/a |
+| list-1 | It's list number one. | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| input_with_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
 | input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
 | long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
@@ -23,5 +23,5 @@
 |------|-------------|
 | unquoted | It's unquoted output. |
 | output-2 | It's output number two. |
-| output-1 | n/a |
+| output-1 | It's output number one. |
 | output-0.12 | terraform 0.12 only |

--- a/internal/pkg/print/markdown/table/testdata/table-OnlyInputs.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-OnlyInputs.golden
@@ -5,14 +5,14 @@
 | unquoted | n/a | `any` | n/a |
 | string-3 | n/a | `string` | `""` |
 | string-2 | It's string number two. | `string` | n/a |
-| string-1 | n/a | `string` | `"bar"` |
+| string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| map-1 | It's map number one. | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
-| input_with_underscores | n/a | `any` | n/a |
+| list-1 | It's list number one. | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| input_with_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
 | input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
 | long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |

--- a/internal/pkg/print/markdown/table/testdata/table-OnlyOutputs.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-OnlyOutputs.golden
@@ -4,5 +4,5 @@
 |------|-------------|
 | unquoted | It's unquoted output. |
 | output-2 | It's output number two. |
-| output-1 | n/a |
+| output-1 | It's output number one. |
 | output-0.12 | terraform 0.12 only |

--- a/internal/pkg/print/markdown/table/testdata/table-SortByName.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-SortByName.golden
@@ -13,15 +13,15 @@
 |------|-------------|------|---------|
 | input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| input_with_underscores | n/a | `any` | n/a |
-| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| input_with_underscores | A variable with underscores. | `any` | n/a |
+| list-1 | It's list number one. | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
 | list-2 | It's list number two. | `list` | n/a |
 | list-3 | n/a | `list` | `[]` |
 | long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
-| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| map-1 | It's map number one. | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
 | map-2 | It's map number two. | `map` | n/a |
 | map-3 | n/a | `map` | `{}` |
-| string-1 | n/a | `string` | `"bar"` |
+| string-1 | It's string number one. | `string` | `"bar"` |
 | string-2 | It's string number two. | `string` | n/a |
 | string-3 | n/a | `string` | `""` |
 | unquoted | n/a | `any` | n/a |
@@ -31,6 +31,6 @@
 | Name | Description |
 |------|-------------|
 | output-0.12 | terraform 0.12 only |
-| output-1 | n/a |
+| output-1 | It's output number one. |
 | output-2 | It's output number two. |
 | unquoted | It's unquoted output. |

--- a/internal/pkg/print/markdown/table/testdata/table-SortByRequired.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-SortByRequired.golden
@@ -11,19 +11,19 @@
 
 | Name | Description | Type | Default |
 |------|-------------|------|---------|
-| input_with_underscores | n/a | `any` | n/a |
+| input_with_underscores | A variable with underscores. | `any` | n/a |
 | list-2 | It's list number two. | `list` | n/a |
 | map-2 | It's map number two. | `map` | n/a |
 | string-2 | It's string number two. | `string` | n/a |
 | unquoted | n/a | `any` | n/a |
 | input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| list-1 | It's list number one. | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
 | list-3 | n/a | `list` | `[]` |
 | long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
-| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| map-1 | It's map number one. | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
 | map-3 | n/a | `map` | `{}` |
-| string-1 | n/a | `string` | `"bar"` |
+| string-1 | It's string number one. | `string` | `"bar"` |
 | string-3 | n/a | `string` | `""` |
 
 ## Outputs
@@ -31,6 +31,6 @@
 | Name | Description |
 |------|-------------|
 | output-0.12 | terraform 0.12 only |
-| output-1 | n/a |
+| output-1 | It's output number one. |
 | output-2 | It's output number two. |
 | unquoted | It's unquoted output. |

--- a/internal/pkg/print/markdown/table/testdata/table-WithRequired.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-WithRequired.golden
@@ -14,14 +14,14 @@
 | unquoted | n/a | `any` | n/a | yes |
 | string-3 | n/a | `string` | `""` | no |
 | string-2 | It's string number two. | `string` | n/a | yes |
-| string-1 | n/a | `string` | `"bar"` | no |
+| string-1 | It's string number one. | `string` | `"bar"` | no |
 | map-3 | n/a | `map` | `{}` | no |
 | map-2 | It's map number two. | `map` | n/a | yes |
-| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> | no |
+| map-1 | It's map number one. | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> | no |
 | list-3 | n/a | `list` | `[]` | no |
 | list-2 | It's list number two. | `list` | n/a | yes |
-| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> | no |
-| input_with_underscores | n/a | `any` | n/a | yes |
+| list-1 | It's list number one. | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> | no |
+| input_with_underscores | A variable with underscores. | `any` | n/a | yes |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` | no |
 | input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> | no |
 | long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> | no |
@@ -32,5 +32,5 @@
 |------|-------------|
 | unquoted | It's unquoted output. |
 | output-2 | It's output number two. |
-| output-1 | n/a |
+| output-1 | It's output number one. |
 | output-0.12 | terraform 0.12 only |

--- a/internal/pkg/print/markdown/table/testdata/table.golden
+++ b/internal/pkg/print/markdown/table/testdata/table.golden
@@ -14,14 +14,14 @@
 | unquoted | n/a | `any` | n/a |
 | string-3 | n/a | `string` | `""` |
 | string-2 | It's string number two. | `string` | n/a |
-| string-1 | n/a | `string` | `"bar"` |
+| string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | n/a | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| map-1 | It's map number one. | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | n/a | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
-| input_with_underscores | n/a | `any` | n/a |
+| list-1 | It's list number one. | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| input_with_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
 | input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
 | long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
@@ -32,5 +32,5 @@
 |------|-------------|
 | unquoted | It's unquoted output. |
 | output-2 | It's output number two. |
-| output-1 | n/a |
+| output-1 | It's output number one. |
 | output-0.12 | terraform 0.12 only |

--- a/internal/pkg/print/pretty/testdata/pretty-NoColor.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoColor.golden
@@ -20,7 +20,7 @@ input.string-2 (required)
 It's string number two.
 
 input.string-1 ("bar")
-n/a
+It's string number one.
 
 input.map-3 ({})
 n/a
@@ -33,7 +33,7 @@ input.map-1 ({
   "b": 2,
   "c": 3
 })
-n/a
+It's map number one.
 
 input.list-3 ([])
 n/a
@@ -46,10 +46,10 @@ input.list-1 ([
   "b",
   "c"
 ])
-n/a
+It's list number one.
 
 input.input_with_underscores (required)
-n/a
+A variable with underscores.
 
 input.input-with-pipe ("v1")
 It includes v1 | v2 | v3
@@ -94,7 +94,7 @@ output.output-2
 It's output number two.
 
 output.output-1
-n/a
+It's output number one.
 
 output.output-0.12
 terraform 0.12 only

--- a/internal/pkg/print/pretty/testdata/pretty-NoInputs.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoInputs.golden
@@ -17,7 +17,7 @@
 [90mIt's output number two.[0m
 
 [36moutput.output-1[0m
-[90mn/a[0m
+[90mIt's output number one.[0m
 
 [36moutput.output-0.12[0m
 [90mterraform 0.12 only[0m

--- a/internal/pkg/print/pretty/testdata/pretty-NoOutputs.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoOutputs.golden
@@ -20,7 +20,7 @@
 [90mIt's string number two.[0m
 
 [36minput.string-1[0m ("bar")
-[90mn/a[0m
+[90mIt's string number one.[0m
 
 [36minput.map-3[0m ({})
 [90mn/a[0m
@@ -33,7 +33,7 @@
   "b": 2,
   "c": 3
 })
-[90mn/a[0m
+[90mIt's map number one.[0m
 
 [36minput.list-3[0m ([])
 [90mn/a[0m
@@ -46,10 +46,10 @@
   "b",
   "c"
 ])
-[90mn/a[0m
+[90mIt's list number one.[0m
 
 [36minput.input_with_underscores[0m (required)
-[90mn/a[0m
+[90mA variable with underscores.[0m
 
 [36minput.input-with-pipe[0m ("v1")
 [90mIt includes v1 | v2 | v3[0m

--- a/internal/pkg/print/pretty/testdata/pretty-NoProviders.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoProviders.golden
@@ -10,7 +10,7 @@
 [90mIt's string number two.[0m
 
 [36minput.string-1[0m ("bar")
-[90mn/a[0m
+[90mIt's string number one.[0m
 
 [36minput.map-3[0m ({})
 [90mn/a[0m
@@ -23,7 +23,7 @@
   "b": 2,
   "c": 3
 })
-[90mn/a[0m
+[90mIt's map number one.[0m
 
 [36minput.list-3[0m ([])
 [90mn/a[0m
@@ -36,10 +36,10 @@
   "b",
   "c"
 ])
-[90mn/a[0m
+[90mIt's list number one.[0m
 
 [36minput.input_with_underscores[0m (required)
-[90mn/a[0m
+[90mA variable with underscores.[0m
 
 [36minput.input-with-pipe[0m ("v1")
 [90mIt includes v1 | v2 | v3[0m
@@ -84,7 +84,7 @@ It spans over multiple lines.[0m
 [90mIt's output number two.[0m
 
 [36moutput.output-1[0m
-[90mn/a[0m
+[90mIt's output number one.[0m
 
 [36moutput.output-0.12[0m
 [90mterraform 0.12 only[0m

--- a/internal/pkg/print/pretty/testdata/pretty-OnlyInputs.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-OnlyInputs.golden
@@ -10,7 +10,7 @@
 [90mIt's string number two.[0m
 
 [36minput.string-1[0m ("bar")
-[90mn/a[0m
+[90mIt's string number one.[0m
 
 [36minput.map-3[0m ({})
 [90mn/a[0m
@@ -23,7 +23,7 @@
   "b": 2,
   "c": 3
 })
-[90mn/a[0m
+[90mIt's map number one.[0m
 
 [36minput.list-3[0m ([])
 [90mn/a[0m
@@ -36,10 +36,10 @@
   "b",
   "c"
 ])
-[90mn/a[0m
+[90mIt's list number one.[0m
 
 [36minput.input_with_underscores[0m (required)
-[90mn/a[0m
+[90mA variable with underscores.[0m
 
 [36minput.input-with-pipe[0m ("v1")
 [90mIt includes v1 | v2 | v3[0m

--- a/internal/pkg/print/pretty/testdata/pretty-OnlyOutputs.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-OnlyOutputs.golden
@@ -7,7 +7,7 @@
 [90mIt's output number two.[0m
 
 [36moutput.output-1[0m
-[90mn/a[0m
+[90mIt's output number one.[0m
 
 [36moutput.output-0.12[0m
 [90mterraform 0.12 only[0m

--- a/internal/pkg/print/pretty/testdata/pretty-SortByName.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-SortByName.golden
@@ -25,14 +25,14 @@ default     = [
 [90mIt includes v1 | v2 | v3[0m
 
 [36minput.input_with_underscores[0m (required)
-[90mn/a[0m
+[90mA variable with underscores.[0m
 
 [36minput.list-1[0m ([
   "a",
   "b",
   "c"
 ])
-[90mn/a[0m
+[90mIt's list number one.[0m
 
 [36minput.list-2[0m (required)
 [90mIt's list number two.[0m
@@ -65,7 +65,7 @@ It spans over multiple lines.[0m
   "b": 2,
   "c": 3
 })
-[90mn/a[0m
+[90mIt's map number one.[0m
 
 [36minput.map-2[0m (required)
 [90mIt's map number two.[0m
@@ -74,7 +74,7 @@ It spans over multiple lines.[0m
 [90mn/a[0m
 
 [36minput.string-1[0m ("bar")
-[90mn/a[0m
+[90mIt's string number one.[0m
 
 [36minput.string-2[0m (required)
 [90mIt's string number two.[0m
@@ -91,7 +91,7 @@ It spans over multiple lines.[0m
 [90mterraform 0.12 only[0m
 
 [36moutput.output-1[0m
-[90mn/a[0m
+[90mIt's output number one.[0m
 
 [36moutput.output-2[0m
 [90mIt's output number two.[0m

--- a/internal/pkg/print/pretty/testdata/pretty-SortByRequired.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-SortByRequired.golden
@@ -11,7 +11,7 @@
 
 
 [36minput.input_with_underscores[0m (required)
-[90mn/a[0m
+[90mA variable with underscores.[0m
 
 [36minput.list-2[0m (required)
 [90mIt's list number two.[0m
@@ -44,7 +44,7 @@ default     = [
   "b",
   "c"
 ])
-[90mn/a[0m
+[90mIt's list number one.[0m
 
 [36minput.list-3[0m ([])
 [90mn/a[0m
@@ -74,13 +74,13 @@ It spans over multiple lines.[0m
   "b": 2,
   "c": 3
 })
-[90mn/a[0m
+[90mIt's map number one.[0m
 
 [36minput.map-3[0m ({})
 [90mn/a[0m
 
 [36minput.string-1[0m ("bar")
-[90mn/a[0m
+[90mIt's string number one.[0m
 
 [36minput.string-3[0m ("")
 [90mn/a[0m
@@ -91,7 +91,7 @@ It spans over multiple lines.[0m
 [90mterraform 0.12 only[0m
 
 [36moutput.output-1[0m
-[90mn/a[0m
+[90mIt's output number one.[0m
 
 [36moutput.output-2[0m
 [90mIt's output number two.[0m

--- a/internal/pkg/print/pretty/testdata/pretty.golden
+++ b/internal/pkg/print/pretty/testdata/pretty.golden
@@ -20,7 +20,7 @@
 [90mIt's string number two.[0m
 
 [36minput.string-1[0m ("bar")
-[90mn/a[0m
+[90mIt's string number one.[0m
 
 [36minput.map-3[0m ({})
 [90mn/a[0m
@@ -33,7 +33,7 @@
   "b": 2,
   "c": 3
 })
-[90mn/a[0m
+[90mIt's map number one.[0m
 
 [36minput.list-3[0m ([])
 [90mn/a[0m
@@ -46,10 +46,10 @@
   "b",
   "c"
 ])
-[90mn/a[0m
+[90mIt's list number one.[0m
 
 [36minput.input_with_underscores[0m (required)
-[90mn/a[0m
+[90mA variable with underscores.[0m
 
 [36minput.input-with-pipe[0m ("v1")
 [90mIt includes v1 | v2 | v3[0m
@@ -94,7 +94,7 @@ It spans over multiple lines.[0m
 [90mIt's output number two.[0m
 
 [36moutput.output-1[0m
-[90mn/a[0m
+[90mIt's output number one.[0m
 
 [36moutput.output-0.12[0m
 [90mterraform 0.12 only[0m

--- a/internal/pkg/tfconf/comment.go
+++ b/internal/pkg/tfconf/comment.go
@@ -1,0 +1,62 @@
+package tfconf
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+func readComment(filename string, lineNum int) string {
+	lines, err := readLines(filename, lineNum)
+	if err != nil {
+		return "" // absorb the error, we don't need to bubble it up or break the execution
+	}
+	return strings.Join(lines, " ")
+}
+
+// Reading leading comments, i.e. lines start with # or //
+// immediately before specific line number in given file
+func readLines(filename string, lineNum int) ([]string, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	bf := bufio.NewReader(f)
+	var lines = make([]string, 0)
+
+	for lnum := 0; lnum < lineNum; lnum++ {
+		line, err := bf.ReadString('\n')
+		if err == io.EOF {
+			switch lnum {
+			case 0:
+				return nil, errors.New("no lines in file")
+			case 1:
+				return nil, errors.New("only 1 line")
+			default:
+				return nil, fmt.Errorf("only %d lines", lnum)
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		if strings.HasPrefix(line, "#") || strings.HasPrefix(line, "//") {
+			line = strings.TrimSpace(line)
+			line = strings.TrimPrefix(line, "#")
+			line = strings.TrimPrefix(line, "//")
+			line = strings.TrimSpace(line)
+			lines = append(lines, line)
+		} else {
+			lines = nil
+		}
+	}
+
+	return lines, nil
+}

--- a/internal/pkg/tfconf/module.go
+++ b/internal/pkg/tfconf/module.go
@@ -100,10 +100,15 @@ func CreateModule(path string) (*Module, error) {
 			}
 		}
 
+		inputDescription := input.Description
+		if inputDescription == "" {
+			inputDescription = readComment(input.Pos.Filename, input.Pos.Line-1)
+		}
+
 		i := &Input{
 			Name:        input.Name,
 			Type:        inputType,
-			Description: input.Description,
+			Description: inputDescription,
 			Default:     defaultValue,
 			Position: Position{
 				Filename: input.Pos.Filename,
@@ -121,9 +126,13 @@ func CreateModule(path string) (*Module, error) {
 
 	var outputs = make([]*Output, 0, len(mod.Outputs))
 	for _, output := range mod.Outputs {
+		outputDescription := output.Description
+		if outputDescription == "" {
+			outputDescription = readComment(output.Pos.Filename, output.Pos.Line-1)
+		}
 		outputs = append(outputs, &Output{
 			Name:        output.Name,
-			Description: output.Description,
+			Description: outputDescription,
 			Position: Position{
 				Filename: output.Pos.Filename,
 				Line:     output.Pos.Line,


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [x] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

As part of preparing the support for Terraform 0.12 which has been discussed in length (https://github.com/segmentio/terraform-docs/issues/62#issuecomment-507069369, https://github.com/segmentio/terraform-docs/issues/62#issuecomment-507069369 and https://github.com/hashicorp/terraform-config-inspect/issues/21#issuecomment-525259471) we had decided to drop the support of extracting leading `variable` and `output` comments, but this PR is going to address them with minimal effort, which is internal to `terraform-docs` codebase and does not depend on Terraform community as a whole and `terraform-config-inspect` in particular.

### Issues Resolved

Partially addresses #109.

Supported comment formats are:

- multi-lines start with `#` comment format
- multi-lines start with `//` comment format

Unsupported comments formats is:

- jsdoc, c or java-like multi-line comment `/** **/`

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [ ] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
