### PR TITLE
Deprecate accepting files as commands param

### DIFF
--- a/cmd/json.go
+++ b/cmd/json.go
@@ -8,7 +8,7 @@ import (
 
 var jsonCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
-	Use:   "json [PATH...]",
+	Use:   "json [PATH]",
 	Short: "Generate a JSON of inputs and outputs",
 	Run: func(cmd *cobra.Command, args []string) {
 		doPrint(args, func(module *tfconf.Module) (string, error) {

--- a/cmd/markdown.go
+++ b/cmd/markdown.go
@@ -9,7 +9,7 @@ import (
 
 var markdownCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1),
-	Use:     "markdown [PATH...]",
+	Use:     "markdown [PATH]",
 	Aliases: []string{"md"},
 	Short:   "Generate Markdown of inputs and outputs",
 	Run: func(cmd *cobra.Command, args []string) {
@@ -21,7 +21,7 @@ var markdownCmd = &cobra.Command{
 
 var mdTableCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1),
-	Use:     "table [PATH...]",
+	Use:     "table [PATH]",
 	Aliases: []string{"tbl"},
 	Short:   "Generate Markdown tables of inputs and outputs",
 	Run: func(cmd *cobra.Command, args []string) {
@@ -33,7 +33,7 @@ var mdTableCmd = &cobra.Command{
 
 var mdDocumentCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1),
-	Use:     "document [PATH...]",
+	Use:     "document [PATH]",
 	Aliases: []string{"doc"},
 	Short:   "Generate Markdown document of inputs and outputs",
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/pretty.go
+++ b/cmd/pretty.go
@@ -8,7 +8,7 @@ import (
 
 var prettyCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
-	Use:   "pretty [PATH...]",
+	Use:   "pretty [PATH]",
 	Short: "Generate a colorized pretty of inputs and outputs",
 	Run: func(cmd *cobra.Command, args []string) {
 		doPrint(args, func(module *tfconf.Module) (string, error) {


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [x] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

With Terraform 0.12 ability to generate output from file has been deprecated in favor of from folder which contains one or more `.tf` files.

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [ ] I have added tests to cover my changes.
- [ ] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
