### PR TITLE
Do not wrap multiline blocks in table with <code>

### DIFF
--- a/internal/pkg/print/markdown/markdown.go
+++ b/internal/pkg/print/markdown/markdown.go
@@ -77,7 +77,7 @@ func SanitizeItemForTable(s string, settings *print.Settings) string {
 			return segment
 		},
 		func(segment string) string {
-			segment = fmt.Sprintf("<code><pre>%s</pre></code>", strings.Replace(strings.Replace(segment, "\n", "<br>", -1), "\r", "", -1))
+			segment = fmt.Sprintf("<pre>%s</pre>", strings.Replace(strings.Replace(segment, "\n", "<br>", -1), "\r", "", -1))
 			return segment
 		},
 	)

--- a/internal/pkg/print/markdown/table/testdata/table-EscapeCharacters.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-EscapeCharacters.golden
@@ -38,14 +38,14 @@ module "foo_bar" {
 | string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | It's map number one. | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | It's list number one. | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre> |
 | input\_with\_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
-| long\_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre> | `list` | <pre>[<br>  "name rack:location"<br>]<br></pre> |
+| long\_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre> |
 | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE\_WITH\_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` |
 
 ## Outputs

--- a/internal/pkg/print/markdown/table/testdata/table-IndentationAboveAllowed.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-IndentationAboveAllowed.golden
@@ -38,14 +38,14 @@ module "foo_bar" {
 | string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | It's map number one. | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | It's list number one. | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre> |
 | input_with_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre> | `list` | <pre>[<br>  "name rack:location"<br>]<br></pre> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre> |
 | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` |
 
 ## Outputs

--- a/internal/pkg/print/markdown/table/testdata/table-IndentationBellowAllowed.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-IndentationBellowAllowed.golden
@@ -38,14 +38,14 @@ module "foo_bar" {
 | string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | It's map number one. | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | It's list number one. | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre> |
 | input_with_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre> | `list` | <pre>[<br>  "name rack:location"<br>]<br></pre> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre> |
 | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` |
 
 ## Outputs

--- a/internal/pkg/print/markdown/table/testdata/table-IndentationOfFour.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-IndentationOfFour.golden
@@ -38,14 +38,14 @@ module "foo_bar" {
 | string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | It's map number one. | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | It's list number one. | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre> |
 | input_with_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre> | `list` | <pre>[<br>  "name rack:location"<br>]<br></pre> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre> |
 | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` |
 
 #### Outputs

--- a/internal/pkg/print/markdown/table/testdata/table-NoHeader.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoHeader.golden
@@ -17,14 +17,14 @@
 | string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | It's map number one. | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | It's list number one. | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre> |
 | input_with_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre> | `list` | <pre>[<br>  "name rack:location"<br>]<br></pre> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre> |
 | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` |
 
 ## Outputs

--- a/internal/pkg/print/markdown/table/testdata/table-NoOutputs.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoOutputs.golden
@@ -38,12 +38,12 @@ module "foo_bar" {
 | string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | It's map number one. | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | It's list number one. | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre> |
 | input_with_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre> | `list` | <pre>[<br>  "name rack:location"<br>]<br></pre> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre> |
 | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` |

--- a/internal/pkg/print/markdown/table/testdata/table-NoProviders.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoProviders.golden
@@ -29,14 +29,14 @@ module "foo_bar" {
 | string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | It's map number one. | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | It's list number one. | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre> |
 | input_with_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre> | `list` | <pre>[<br>  "name rack:location"<br>]<br></pre> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre> |
 | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` |
 
 ## Outputs

--- a/internal/pkg/print/markdown/table/testdata/table-OnlyInputs.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-OnlyInputs.golden
@@ -8,12 +8,12 @@
 | string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | It's map number one. | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | It's list number one. | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre> |
 | input_with_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre> | `list` | <pre>[<br>  "name rack:location"<br>]<br></pre> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre> |
 | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` |

--- a/internal/pkg/print/markdown/table/testdata/table-SortByName.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-SortByName.golden
@@ -32,14 +32,14 @@ module "foo_bar" {
 
 | Name | Description | Type | Default |
 |------|-------------|------|---------|
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre> | `list` | <pre>[<br>  "name rack:location"<br>]<br></pre> |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
 | input_with_underscores | A variable with underscores. | `any` | n/a |
-| list-1 | It's list number one. | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre> |
 | list-2 | It's list number two. | `list` | n/a |
 | list-3 | n/a | `list` | `[]` |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
-| map-1 | It's map number one. | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre> |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre> |
 | map-2 | It's map number two. | `map` | n/a |
 | map-3 | n/a | `map` | `{}` |
 | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` |

--- a/internal/pkg/print/markdown/table/testdata/table-SortByRequired.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-SortByRequired.golden
@@ -37,12 +37,12 @@ module "foo_bar" {
 | map-2 | It's map number two. | `map` | n/a |
 | string-2 | It's string number two. | `string` | n/a |
 | unquoted | n/a | `any` | n/a |
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre> | `list` | <pre>[<br>  "name rack:location"<br>]<br></pre> |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| list-1 | It's list number one. | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre> |
 | list-3 | n/a | `list` | `[]` |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
-| map-1 | It's map number one. | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre> |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre> |
 | map-3 | n/a | `map` | `{}` |
 | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` |
 | string-1 | It's string number one. | `string` | `"bar"` |

--- a/internal/pkg/print/markdown/table/testdata/table-WithRequired.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-WithRequired.golden
@@ -38,14 +38,14 @@ module "foo_bar" {
 | string-1 | It's string number one. | `string` | `"bar"` | no |
 | map-3 | n/a | `map` | `{}` | no |
 | map-2 | It's map number two. | `map` | n/a | yes |
-| map-1 | It's map number one. | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> | no |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre> | no |
 | list-3 | n/a | `list` | `[]` | no |
 | list-2 | It's list number two. | `list` | n/a | yes |
-| list-1 | It's list number one. | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> | no |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre> | no |
 | input_with_underscores | A variable with underscores. | `any` | n/a | yes |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` | no |
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> | no |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> | no |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre> | `list` | <pre>[<br>  "name rack:location"<br>]<br></pre> | no |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre> | no |
 | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` | no |
 
 ## Outputs

--- a/internal/pkg/print/markdown/table/testdata/table.golden
+++ b/internal/pkg/print/markdown/table/testdata/table.golden
@@ -38,14 +38,14 @@ module "foo_bar" {
 | string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | It's map number one. | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | It's list number one. | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre> |
 | input_with_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre> | `list` | <pre>[<br>  "name rack:location"<br>]<br></pre> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre> |
 | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` |
 
 ## Outputs


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

Multi-lines block of code in `markdown table` format is being wrapped inside `<code><pre> ... </pre></code>` which seems to cause rendering issues in different Markdown Rendering Engines (e.g. GitHub has serious issues with this, but GitLab has limited issue, etc.) see https://github.com/segmentio/terraform-docs/issues/138#issuecomment-570936597 .

Removing `<code> ... </code>` wrap seems to fix this issue in different platforms. (this is still being validated but looks good at the moment)

### Issues Resolved

Fixes #138 

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [x] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
