### PR TITLE
Read leading module header from main.tf

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ var rootCmd = &cobra.Command{
 	Long:    "A utility to generate documentation from Terraform modules in various output formats",
 	Version: version.Version(),
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		noheader, _ := cmd.Flags().GetBool("no-header")
 		noproviders, _ := cmd.Flags().GetBool("no-providers")
 		noinputs, _ := cmd.Flags().GetBool("no-inputs")
 		nooutputs, _ := cmd.Flags().GetBool("no-outputs")
@@ -29,6 +30,7 @@ var rootCmd = &cobra.Command{
 		norequired, _ := cmd.Flags().GetBool("no-required")
 		noescape, _ := cmd.Flags().GetBool("no-escape")
 
+		settings.ShowHeader = !noheader
 		settings.ShowProviders = !noproviders
 		settings.ShowInputs = !noinputs
 		settings.ShowOutputs = !nooutputs
@@ -41,6 +43,7 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
+	rootCmd.PersistentFlags().BoolVar(new(bool), "no-header", false, "do not show module header")
 	rootCmd.PersistentFlags().BoolVar(new(bool), "no-providers", false, "do not show providers")
 	rootCmd.PersistentFlags().BoolVar(new(bool), "no-inputs", false, "do not show inputs")
 	rootCmd.PersistentFlags().BoolVar(new(bool), "no-outputs", false, "do not show outputs")

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,3 +1,22 @@
+/**
+ * Usage:
+ *
+ * module "foo" {
+ *   source = "github.com/foo/bar"
+ *
+ *   id   = "1234567890"
+ *   name = "baz"
+ *
+ *   zones = ["us-east-1", "us-west-1"]
+ *
+ *   tags = {
+ *     Name         = "baz"
+ *     Created-By   = "first.last@email.com"
+ *     Date-Created = "20180101"
+ *   }
+ * }
+ */
+
 resource "tls_private_key" "baz" {}
 
 data "aws_caller_identity" "current" {

--- a/internal/pkg/print/json/json.go
+++ b/internal/pkg/print/json/json.go
@@ -19,11 +19,15 @@ func Print(module *tfconf.Module, settings *print.Settings) (string, error) {
 	module.Sort(settings)
 
 	copy := &tfconf.Module{
+		Header:    "",
 		Providers: make([]*tfconf.Provider, 0),
 		Inputs:    make([]*tfconf.Input, 0),
 		Outputs:   make([]*tfconf.Output, 0),
 	}
 
+	if settings.ShowHeader {
+		copy.Header = module.Header
+	}
 	if settings.ShowProviders {
 		copy.Providers = module.Providers
 	}

--- a/internal/pkg/print/json/json_test.go
+++ b/internal/pkg/print/json/json_test.go
@@ -11,6 +11,7 @@ import (
 func TestJson(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
 		ShowOutputs:   true,
@@ -29,6 +30,7 @@ func TestJsonSortByName(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		SortByName:    true,
+		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
 		ShowOutputs:   true,
@@ -48,6 +50,7 @@ func TestJsonSortByRequired(t *testing.T) {
 	settings := &print.Settings{
 		SortByName:     true,
 		SortByRequired: true,
+		ShowHeader:     true,
 		ShowProviders:  true,
 		ShowInputs:     true,
 		ShowOutputs:    true,
@@ -62,9 +65,28 @@ func TestJsonSortByRequired(t *testing.T) {
 	assert.Equal(expected, actual)
 }
 
+func TestJsonNoHeader(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowHeader:    false,
+		ShowProviders: true,
+		ShowInputs:    true,
+		ShowOutputs:   true,
+	}
+
+	module, expected, err := testutil.GetExpected("json-NoHeader")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
 func TestJsonNoProviders(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    true,
 		ShowProviders: false,
 		ShowInputs:    true,
 		ShowOutputs:   true,
@@ -82,6 +104,7 @@ func TestJsonNoProviders(t *testing.T) {
 func TestJsonNoInputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    false,
 		ShowOutputs:   true,
@@ -99,6 +122,7 @@ func TestJsonNoInputs(t *testing.T) {
 func TestJsonNoOutputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
 		ShowOutputs:   false,
@@ -113,9 +137,28 @@ func TestJsonNoOutputs(t *testing.T) {
 	assert.Equal(expected, actual)
 }
 
+func TestJsonOnlyHeader(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowHeader:    true,
+		ShowProviders: false,
+		ShowInputs:    false,
+		ShowOutputs:   false,
+	}
+
+	module, expected, err := testutil.GetExpected("json-OnlyHeader")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
 func TestJsonOnlyProviders(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    false,
 		ShowProviders: true,
 		ShowInputs:    false,
 		ShowOutputs:   false,
@@ -133,6 +176,7 @@ func TestJsonOnlyProviders(t *testing.T) {
 func TestJsonOnlyInputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    false,
 		ShowProviders: false,
 		ShowInputs:    true,
 		ShowOutputs:   false,
@@ -150,6 +194,7 @@ func TestJsonOnlyInputs(t *testing.T) {
 func TestJsonOnlyOutputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    false,
 		ShowProviders: false,
 		ShowInputs:    false,
 		ShowOutputs:   true,
@@ -168,6 +213,7 @@ func TestJsonEscapeCharacters(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		EscapeCharacters: true,
+		ShowHeader:       true,
 		ShowProviders:    true,
 		ShowInputs:       true,
 		ShowOutputs:      true,

--- a/internal/pkg/print/json/testdata/json-NoHeader.golden
+++ b/internal/pkg/print/json/testdata/json-NoHeader.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nmodule \"foo\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}",
+  "header": "",
   "inputs": [
     {
       "name": "unquoted",
@@ -101,12 +101,12 @@
     },
     {
       "name": "aws",
-      "version": "\u003e= 2.15.0"
+      "version": ">= 2.15.0"
     },
     {
       "name": "aws",
       "alias": "ident",
-      "version": "\u003e= 2.15.0"
+      "version": ">= 2.15.0"
     },
     {
       "name": "null"

--- a/internal/pkg/print/json/testdata/json-NoInputs.golden
+++ b/internal/pkg/print/json/testdata/json-NoInputs.golden
@@ -1,4 +1,5 @@
 {
+  "header": "Usage:\n\nmodule \"foo\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}",
   "inputs": [],
   "outputs": [
     {

--- a/internal/pkg/print/json/testdata/json-NoOutputs.golden
+++ b/internal/pkg/print/json/testdata/json-NoOutputs.golden
@@ -1,4 +1,5 @@
 {
+  "header": "Usage:\n\nmodule \"foo\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}",
   "inputs": [
     {
       "name": "unquoted",

--- a/internal/pkg/print/json/testdata/json-NoProviders.golden
+++ b/internal/pkg/print/json/testdata/json-NoProviders.golden
@@ -1,4 +1,5 @@
 {
+  "header": "Usage:\n\nmodule \"foo\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}",
   "inputs": [
     {
       "name": "unquoted",

--- a/internal/pkg/print/json/testdata/json-OnlyHeader.golden
+++ b/internal/pkg/print/json/testdata/json-OnlyHeader.golden
@@ -1,0 +1,6 @@
+{
+  "header": "Usage:\n\nmodule \"foo\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}",
+  "inputs": [],
+  "outputs": [],
+  "providers": []
+}

--- a/internal/pkg/print/json/testdata/json-OnlyInputs.golden
+++ b/internal/pkg/print/json/testdata/json-OnlyInputs.golden
@@ -1,4 +1,5 @@
 {
+  "header": "",
   "inputs": [
     {
       "name": "unquoted",

--- a/internal/pkg/print/json/testdata/json-OnlyOutputs.golden
+++ b/internal/pkg/print/json/testdata/json-OnlyOutputs.golden
@@ -1,4 +1,5 @@
 {
+  "header": "",
   "inputs": [],
   "outputs": [
     {

--- a/internal/pkg/print/json/testdata/json-OnlyProviders.golden
+++ b/internal/pkg/print/json/testdata/json-OnlyProviders.golden
@@ -1,4 +1,5 @@
 {
+  "header": "",
   "inputs": [],
   "outputs": [],
   "providers": [

--- a/internal/pkg/print/json/testdata/json-SortByName.golden
+++ b/internal/pkg/print/json/testdata/json-SortByName.golden
@@ -1,4 +1,5 @@
 {
+  "header": "Usage:\n\nmodule \"foo\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}",
   "inputs": [
     {
       "name": "input-with-code-block",

--- a/internal/pkg/print/json/testdata/json-SortByRequired.golden
+++ b/internal/pkg/print/json/testdata/json-SortByRequired.golden
@@ -1,4 +1,5 @@
 {
+  "header": "Usage:\n\nmodule \"foo\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}",
   "inputs": [
     {
       "name": "input_with_underscores",

--- a/internal/pkg/print/json/testdata/json.golden
+++ b/internal/pkg/print/json/testdata/json.golden
@@ -1,4 +1,5 @@
 {
+  "header": "Usage:\n\nmodule \"foo\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}",
   "inputs": [
     {
       "name": "unquoted",

--- a/internal/pkg/print/markdown/document/document.go
+++ b/internal/pkg/print/markdown/document/document.go
@@ -15,6 +15,9 @@ func Print(module *tfconf.Module, settings *print.Settings) (string, error) {
 
 	module.Sort(settings)
 
+	if settings.ShowHeader {
+		printHeader(&buffer, module.Header, settings)
+	}
 	if settings.ShowProviders {
 		printProviders(&buffer, module.Providers, settings)
 	}
@@ -114,6 +117,11 @@ func printInputsAll(buffer *bytes.Buffer, inputs []*tfconf.Input, settings *prin
 	for _, input := range inputs {
 		printInput(buffer, input, settings)
 	}
+}
+
+func printHeader(buffer *bytes.Buffer, header string, settings *print.Settings) {
+	buffer.WriteString(fmt.Sprintf("%s", markdown.SanitizeItemForDocument(header, settings)))
+	buffer.WriteString("\n\n")
 }
 
 func printProviders(buffer *bytes.Buffer, providers []*tfconf.Provider, settings *print.Settings) {

--- a/internal/pkg/print/markdown/document/document_test.go
+++ b/internal/pkg/print/markdown/document/document_test.go
@@ -11,6 +11,7 @@ import (
 func TestDocument(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
 		ShowOutputs:   true,
@@ -28,6 +29,7 @@ func TestDocument(t *testing.T) {
 func TestDocumentWithRequired(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    true,
 		ShowRequired:  true,
 		ShowProviders: true,
 		ShowInputs:    true,
@@ -47,6 +49,7 @@ func TestDocumentSortByName(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		SortByName:    true,
+		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
 		ShowOutputs:   true,
@@ -66,6 +69,7 @@ func TestDocumentSortByRequired(t *testing.T) {
 	settings := &print.Settings{
 		SortByName:     true,
 		SortByRequired: true,
+		ShowHeader:     true,
 		ShowProviders:  true,
 		ShowInputs:     true,
 		ShowOutputs:    true,
@@ -80,9 +84,28 @@ func TestDocumentSortByRequired(t *testing.T) {
 	assert.Equal(expected, actual)
 }
 
+func TestDocumentNoHeader(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowHeader:    false,
+		ShowProviders: true,
+		ShowInputs:    true,
+		ShowOutputs:   true,
+	}
+
+	module, expected, err := testutil.GetExpected("document-NoHeader")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
 func TestDocumentNoProviders(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    true,
 		ShowProviders: false,
 		ShowInputs:    true,
 		ShowOutputs:   true,
@@ -100,6 +123,7 @@ func TestDocumentNoProviders(t *testing.T) {
 func TestDocumentNoInputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    false,
 		ShowOutputs:   true,
@@ -117,6 +141,7 @@ func TestDocumentNoInputs(t *testing.T) {
 func TestDocumentNoOutputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
 		ShowOutputs:   false,
@@ -131,9 +156,28 @@ func TestDocumentNoOutputs(t *testing.T) {
 	assert.Equal(expected, actual)
 }
 
+func TestDocumentOnlyHeader(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowHeader:    true,
+		ShowProviders: false,
+		ShowInputs:    false,
+		ShowOutputs:   false,
+	}
+
+	module, expected, err := testutil.GetExpected("document-OnlyHeader")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
 func TestDocumentOnlyProviders(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    false,
 		ShowProviders: true,
 		ShowInputs:    false,
 		ShowOutputs:   false,
@@ -151,6 +195,7 @@ func TestDocumentOnlyProviders(t *testing.T) {
 func TestDocumentOnlyInputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    false,
 		ShowProviders: false,
 		ShowInputs:    true,
 		ShowOutputs:   false,
@@ -168,6 +213,7 @@ func TestDocumentOnlyInputs(t *testing.T) {
 func TestDocumentOnlyOutputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    false,
 		ShowProviders: false,
 		ShowInputs:    false,
 		ShowOutputs:   true,
@@ -186,6 +232,7 @@ func TestDocumentEscapeCharacters(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		EscapeCharacters: true,
+		ShowHeader:       true,
 		ShowProviders:    true,
 		ShowInputs:       true,
 		ShowOutputs:      true,
@@ -204,6 +251,7 @@ func TestDocumentIndentationBellowAllowed(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		MarkdownIndent: 0,
+		ShowHeader:     true,
 		ShowProviders:  true,
 		ShowInputs:     true,
 		ShowOutputs:    true,
@@ -222,6 +270,7 @@ func TestDocumentIndentationAboveAllowed(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		MarkdownIndent: 10,
+		ShowHeader:     true,
 		ShowProviders:  true,
 		ShowInputs:     true,
 		ShowOutputs:    true,
@@ -240,6 +289,7 @@ func TestDocumentIndentationOfFour(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		MarkdownIndent: 4,
+		ShowHeader:     true,
 		ShowProviders:  true,
 		ShowInputs:     true,
 		ShowOutputs:    true,

--- a/internal/pkg/print/markdown/document/testdata/document-EscapeCharacters.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-EscapeCharacters.golden
@@ -1,3 +1,20 @@
+Usage:
+
+module "foo" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+
 ## Providers
 
 The following providers are used by this module:

--- a/internal/pkg/print/markdown/document/testdata/document-IndentationAboveAllowed.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-IndentationAboveAllowed.golden
@@ -1,3 +1,20 @@
+Usage:
+
+module "foo" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+
 ## Providers
 
 The following providers are used by this module:

--- a/internal/pkg/print/markdown/document/testdata/document-IndentationBellowAllowed.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-IndentationBellowAllowed.golden
@@ -1,3 +1,20 @@
+Usage:
+
+module "foo" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+
 ## Providers
 
 The following providers are used by this module:

--- a/internal/pkg/print/markdown/document/testdata/document-IndentationOfFour.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-IndentationOfFour.golden
@@ -1,3 +1,20 @@
+Usage:
+
+module "foo" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+
 #### Providers
 
 The following providers are used by this module:

--- a/internal/pkg/print/markdown/document/testdata/document-NoHeader.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-NoHeader.golden
@@ -1,20 +1,3 @@
-Usage:
-
-module "foo" {
-  source = "github.com/foo/bar"
-
-  id   = "1234567890"
-  name = "baz"
-
-  zones = ["us-east-1", "us-west-1"]
-
-  tags = {
-    Name         = "baz"
-    Created-By   = "first.last@email.com"
-    Date-Created = "20180101"
-  }
-}
-
 ## Providers
 
 The following providers are used by this module:
@@ -201,3 +184,23 @@ Default:
   "name": "hello"
 }
 ```
+
+## Outputs
+
+The following outputs are exported:
+
+### unquoted
+
+Description: It's unquoted output.
+
+### output-2
+
+Description: It's output number two.
+
+### output-1
+
+Description: It's output number one.
+
+### output-0.12
+
+Description: terraform 0.12 only

--- a/internal/pkg/print/markdown/document/testdata/document-NoInputs.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-NoInputs.golden
@@ -1,3 +1,20 @@
+Usage:
+
+module "foo" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+
 ## Providers
 
 The following providers are used by this module:

--- a/internal/pkg/print/markdown/document/testdata/document-NoProviders.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-NoProviders.golden
@@ -1,3 +1,20 @@
+Usage:
+
+module "foo" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+
 ## Inputs
 
 The following input variables are supported:

--- a/internal/pkg/print/markdown/document/testdata/document-OnlyHeader.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-OnlyHeader.golden
@@ -1,0 +1,16 @@
+Usage:
+
+module "foo" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}

--- a/internal/pkg/print/markdown/document/testdata/document-SortByName.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-SortByName.golden
@@ -1,3 +1,20 @@
+Usage:
+
+module "foo" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+
 ## Providers
 
 The following providers are used by this module:

--- a/internal/pkg/print/markdown/document/testdata/document-SortByRequired.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-SortByRequired.golden
@@ -1,3 +1,20 @@
+Usage:
+
+module "foo" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+
 ## Providers
 
 The following providers are used by this module:

--- a/internal/pkg/print/markdown/document/testdata/document-WithRequired.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-WithRequired.golden
@@ -1,3 +1,20 @@
+Usage:
+
+module "foo" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+
 ## Providers
 
 The following providers are used by this module:

--- a/internal/pkg/print/markdown/document/testdata/document.golden
+++ b/internal/pkg/print/markdown/document/testdata/document.golden
@@ -1,3 +1,20 @@
+Usage:
+
+module "foo" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+
 ## Providers
 
 The following providers are used by this module:

--- a/internal/pkg/print/markdown/table/table.go
+++ b/internal/pkg/print/markdown/table/table.go
@@ -15,6 +15,9 @@ func Print(module *tfconf.Module, settings *print.Settings) (string, error) {
 
 	module.Sort(settings)
 
+	if settings.ShowHeader {
+		printHeader(&buffer, module.Header, settings)
+	}
 	if settings.ShowProviders {
 		printProviders(&buffer, module.Providers, settings)
 	}
@@ -55,6 +58,11 @@ func printIsInputRequired(input *tfconf.Input) string {
 		return "yes"
 	}
 	return "no"
+}
+
+func printHeader(buffer *bytes.Buffer, header string, settings *print.Settings) {
+	buffer.WriteString(fmt.Sprintf("%s", markdown.SanitizeItemForDocument(header, settings)))
+	buffer.WriteString("\n\n")
 }
 
 func printProviders(buffer *bytes.Buffer, providers []*tfconf.Provider, settings *print.Settings) {

--- a/internal/pkg/print/markdown/table/table_test.go
+++ b/internal/pkg/print/markdown/table/table_test.go
@@ -11,6 +11,7 @@ import (
 func TestTable(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
 		ShowOutputs:   true,
@@ -29,6 +30,7 @@ func TestTableWithRequired(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		ShowRequired:  true,
+		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
 		ShowOutputs:   true,
@@ -47,6 +49,7 @@ func TestTableSortByName(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		SortByName:    true,
+		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
 		ShowOutputs:   true,
@@ -66,6 +69,7 @@ func TestTableSortByRequired(t *testing.T) {
 	settings := &print.Settings{
 		SortByName:     true,
 		SortByRequired: true,
+		ShowHeader:     true,
 		ShowProviders:  true,
 		ShowInputs:     true,
 		ShowOutputs:    true,
@@ -80,9 +84,28 @@ func TestTableSortByRequired(t *testing.T) {
 	assert.Equal(expected, actual)
 }
 
+func TestTableNoHeader(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowHeader:    false,
+		ShowProviders: true,
+		ShowInputs:    true,
+		ShowOutputs:   true,
+	}
+
+	module, expected, err := testutil.GetExpected("table-NoHeader")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
 func TestTableNoProviders(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    true,
 		ShowProviders: false,
 		ShowInputs:    true,
 		ShowOutputs:   true,
@@ -100,6 +123,7 @@ func TestTableNoProviders(t *testing.T) {
 func TestTableNoInputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    false,
 		ShowOutputs:   true,
@@ -117,6 +141,7 @@ func TestTableNoInputs(t *testing.T) {
 func TestTableNoOutputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
 		ShowOutputs:   false,
@@ -131,9 +156,28 @@ func TestTableNoOutputs(t *testing.T) {
 	assert.Equal(expected, actual)
 }
 
+func TestTableOnlyHeader(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowHeader:    true,
+		ShowProviders: false,
+		ShowInputs:    false,
+		ShowOutputs:   false,
+	}
+
+	module, expected, err := testutil.GetExpected("table-OnlyHeader")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
 func TestTableOnlyProviders(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    false,
 		ShowProviders: true,
 		ShowInputs:    false,
 		ShowOutputs:   false,
@@ -151,6 +195,7 @@ func TestTableOnlyProviders(t *testing.T) {
 func TestTableOnlyInputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    false,
 		ShowProviders: false,
 		ShowInputs:    true,
 		ShowOutputs:   false,
@@ -168,6 +213,7 @@ func TestTableOnlyInputs(t *testing.T) {
 func TestTableOnlyOutputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    false,
 		ShowProviders: false,
 		ShowInputs:    false,
 		ShowOutputs:   true,
@@ -186,6 +232,7 @@ func TestTableEscapeCharacters(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		EscapeCharacters: true,
+		ShowHeader:       true,
 		ShowProviders:    true,
 		ShowInputs:       true,
 		ShowOutputs:      true,
@@ -204,6 +251,7 @@ func TestTableIndentationBellowAllowed(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		MarkdownIndent: 0,
+		ShowHeader:     true,
 		ShowProviders:  true,
 		ShowInputs:     true,
 		ShowOutputs:    true,
@@ -222,6 +270,7 @@ func TestTableIndentationAboveAllowed(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		MarkdownIndent: 10,
+		ShowHeader:     true,
 		ShowProviders:  true,
 		ShowInputs:     true,
 		ShowOutputs:    true,
@@ -240,6 +289,7 @@ func TestTableIndentationOfFour(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		MarkdownIndent: 4,
+		ShowHeader:     true,
 		ShowProviders:  true,
 		ShowInputs:     true,
 		ShowOutputs:    true,

--- a/internal/pkg/print/markdown/table/testdata/table-EscapeCharacters.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-EscapeCharacters.golden
@@ -1,3 +1,20 @@
+Usage:
+
+module "foo" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+
 ## Providers
 
 | Name | Version |

--- a/internal/pkg/print/markdown/table/testdata/table-IndentationAboveAllowed.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-IndentationAboveAllowed.golden
@@ -1,3 +1,20 @@
+Usage:
+
+module "foo" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+
 ## Providers
 
 | Name | Version |

--- a/internal/pkg/print/markdown/table/testdata/table-IndentationBellowAllowed.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-IndentationBellowAllowed.golden
@@ -1,3 +1,20 @@
+Usage:
+
+module "foo" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+
 ## Providers
 
 | Name | Version |

--- a/internal/pkg/print/markdown/table/testdata/table-NoHeader.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoHeader.golden
@@ -1,21 +1,4 @@
-Usage:
-
-module "foo" {
-  source = "github.com/foo/bar"
-
-  id   = "1234567890"
-  name = "baz"
-
-  zones = ["us-east-1", "us-west-1"]
-
-  tags = {
-    Name         = "baz"
-    Created-By   = "first.last@email.com"
-    Date-Created = "20180101"
-  }
-}
-
-#### Providers
+## Providers
 
 | Name | Version |
 |------|---------|
@@ -24,7 +7,7 @@ module "foo" {
 | aws.ident | >= 2.15.0 |
 | null | n/a |
 
-#### Inputs
+## Inputs
 
 | Name | Description | Type | Default |
 |------|-------------|------|---------|
@@ -43,7 +26,7 @@ module "foo" {
 | input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
 | long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
 
-#### Outputs
+## Outputs
 
 | Name | Description |
 |------|-------------|

--- a/internal/pkg/print/markdown/table/testdata/table-NoInputs.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoInputs.golden
@@ -1,3 +1,20 @@
+Usage:
+
+module "foo" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+
 ## Providers
 
 | Name | Version |

--- a/internal/pkg/print/markdown/table/testdata/table-NoOutputs.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoOutputs.golden
@@ -1,3 +1,20 @@
+Usage:
+
+module "foo" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+
 ## Providers
 
 | Name | Version |

--- a/internal/pkg/print/markdown/table/testdata/table-NoProviders.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoProviders.golden
@@ -1,3 +1,20 @@
+Usage:
+
+module "foo" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+
 ## Inputs
 
 | Name | Description | Type | Default |

--- a/internal/pkg/print/markdown/table/testdata/table-OnlyHeader.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-OnlyHeader.golden
@@ -1,0 +1,16 @@
+Usage:
+
+module "foo" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}

--- a/internal/pkg/print/markdown/table/testdata/table-SortByName.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-SortByName.golden
@@ -1,3 +1,20 @@
+Usage:
+
+module "foo" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+
 ## Providers
 
 | Name | Version |

--- a/internal/pkg/print/markdown/table/testdata/table-SortByRequired.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-SortByRequired.golden
@@ -1,3 +1,20 @@
+Usage:
+
+module "foo" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+
 ## Providers
 
 | Name | Version |

--- a/internal/pkg/print/markdown/table/testdata/table-WithRequired.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-WithRequired.golden
@@ -1,3 +1,20 @@
+Usage:
+
+module "foo" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+
 ## Providers
 
 | Name | Version |

--- a/internal/pkg/print/markdown/table/testdata/table.golden
+++ b/internal/pkg/print/markdown/table/testdata/table.golden
@@ -1,3 +1,20 @@
+Usage:
+
+module "foo" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+
 ## Providers
 
 | Name | Version |

--- a/internal/pkg/print/pretty/pretty.go
+++ b/internal/pkg/print/pretty/pretty.go
@@ -15,6 +15,9 @@ func Print(module *tfconf.Module, settings *print.Settings) (string, error) {
 
 	module.Sort(settings)
 
+	if settings.ShowHeader {
+		printHeader(&buffer, module.Header, settings)
+	}
 	if settings.ShowProviders {
 		printProviders(&buffer, module.Providers, settings)
 	}
@@ -54,6 +57,26 @@ func getDescription(description string) string {
 	}
 
 	return result
+}
+
+func printHeader(buffer *bytes.Buffer, header string, settings *print.Settings) {
+	buffer.WriteString("\n\n")
+
+	for _, line := range strings.Split(header, "\n") {
+		var format string
+		if settings.ShowColor {
+			format = "\033[90m%s\033[0m\n"
+		} else {
+			format = "%s\n"
+		}
+		buffer.WriteString(
+			fmt.Sprintf(
+				format,
+				line,
+			),
+		)
+	}
+	buffer.WriteString("\n")
 }
 
 func printProviders(buffer *bytes.Buffer, providers []*tfconf.Provider, settings *print.Settings) {

--- a/internal/pkg/print/pretty/pretty_test.go
+++ b/internal/pkg/print/pretty/pretty_test.go
@@ -11,6 +11,7 @@ import (
 func TestPretty(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
 		ShowOutputs:   true,
@@ -30,6 +31,7 @@ func TestPrettySortByName(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		SortByName:    true,
+		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
 		ShowOutputs:   true,
@@ -50,6 +52,7 @@ func TestPrettySortByRequired(t *testing.T) {
 	settings := &print.Settings{
 		SortByName:     true,
 		SortByRequired: true,
+		ShowHeader:     true,
 		ShowProviders:  true,
 		ShowInputs:     true,
 		ShowOutputs:    true,
@@ -65,9 +68,29 @@ func TestPrettySortByRequired(t *testing.T) {
 	assert.Equal(expected, actual)
 }
 
+func TestPrettyNoHeader(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowProviders: false,
+		ShowHeader:    false,
+		ShowInputs:    true,
+		ShowOutputs:   true,
+		ShowColor:     true,
+	}
+
+	module, expected, err := testutil.GetExpected("pretty-NoHeader")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
 func TestPrettyNoProviders(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    true,
 		ShowProviders: false,
 		ShowInputs:    true,
 		ShowOutputs:   true,
@@ -86,6 +109,7 @@ func TestPrettyNoProviders(t *testing.T) {
 func TestPrettyNoInputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    false,
 		ShowOutputs:   true,
@@ -104,6 +128,7 @@ func TestPrettyNoInputs(t *testing.T) {
 func TestPrettyNoOutputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
 		ShowOutputs:   false,
@@ -119,9 +144,29 @@ func TestPrettyNoOutputs(t *testing.T) {
 	assert.Equal(expected, actual)
 }
 
+func TestPrettyOnlyHeader(t *testing.T) {
+	assert := assert.New(t)
+	settings := &print.Settings{
+		ShowHeader:    true,
+		ShowProviders: false,
+		ShowInputs:    false,
+		ShowOutputs:   false,
+		ShowColor:     true,
+	}
+
+	module, expected, err := testutil.GetExpected("pretty-OnlyHeader")
+	assert.Nil(err)
+
+	actual, err := Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
 func TestPrettyOnlyProviders(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    false,
 		ShowProviders: true,
 		ShowInputs:    false,
 		ShowOutputs:   false,
@@ -140,6 +185,7 @@ func TestPrettyOnlyProviders(t *testing.T) {
 func TestPrettyOnlyInputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    false,
 		ShowProviders: false,
 		ShowInputs:    true,
 		ShowOutputs:   false,
@@ -158,6 +204,7 @@ func TestPrettyOnlyInputs(t *testing.T) {
 func TestPrettyOnlyOutputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    false,
 		ShowProviders: false,
 		ShowInputs:    false,
 		ShowOutputs:   true,
@@ -176,6 +223,7 @@ func TestPrettyOnlyOutputs(t *testing.T) {
 func TestPrettyNoColor(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
 		ShowOutputs:   true,

--- a/internal/pkg/print/pretty/testdata/pretty-NoColor.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoColor.golden
@@ -1,5 +1,24 @@
 
 
+Usage:
+
+module "foo" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+
+
+
 provider.tls
 
 provider.aws (>= 2.15.0)

--- a/internal/pkg/print/pretty/testdata/pretty-NoHeader.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoHeader.golden
@@ -1,24 +1,5 @@
 
 
-[90mUsage:[0m
-[90m[0m
-[90mmodule "foo" {[0m
-[90m  source = "github.com/foo/bar"[0m
-[90m[0m
-[90m  id   = "1234567890"[0m
-[90m  name = "baz"[0m
-[90m[0m
-[90m  zones = ["us-east-1", "us-west-1"][0m
-[90m[0m
-[90m  tags = {[0m
-[90m    Name         = "baz"[0m
-[90m    Created-By   = "first.last@email.com"[0m
-[90m    Date-Created = "20180101"[0m
-[90m  }[0m
-[90m}[0m
-
-
-
 [36minput.unquoted[0m (required)
 [90mn/a[0m
 

--- a/internal/pkg/print/pretty/testdata/pretty-NoOutputs.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoOutputs.golden
@@ -1,5 +1,24 @@
 
 
+[90mUsage:[0m
+[90m[0m
+[90mmodule "foo" {[0m
+[90m  source = "github.com/foo/bar"[0m
+[90m[0m
+[90m  id   = "1234567890"[0m
+[90m  name = "baz"[0m
+[90m[0m
+[90m  zones = ["us-east-1", "us-west-1"][0m
+[90m[0m
+[90m  tags = {[0m
+[90m    Name         = "baz"[0m
+[90m    Created-By   = "first.last@email.com"[0m
+[90m    Date-Created = "20180101"[0m
+[90m  }[0m
+[90m}[0m
+
+
+
 [36mprovider.tls[0m
 
 [36mprovider.aws[0m (>= 2.15.0)

--- a/internal/pkg/print/pretty/testdata/pretty-OnlyHeader.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-OnlyHeader.golden
@@ -17,27 +17,3 @@
 [90m  }[0m
 [90m}[0m
 
-
-
-[36mprovider.tls[0m
-
-[36mprovider.aws[0m (>= 2.15.0)
-
-[36mprovider.aws.ident[0m (>= 2.15.0)
-
-[36mprovider.null[0m
-
-
-
-[36moutput.unquoted[0m
-[90mIt's unquoted output.[0m
-
-[36moutput.output-2[0m
-[90mIt's output number two.[0m
-
-[36moutput.output-1[0m
-[90mIt's output number one.[0m
-
-[36moutput.output-0.12[0m
-[90mterraform 0.12 only[0m
-

--- a/internal/pkg/print/pretty/testdata/pretty-SortByName.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-SortByName.golden
@@ -1,5 +1,24 @@
 
 
+[90mUsage:[0m
+[90m[0m
+[90mmodule "foo" {[0m
+[90m  source = "github.com/foo/bar"[0m
+[90m[0m
+[90m  id   = "1234567890"[0m
+[90m  name = "baz"[0m
+[90m[0m
+[90m  zones = ["us-east-1", "us-west-1"][0m
+[90m[0m
+[90m  tags = {[0m
+[90m    Name         = "baz"[0m
+[90m    Created-By   = "first.last@email.com"[0m
+[90m    Date-Created = "20180101"[0m
+[90m  }[0m
+[90m}[0m
+
+
+
 [36mprovider.aws[0m (>= 2.15.0)
 
 [36mprovider.aws.ident[0m (>= 2.15.0)

--- a/internal/pkg/print/pretty/testdata/pretty-SortByRequired.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-SortByRequired.golden
@@ -1,5 +1,24 @@
 
 
+[90mUsage:[0m
+[90m[0m
+[90mmodule "foo" {[0m
+[90m  source = "github.com/foo/bar"[0m
+[90m[0m
+[90m  id   = "1234567890"[0m
+[90m  name = "baz"[0m
+[90m[0m
+[90m  zones = ["us-east-1", "us-west-1"][0m
+[90m[0m
+[90m  tags = {[0m
+[90m    Name         = "baz"[0m
+[90m    Created-By   = "first.last@email.com"[0m
+[90m    Date-Created = "20180101"[0m
+[90m  }[0m
+[90m}[0m
+
+
+
 [36mprovider.aws[0m (>= 2.15.0)
 
 [36mprovider.aws.ident[0m (>= 2.15.0)

--- a/internal/pkg/print/pretty/testdata/pretty.golden
+++ b/internal/pkg/print/pretty/testdata/pretty.golden
@@ -1,5 +1,24 @@
 
 
+[90mUsage:[0m
+[90m[0m
+[90mmodule "foo" {[0m
+[90m  source = "github.com/foo/bar"[0m
+[90m[0m
+[90m  id   = "1234567890"[0m
+[90m  name = "baz"[0m
+[90m[0m
+[90m  zones = ["us-east-1", "us-west-1"][0m
+[90m[0m
+[90m  tags = {[0m
+[90m    Name         = "baz"[0m
+[90m    Created-By   = "first.last@email.com"[0m
+[90m    Date-Created = "20180101"[0m
+[90m  }[0m
+[90m}[0m
+
+
+
 [36mprovider.tls[0m
 
 [36mprovider.aws[0m (>= 2.15.0)

--- a/internal/pkg/print/settings.go
+++ b/internal/pkg/print/settings.go
@@ -14,6 +14,10 @@ type Settings struct {
 	// scope: Pretty
 	ShowColor bool
 
+	// ShowHeader show "Header" module information (default: true)
+	// scope: Global
+	ShowHeader bool
+
 	// ShowInputs show "Inputs" information (default: true)
 	// scope: Global
 	ShowInputs bool
@@ -45,6 +49,7 @@ func NewSettings() *Settings {
 		EscapeCharacters: true,
 		MarkdownIndent:   2,
 		ShowColor:        true,
+		ShowHeader:       true,
 		ShowInputs:       true,
 		ShowOutputs:      true,
 		ShowProviders:    true,

--- a/internal/pkg/reader/lines.go
+++ b/internal/pkg/reader/lines.go
@@ -1,0 +1,65 @@
+package reader
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+// Lines represents line reader in a given 'FileName' immediately
+// before the given 'LineNum'. Extraction happens when 'Condition'
+// is met and being processed by 'Parser' function.
+type Lines struct {
+	FileName  string
+	LineNum   int // value -1 means scan the whole file and break after finding what we were looking for
+	Condition func(line string) bool
+	Parser    func(line string) (string, bool)
+}
+
+// Extract extracts lines in given file and based on the provided
+// condition. returns empty if nothing found.
+func (l *Lines) Extract() ([]string, error) {
+	f, err := os.Open(l.FileName)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	bf := bufio.NewReader(f)
+	var lines = make([]string, 0)
+
+	for lnum := 0; ; lnum++ {
+		if l.LineNum != -1 && lnum >= l.LineNum {
+			break
+		}
+		line, err := bf.ReadString('\n')
+		if err == io.EOF {
+			switch lnum {
+			case 0:
+				return nil, errors.New("no lines in file")
+			case 1:
+				return nil, errors.New("only 1 line")
+			default:
+				return nil, fmt.Errorf("only %d lines", lnum)
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+		if l.Condition(line) {
+			if extracted, capture := l.Parser(line); capture {
+				lines = append(lines, extracted)
+			}
+		} else if l.LineNum == -1 {
+			break
+		} else {
+			lines = nil
+		}
+	}
+
+	return lines, nil
+}

--- a/internal/pkg/tfconf/comment.go
+++ b/internal/pkg/tfconf/comment.go
@@ -1,62 +1,29 @@
 package tfconf
 
 import (
-	"bufio"
-	"errors"
-	"fmt"
-	"io"
-	"os"
 	"strings"
+
+	"github.com/segmentio/terraform-docs/internal/pkg/reader"
 )
 
 func readComment(filename string, lineNum int) string {
-	lines, err := readLines(filename, lineNum)
-	if err != nil {
-		return "" // absorb the error, we don't need to bubble it up or break the execution
-	}
-	return strings.Join(lines, " ")
-}
-
-// Reading leading comments, i.e. lines start with # or //
-// immediately before specific line number in given file
-func readLines(filename string, lineNum int) ([]string, error) {
-	f, err := os.Open(filename)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		_ = f.Close()
-	}()
-
-	bf := bufio.NewReader(f)
-	var lines = make([]string, 0)
-
-	for lnum := 0; lnum < lineNum; lnum++ {
-		line, err := bf.ReadString('\n')
-		if err == io.EOF {
-			switch lnum {
-			case 0:
-				return nil, errors.New("no lines in file")
-			case 1:
-				return nil, errors.New("only 1 line")
-			default:
-				return nil, fmt.Errorf("only %d lines", lnum)
-			}
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		if strings.HasPrefix(line, "#") || strings.HasPrefix(line, "//") {
+	lines := reader.Lines{
+		FileName: filename,
+		LineNum:  lineNum,
+		Condition: func(line string) bool {
+			return strings.HasPrefix(line, "#") || strings.HasPrefix(line, "//")
+		},
+		Parser: func(line string) (string, bool) {
 			line = strings.TrimSpace(line)
 			line = strings.TrimPrefix(line, "#")
 			line = strings.TrimPrefix(line, "//")
 			line = strings.TrimSpace(line)
-			lines = append(lines, line)
-		} else {
-			lines = nil
-		}
+			return line, true
+		},
 	}
-
-	return lines, nil
+	comment, err := lines.Extract()
+	if err != nil {
+		return "" // absorb the error, we don't need to bubble it up or break the execution
+	}
+	return strings.Join(comment, " ")
 }

--- a/internal/pkg/tfconf/header.go
+++ b/internal/pkg/tfconf/header.go
@@ -1,0 +1,39 @@
+package tfconf
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	"github.com/segmentio/terraform-docs/internal/pkg/reader"
+)
+
+func readHeader(path string) string {
+	filename := filepath.Join(path, "main.tf")
+	_, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return "" // absorb the error, we don't need to bubble it up or break the execution
+	}
+	lines := reader.Lines{
+		FileName: filename,
+		LineNum:  -1,
+		Condition: func(line string) bool {
+			line = strings.TrimSpace(line)
+			return strings.HasPrefix(line, "/*") || strings.HasPrefix(line, "*") || strings.HasPrefix(line, "*/")
+		},
+		Parser: func(line string) (string, bool) {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "/*") || strings.HasPrefix(line, "*/") {
+				return "", false
+			}
+			line = strings.TrimPrefix(line, "* ")
+			line = strings.TrimPrefix(line, "*")
+			return line, true
+		},
+	}
+	header, err := lines.Extract()
+	if err != nil {
+		return "" // absorb the error, we don't need to bubble it up or break the execution
+	}
+	return strings.Join(header, "\n")
+}

--- a/internal/pkg/tfconf/module.go
+++ b/internal/pkg/tfconf/module.go
@@ -13,6 +13,7 @@ import (
 
 // Module represents a Terraform mod.
 type Module struct {
+	Header         string      `json:"header"`
 	Inputs         []*Input    `json:"inputs"`
 	Outputs        []*Output   `json:"outputs"`
 	Providers      []*Provider `json:"providers"`
@@ -65,6 +66,8 @@ func (m *Module) Sort(settings *print.Settings) {
 // outputs dircoverd from provided 'path' containing Terraform config
 func CreateModule(path string) (*Module, error) {
 	mod := loadModule(path)
+
+	header := readHeader(path)
 
 	var inputs = make([]*Input, 0, len(mod.Variables))
 	var requiredInputs = make([]*Input, 0, len(mod.Variables))
@@ -147,6 +150,7 @@ func CreateModule(path string) (*Module, error) {
 	}
 
 	module := &Module{
+		Header:         header,
 		Inputs:         inputs,
 		Outputs:        outputs,
 		Providers:      providers,


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

As part of preparing the support for Terraform 0.12 which has been discussed in length (https://github.com/segmentio/terraform-docs/issues/62#issuecomment-507069369, https://github.com/segmentio/terraform-docs/issues/62#issuecomment-507069369 and https://github.com/hashicorp/terraform-config-inspect/issues/21#issuecomment-525259471) we had decided to drop the support of extracting module header comment from `main.tf` file, but this PR is going to address it with minimal effort, which is internal to `terraform-docs` codebase and does not depend on Terraform community as a whole and `terraform-config-inspect` in particular.

Supported comment formats is:

- jsdoc, c or java-like multi-line comment `/** **/`

BREAKING CHANGE:

- In the JSON format respone, module "Comment" has been renamed to module `header`.

### Issues Resolved

Fixes #146 

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [x] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
