### PR TITLE
Show all JSON properties, empty or null

### DIFF
--- a/internal/pkg/print/json/testdata/json-EscapeCharacters.golden
+++ b/internal/pkg/print/json/testdata/json-EscapeCharacters.golden
@@ -3,17 +3,21 @@
   "inputs": [
     {
       "name": "unquoted",
-      "type": "any"
+      "type": "any",
+      "description": "",
+      "default": null
     },
     {
       "name": "string-3",
       "type": "string",
+      "description": "",
       "default": "\"\""
     },
     {
       "name": "string-2",
       "type": "string",
-      "description": "It's string number two."
+      "description": "It's string number two.",
+      "default": null
     },
     {
       "name": "string-1",
@@ -24,12 +28,14 @@
     {
       "name": "map-3",
       "type": "map",
+      "description": "",
       "default": "{}"
     },
     {
       "name": "map-2",
       "type": "map",
-      "description": "It's map number two."
+      "description": "It's map number two.",
+      "default": null
     },
     {
       "name": "map-1",
@@ -40,12 +46,14 @@
     {
       "name": "list-3",
       "type": "list",
+      "description": "",
       "default": "[]"
     },
     {
       "name": "list-2",
       "type": "list",
-      "description": "It's list number two."
+      "description": "It's list number two.",
+      "default": null
     },
     {
       "name": "list-1",
@@ -56,7 +64,8 @@
     {
       "name": "input_with_underscores",
       "type": "any",
-      "description": "A variable with underscores."
+      "description": "A variable with underscores.",
+      "default": null
     },
     {
       "name": "input-with-pipe",

--- a/internal/pkg/print/json/testdata/json-NoHeader.golden
+++ b/internal/pkg/print/json/testdata/json-NoHeader.golden
@@ -3,17 +3,21 @@
   "inputs": [
     {
       "name": "unquoted",
-      "type": "any"
+      "type": "any",
+      "description": "",
+      "default": null
     },
     {
       "name": "string-3",
       "type": "string",
+      "description": "",
       "default": "\"\""
     },
     {
       "name": "string-2",
       "type": "string",
-      "description": "It's string number two."
+      "description": "It's string number two.",
+      "default": null
     },
     {
       "name": "string-1",
@@ -24,12 +28,14 @@
     {
       "name": "map-3",
       "type": "map",
+      "description": "",
       "default": "{}"
     },
     {
       "name": "map-2",
       "type": "map",
-      "description": "It's map number two."
+      "description": "It's map number two.",
+      "default": null
     },
     {
       "name": "map-1",
@@ -40,12 +46,14 @@
     {
       "name": "list-3",
       "type": "list",
+      "description": "",
       "default": "[]"
     },
     {
       "name": "list-2",
       "type": "list",
-      "description": "It's list number two."
+      "description": "It's list number two.",
+      "default": null
     },
     {
       "name": "list-1",
@@ -56,7 +64,8 @@
     {
       "name": "input_with_underscores",
       "type": "any",
-      "description": "A variable with underscores."
+      "description": "A variable with underscores.",
+      "default": null
     },
     {
       "name": "input-with-pipe",

--- a/internal/pkg/print/json/testdata/json-NoOutputs.golden
+++ b/internal/pkg/print/json/testdata/json-NoOutputs.golden
@@ -3,17 +3,21 @@
   "inputs": [
     {
       "name": "unquoted",
-      "type": "any"
+      "type": "any",
+      "description": "",
+      "default": null
     },
     {
       "name": "string-3",
       "type": "string",
+      "description": "",
       "default": "\"\""
     },
     {
       "name": "string-2",
       "type": "string",
-      "description": "It's string number two."
+      "description": "It's string number two.",
+      "default": null
     },
     {
       "name": "string-1",
@@ -24,12 +28,14 @@
     {
       "name": "map-3",
       "type": "map",
+      "description": "",
       "default": "{}"
     },
     {
       "name": "map-2",
       "type": "map",
-      "description": "It's map number two."
+      "description": "It's map number two.",
+      "default": null
     },
     {
       "name": "map-1",
@@ -40,12 +46,14 @@
     {
       "name": "list-3",
       "type": "list",
+      "description": "",
       "default": "[]"
     },
     {
       "name": "list-2",
       "type": "list",
-      "description": "It's list number two."
+      "description": "It's list number two.",
+      "default": null
     },
     {
       "name": "list-1",
@@ -56,7 +64,8 @@
     {
       "name": "input_with_underscores",
       "type": "any",
-      "description": "A variable with underscores."
+      "description": "A variable with underscores.",
+      "default": null
     },
     {
       "name": "input-with-pipe",

--- a/internal/pkg/print/json/testdata/json-NoProviders.golden
+++ b/internal/pkg/print/json/testdata/json-NoProviders.golden
@@ -3,17 +3,21 @@
   "inputs": [
     {
       "name": "unquoted",
-      "type": "any"
+      "type": "any",
+      "description": "",
+      "default": null
     },
     {
       "name": "string-3",
       "type": "string",
+      "description": "",
       "default": "\"\""
     },
     {
       "name": "string-2",
       "type": "string",
-      "description": "It's string number two."
+      "description": "It's string number two.",
+      "default": null
     },
     {
       "name": "string-1",
@@ -24,12 +28,14 @@
     {
       "name": "map-3",
       "type": "map",
+      "description": "",
       "default": "{}"
     },
     {
       "name": "map-2",
       "type": "map",
-      "description": "It's map number two."
+      "description": "It's map number two.",
+      "default": null
     },
     {
       "name": "map-1",
@@ -40,12 +46,14 @@
     {
       "name": "list-3",
       "type": "list",
+      "description": "",
       "default": "[]"
     },
     {
       "name": "list-2",
       "type": "list",
-      "description": "It's list number two."
+      "description": "It's list number two.",
+      "default": null
     },
     {
       "name": "list-1",
@@ -56,7 +64,8 @@
     {
       "name": "input_with_underscores",
       "type": "any",
-      "description": "A variable with underscores."
+      "description": "A variable with underscores.",
+      "default": null
     },
     {
       "name": "input-with-pipe",

--- a/internal/pkg/print/json/testdata/json-OnlyInputs.golden
+++ b/internal/pkg/print/json/testdata/json-OnlyInputs.golden
@@ -3,17 +3,21 @@
   "inputs": [
     {
       "name": "unquoted",
-      "type": "any"
+      "type": "any",
+      "description": "",
+      "default": null
     },
     {
       "name": "string-3",
       "type": "string",
+      "description": "",
       "default": "\"\""
     },
     {
       "name": "string-2",
       "type": "string",
-      "description": "It's string number two."
+      "description": "It's string number two.",
+      "default": null
     },
     {
       "name": "string-1",
@@ -24,12 +28,14 @@
     {
       "name": "map-3",
       "type": "map",
+      "description": "",
       "default": "{}"
     },
     {
       "name": "map-2",
       "type": "map",
-      "description": "It's map number two."
+      "description": "It's map number two.",
+      "default": null
     },
     {
       "name": "map-1",
@@ -40,12 +46,14 @@
     {
       "name": "list-3",
       "type": "list",
+      "description": "",
       "default": "[]"
     },
     {
       "name": "list-2",
       "type": "list",
-      "description": "It's list number two."
+      "description": "It's list number two.",
+      "default": null
     },
     {
       "name": "list-1",
@@ -56,7 +64,8 @@
     {
       "name": "input_with_underscores",
       "type": "any",
-      "description": "A variable with underscores."
+      "description": "A variable with underscores.",
+      "default": null
     },
     {
       "name": "input-with-pipe",

--- a/internal/pkg/print/json/testdata/json-SortByName.golden
+++ b/internal/pkg/print/json/testdata/json-SortByName.golden
@@ -16,7 +16,8 @@
     {
       "name": "input_with_underscores",
       "type": "any",
-      "description": "A variable with underscores."
+      "description": "A variable with underscores.",
+      "default": null
     },
     {
       "name": "list-1",
@@ -27,11 +28,13 @@
     {
       "name": "list-2",
       "type": "list",
-      "description": "It's list number two."
+      "description": "It's list number two.",
+      "default": null
     },
     {
       "name": "list-3",
       "type": "list",
+      "description": "",
       "default": "[]"
     },
     {
@@ -49,11 +52,13 @@
     {
       "name": "map-2",
       "type": "map",
-      "description": "It's map number two."
+      "description": "It's map number two.",
+      "default": null
     },
     {
       "name": "map-3",
       "type": "map",
+      "description": "",
       "default": "{}"
     },
     {
@@ -71,16 +76,20 @@
     {
       "name": "string-2",
       "type": "string",
-      "description": "It's string number two."
+      "description": "It's string number two.",
+      "default": null
     },
     {
       "name": "string-3",
       "type": "string",
+      "description": "",
       "default": "\"\""
     },
     {
       "name": "unquoted",
-      "type": "any"
+      "type": "any",
+      "description": "",
+      "default": null
     }
   ],
   "outputs": [

--- a/internal/pkg/print/json/testdata/json-SortByRequired.golden
+++ b/internal/pkg/print/json/testdata/json-SortByRequired.golden
@@ -4,26 +4,32 @@
     {
       "name": "input_with_underscores",
       "type": "any",
-      "description": "A variable with underscores."
+      "description": "A variable with underscores.",
+      "default": null
     },
     {
       "name": "list-2",
       "type": "list",
-      "description": "It's list number two."
+      "description": "It's list number two.",
+      "default": null
     },
     {
       "name": "map-2",
       "type": "map",
-      "description": "It's map number two."
+      "description": "It's map number two.",
+      "default": null
     },
     {
       "name": "string-2",
       "type": "string",
-      "description": "It's string number two."
+      "description": "It's string number two.",
+      "default": null
     },
     {
       "name": "unquoted",
-      "type": "any"
+      "type": "any",
+      "description": "",
+      "default": null
     },
     {
       "name": "input-with-code-block",
@@ -46,6 +52,7 @@
     {
       "name": "list-3",
       "type": "list",
+      "description": "",
       "default": "[]"
     },
     {
@@ -63,6 +70,7 @@
     {
       "name": "map-3",
       "type": "map",
+      "description": "",
       "default": "{}"
     },
     {
@@ -80,6 +88,7 @@
     {
       "name": "string-3",
       "type": "string",
+      "description": "",
       "default": "\"\""
     }
   ],

--- a/internal/pkg/print/json/testdata/json.golden
+++ b/internal/pkg/print/json/testdata/json.golden
@@ -3,17 +3,21 @@
   "inputs": [
     {
       "name": "unquoted",
-      "type": "any"
+      "type": "any",
+      "description": "",
+      "default": null
     },
     {
       "name": "string-3",
       "type": "string",
+      "description": "",
       "default": "\"\""
     },
     {
       "name": "string-2",
       "type": "string",
-      "description": "It's string number two."
+      "description": "It's string number two.",
+      "default": null
     },
     {
       "name": "string-1",
@@ -24,12 +28,14 @@
     {
       "name": "map-3",
       "type": "map",
+      "description": "",
       "default": "{}"
     },
     {
       "name": "map-2",
       "type": "map",
-      "description": "It's map number two."
+      "description": "It's map number two.",
+      "default": null
     },
     {
       "name": "map-1",
@@ -40,12 +46,14 @@
     {
       "name": "list-3",
       "type": "list",
+      "description": "",
       "default": "[]"
     },
     {
       "name": "list-2",
       "type": "list",
-      "description": "It's list number two."
+      "description": "It's list number two.",
+      "default": null
     },
     {
       "name": "list-1",
@@ -56,7 +64,8 @@
     {
       "name": "input_with_underscores",
       "type": "any",
-      "description": "A variable with underscores."
+      "description": "A variable with underscores.",
+      "default": null
     },
     {
       "name": "input-with-pipe",

--- a/internal/pkg/print/markdown/document/document.go
+++ b/internal/pkg/print/markdown/document/document.go
@@ -54,7 +54,7 @@ func getInputValue(input *tfconf.Input) string {
 	var extraline = false
 
 	if input.HasDefault() {
-		if result, extraline = markdown.PrintFencedCodeBlock(input.Default, "json"); !extraline {
+		if result, extraline = markdown.PrintFencedCodeBlock(*input.Default, "json"); !extraline {
 			result += "\n"
 		}
 	}

--- a/internal/pkg/print/markdown/table/table.go
+++ b/internal/pkg/print/markdown/table/table.go
@@ -48,7 +48,7 @@ func getInputValue(input *tfconf.Input) string {
 	var result = "n/a"
 
 	if input.HasDefault() {
-		result, _ = markdown.PrintFencedCodeBlock(input.Default, "")
+		result, _ = markdown.PrintFencedCodeBlock(*input.Default, "")
 	}
 	return result
 }

--- a/internal/pkg/print/pretty/pretty.go
+++ b/internal/pkg/print/pretty/pretty.go
@@ -43,7 +43,7 @@ func getInputDefaultValue(input *tfconf.Input, settings *print.Settings) string 
 	var result = "required"
 
 	if input.HasDefault() {
-		result = input.Default
+		result = *input.Default
 	}
 
 	return result

--- a/internal/pkg/tfconf/input.go
+++ b/internal/pkg/tfconf/input.go
@@ -3,15 +3,15 @@ package tfconf
 // Input represents a Terraform input.
 type Input struct {
 	Name        string   `json:"name"`
-	Type        string   `json:"type,omitempty"`
-	Description string   `json:"description,omitempty"`
-	Default     string   `json:"default,omitempty"`
+	Type        string   `json:"type"`
+	Description string   `json:"description"`
+	Default     *string  `json:"default"`
 	Position    Position `json:"-"`
 }
 
 // HasDefault indicates if a Terraform variable has a default value set.
 func (i *Input) HasDefault() bool {
-	return len(i.Default) > 0
+	return i.Default != nil
 }
 
 type inputsSortedByName []*Input

--- a/internal/pkg/tfconf/module.go
+++ b/internal/pkg/tfconf/module.go
@@ -83,13 +83,13 @@ func CreateModule(path string) (*Module, error) {
 			inputType = "any"
 		}
 
-		var defaultValue string
+		var defaultValue *string = new(string)
 		if input.Default != nil {
 			marshaled, err := json.MarshalIndent(input.Default, "", "  ")
 			if err != nil {
 				return nil, err
 			}
-			defaultValue = string(marshaled)
+			*defaultValue = string(marshaled)
 
 			if inputType == "any" {
 				switch xType := fmt.Sprintf("%T", input.Default); xType {
@@ -105,6 +105,8 @@ func CreateModule(path string) (*Module, error) {
 					inputType = "map"
 				}
 			}
+		} else {
+			defaultValue = nil
 		}
 
 		inputDescription := input.Description

--- a/internal/pkg/tfconf/module.go
+++ b/internal/pkg/tfconf/module.go
@@ -83,7 +83,7 @@ func CreateModule(path string) (*Module, error) {
 			inputType = "any"
 		}
 
-		var defaultValue *string = new(string)
+		var defaultValue = new(string)
 		if input.Default != nil {
 			marshaled, err := json.MarshalIndent(input.Default, "", "  ")
 			if err != nil {


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

JSON properties which are `nil` were dropped from being rendered instead of being shown as `key: ""` or `key: null`. This PR fixes that. If properties are not defined one of the following can happen:

- `type: ""` (in reality never should happen though)
- `description: ""`
- `default: null`

### Issues Resolved

Fixes #158 

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [ ] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
