### PR TITLE
Show empty JSON properties, as 'null' for all types

### DIFF
--- a/internal/pkg/print/json/testdata/json-EscapeCharacters.golden
+++ b/internal/pkg/print/json/testdata/json-EscapeCharacters.golden
@@ -4,13 +4,13 @@
     {
       "name": "unquoted",
       "type": "any",
-      "description": "",
+      "description": null,
       "default": null
     },
     {
       "name": "string-3",
       "type": "string",
-      "description": "",
+      "description": null,
       "default": "\"\""
     },
     {
@@ -28,7 +28,7 @@
     {
       "name": "map-3",
       "type": "map",
-      "description": "",
+      "description": null,
       "default": "{}"
     },
     {
@@ -46,7 +46,7 @@
     {
       "name": "list-3",
       "type": "list",
-      "description": "",
+      "description": null,
       "default": "[]"
     },
     {
@@ -112,10 +112,13 @@
   ],
   "providers": [
     {
-      "name": "tls"
+      "name": "tls",
+      "alias": null,
+      "version": null
     },
     {
       "name": "aws",
+      "alias": null,
       "version": "\u003e= 2.15.0"
     },
     {
@@ -124,7 +127,9 @@
       "version": "\u003e= 2.15.0"
     },
     {
-      "name": "null"
+      "name": "null",
+      "alias": null,
+      "version": null
     }
   ]
 }

--- a/internal/pkg/print/json/testdata/json-NoHeader.golden
+++ b/internal/pkg/print/json/testdata/json-NoHeader.golden
@@ -4,13 +4,13 @@
     {
       "name": "unquoted",
       "type": "any",
-      "description": "",
+      "description": null,
       "default": null
     },
     {
       "name": "string-3",
       "type": "string",
-      "description": "",
+      "description": null,
       "default": "\"\""
     },
     {
@@ -28,7 +28,7 @@
     {
       "name": "map-3",
       "type": "map",
-      "description": "",
+      "description": null,
       "default": "{}"
     },
     {
@@ -46,7 +46,7 @@
     {
       "name": "list-3",
       "type": "list",
-      "description": "",
+      "description": null,
       "default": "[]"
     },
     {
@@ -112,10 +112,13 @@
   ],
   "providers": [
     {
-      "name": "tls"
+      "name": "tls",
+      "alias": null,
+      "version": null
     },
     {
       "name": "aws",
+      "alias": null,
       "version": ">= 2.15.0"
     },
     {
@@ -124,7 +127,9 @@
       "version": ">= 2.15.0"
     },
     {
-      "name": "null"
+      "name": "null",
+      "alias": null,
+      "version": null
     }
   ]
 }

--- a/internal/pkg/print/json/testdata/json-NoInputs.golden
+++ b/internal/pkg/print/json/testdata/json-NoInputs.golden
@@ -21,10 +21,13 @@
   ],
   "providers": [
     {
-      "name": "tls"
+      "name": "tls",
+      "alias": null,
+      "version": null
     },
     {
       "name": "aws",
+      "alias": null,
       "version": ">= 2.15.0"
     },
     {
@@ -33,7 +36,9 @@
       "version": ">= 2.15.0"
     },
     {
-      "name": "null"
+      "name": "null",
+      "alias": null,
+      "version": null
     }
   ]
 }

--- a/internal/pkg/print/json/testdata/json-NoOutputs.golden
+++ b/internal/pkg/print/json/testdata/json-NoOutputs.golden
@@ -4,13 +4,13 @@
     {
       "name": "unquoted",
       "type": "any",
-      "description": "",
+      "description": null,
       "default": null
     },
     {
       "name": "string-3",
       "type": "string",
-      "description": "",
+      "description": null,
       "default": "\"\""
     },
     {
@@ -28,7 +28,7 @@
     {
       "name": "map-3",
       "type": "map",
-      "description": "",
+      "description": null,
       "default": "{}"
     },
     {
@@ -46,7 +46,7 @@
     {
       "name": "list-3",
       "type": "list",
-      "description": "",
+      "description": null,
       "default": "[]"
     },
     {
@@ -95,10 +95,13 @@
   "outputs": [],
   "providers": [
     {
-      "name": "tls"
+      "name": "tls",
+      "alias": null,
+      "version": null
     },
     {
       "name": "aws",
+      "alias": null,
       "version": ">= 2.15.0"
     },
     {
@@ -107,7 +110,9 @@
       "version": ">= 2.15.0"
     },
     {
-      "name": "null"
+      "name": "null",
+      "alias": null,
+      "version": null
     }
   ]
 }

--- a/internal/pkg/print/json/testdata/json-NoProviders.golden
+++ b/internal/pkg/print/json/testdata/json-NoProviders.golden
@@ -4,13 +4,13 @@
     {
       "name": "unquoted",
       "type": "any",
-      "description": "",
+      "description": null,
       "default": null
     },
     {
       "name": "string-3",
       "type": "string",
-      "description": "",
+      "description": null,
       "default": "\"\""
     },
     {
@@ -28,7 +28,7 @@
     {
       "name": "map-3",
       "type": "map",
-      "description": "",
+      "description": null,
       "default": "{}"
     },
     {
@@ -46,7 +46,7 @@
     {
       "name": "list-3",
       "type": "list",
-      "description": "",
+      "description": null,
       "default": "[]"
     },
     {

--- a/internal/pkg/print/json/testdata/json-OnlyInputs.golden
+++ b/internal/pkg/print/json/testdata/json-OnlyInputs.golden
@@ -4,13 +4,13 @@
     {
       "name": "unquoted",
       "type": "any",
-      "description": "",
+      "description": null,
       "default": null
     },
     {
       "name": "string-3",
       "type": "string",
-      "description": "",
+      "description": null,
       "default": "\"\""
     },
     {
@@ -28,7 +28,7 @@
     {
       "name": "map-3",
       "type": "map",
-      "description": "",
+      "description": null,
       "default": "{}"
     },
     {
@@ -46,7 +46,7 @@
     {
       "name": "list-3",
       "type": "list",
-      "description": "",
+      "description": null,
       "default": "[]"
     },
     {

--- a/internal/pkg/print/json/testdata/json-OnlyProviders.golden
+++ b/internal/pkg/print/json/testdata/json-OnlyProviders.golden
@@ -4,10 +4,13 @@
   "outputs": [],
   "providers": [
     {
-      "name": "tls"
+      "name": "tls",
+      "alias": null,
+      "version": null
     },
     {
       "name": "aws",
+      "alias": null,
       "version": ">= 2.15.0"
     },
     {
@@ -16,7 +19,9 @@
       "version": ">= 2.15.0"
     },
     {
-      "name": "null"
+      "name": "null",
+      "alias": null,
+      "version": null
     }
   ]
 }

--- a/internal/pkg/print/json/testdata/json-SortByName.golden
+++ b/internal/pkg/print/json/testdata/json-SortByName.golden
@@ -34,7 +34,7 @@
     {
       "name": "list-3",
       "type": "list",
-      "description": "",
+      "description": null,
       "default": "[]"
     },
     {
@@ -58,7 +58,7 @@
     {
       "name": "map-3",
       "type": "map",
-      "description": "",
+      "description": null,
       "default": "{}"
     },
     {
@@ -82,13 +82,13 @@
     {
       "name": "string-3",
       "type": "string",
-      "description": "",
+      "description": null,
       "default": "\"\""
     },
     {
       "name": "unquoted",
       "type": "any",
-      "description": "",
+      "description": null,
       "default": null
     }
   ],
@@ -113,6 +113,7 @@
   "providers": [
     {
       "name": "aws",
+      "alias": null,
       "version": ">= 2.15.0"
     },
     {
@@ -121,10 +122,14 @@
       "version": ">= 2.15.0"
     },
     {
-      "name": "null"
+      "name": "null",
+      "alias": null,
+      "version": null
     },
     {
-      "name": "tls"
+      "name": "tls",
+      "alias": null,
+      "version": null
     }
   ]
 }

--- a/internal/pkg/print/json/testdata/json-SortByRequired.golden
+++ b/internal/pkg/print/json/testdata/json-SortByRequired.golden
@@ -28,7 +28,7 @@
     {
       "name": "unquoted",
       "type": "any",
-      "description": "",
+      "description": null,
       "default": null
     },
     {
@@ -52,7 +52,7 @@
     {
       "name": "list-3",
       "type": "list",
-      "description": "",
+      "description": null,
       "default": "[]"
     },
     {
@@ -70,7 +70,7 @@
     {
       "name": "map-3",
       "type": "map",
-      "description": "",
+      "description": null,
       "default": "{}"
     },
     {
@@ -88,7 +88,7 @@
     {
       "name": "string-3",
       "type": "string",
-      "description": "",
+      "description": null,
       "default": "\"\""
     }
   ],
@@ -113,6 +113,7 @@
   "providers": [
     {
       "name": "aws",
+      "alias": null,
       "version": ">= 2.15.0"
     },
     {
@@ -121,10 +122,14 @@
       "version": ">= 2.15.0"
     },
     {
-      "name": "null"
+      "name": "null",
+      "alias": null,
+      "version": null
     },
     {
-      "name": "tls"
+      "name": "tls",
+      "alias": null,
+      "version": null
     }
   ]
 }

--- a/internal/pkg/print/json/testdata/json.golden
+++ b/internal/pkg/print/json/testdata/json.golden
@@ -4,13 +4,13 @@
     {
       "name": "unquoted",
       "type": "any",
-      "description": "",
+      "description": null,
       "default": null
     },
     {
       "name": "string-3",
       "type": "string",
-      "description": "",
+      "description": null,
       "default": "\"\""
     },
     {
@@ -28,7 +28,7 @@
     {
       "name": "map-3",
       "type": "map",
-      "description": "",
+      "description": null,
       "default": "{}"
     },
     {
@@ -46,7 +46,7 @@
     {
       "name": "list-3",
       "type": "list",
-      "description": "",
+      "description": null,
       "default": "[]"
     },
     {
@@ -112,10 +112,13 @@
   ],
   "providers": [
     {
-      "name": "tls"
+      "name": "tls",
+      "alias": null,
+      "version": null
     },
     {
       "name": "aws",
+      "alias": null,
       "version": ">= 2.15.0"
     },
     {
@@ -124,7 +127,9 @@
       "version": ">= 2.15.0"
     },
     {
-      "name": "null"
+      "name": "null",
+      "alias": null,
+      "version": null
     }
   ]
 }

--- a/internal/pkg/print/markdown/document/document.go
+++ b/internal/pkg/print/markdown/document/document.go
@@ -43,7 +43,7 @@ func getInputType(input *tfconf.Input) string {
 	var result = ""
 	var extraline = false
 
-	if result, extraline = markdown.PrintFencedCodeBlock(input.Type, "hcl"); !extraline {
+	if result, extraline = markdown.PrintFencedCodeBlock(string(input.Type), "hcl"); !extraline {
 		result += "\n"
 	}
 	return result
@@ -54,7 +54,7 @@ func getInputValue(input *tfconf.Input) string {
 	var extraline = false
 
 	if input.HasDefault() {
-		if result, extraline = markdown.PrintFencedCodeBlock(*input.Default, "json"); !extraline {
+		if result, extraline = markdown.PrintFencedCodeBlock(string(input.Default), "json"); !extraline {
 			result += "\n"
 		}
 	}
@@ -64,7 +64,7 @@ func getInputValue(input *tfconf.Input) string {
 func printInput(buffer *bytes.Buffer, input *tfconf.Input, settings *print.Settings) {
 	buffer.WriteString("\n")
 	buffer.WriteString(fmt.Sprintf("%s %s\n\n", markdown.GenerateIndentation(1, settings), markdown.SanitizeName(input.Name, settings)))
-	buffer.WriteString(fmt.Sprintf("Description: %s\n\n", markdown.SanitizeItemForDocument(input.Description, settings)))
+	buffer.WriteString(fmt.Sprintf("Description: %s\n\n", markdown.SanitizeItemForDocument(string(input.Description), settings)))
 	buffer.WriteString(fmt.Sprintf("Type: %s", getInputType(input)))
 
 	// Don't print defaults for required inputs when we're already explicit about it being required
@@ -167,6 +167,6 @@ func printOutputs(buffer *bytes.Buffer, outputs []*tfconf.Output, settings *prin
 	for _, output := range outputs {
 		buffer.WriteString("\n")
 		buffer.WriteString(fmt.Sprintf("%s %s\n\n", markdown.GenerateIndentation(1, settings), markdown.SanitizeName(output.Name, settings)))
-		buffer.WriteString(fmt.Sprintf("Description: %s\n", markdown.SanitizeItemForDocument(output.Description, settings)))
+		buffer.WriteString(fmt.Sprintf("Description: %s\n", markdown.SanitizeItemForDocument(string(output.Description), settings)))
 	}
 }

--- a/internal/pkg/print/markdown/table/table.go
+++ b/internal/pkg/print/markdown/table/table.go
@@ -34,13 +34,13 @@ func Print(module *tfconf.Module, settings *print.Settings) (string, error) {
 func getProviderVersion(provider *tfconf.Provider) string {
 	var result = "n/a"
 	if provider.Version != "" {
-		result = provider.Version
+		result = string(provider.Version)
 	}
 	return result
 }
 
 func getInputType(input *tfconf.Input) string {
-	inputType, _ := markdown.PrintFencedCodeBlock(input.Type, "")
+	inputType, _ := markdown.PrintFencedCodeBlock(string(input.Type), "")
 	return inputType
 }
 
@@ -48,7 +48,7 @@ func getInputValue(input *tfconf.Input) string {
 	var result = "n/a"
 
 	if input.HasDefault() {
-		result, _ = markdown.PrintFencedCodeBlock(*input.Default, "")
+		result, _ = markdown.PrintFencedCodeBlock(string(input.Default), "")
 	}
 	return result
 }
@@ -120,7 +120,7 @@ func printInputs(buffer *bytes.Buffer, inputs []*tfconf.Input, settings *print.S
 			fmt.Sprintf(
 				"| %s | %s | %s | %s |",
 				markdown.SanitizeName(input.Name, settings),
-				markdown.SanitizeItemForTable(input.Description, settings),
+				markdown.SanitizeItemForTable(string(input.Description), settings),
 				markdown.SanitizeItemForTable(getInputType(input), settings),
 				markdown.SanitizeItemForTable(getInputValue(input), settings),
 			),
@@ -151,7 +151,7 @@ func printOutputs(buffer *bytes.Buffer, outputs []*tfconf.Output, settings *prin
 			fmt.Sprintf(
 				"| %s | %s |\n",
 				markdown.SanitizeName(output.Name, settings),
-				markdown.SanitizeItemForTable(output.Description, settings),
+				markdown.SanitizeItemForTable(string(output.Description), settings),
 			),
 		)
 	}

--- a/internal/pkg/print/pretty/pretty.go
+++ b/internal/pkg/print/pretty/pretty.go
@@ -43,7 +43,7 @@ func getInputDefaultValue(input *tfconf.Input, settings *print.Settings) string 
 	var result = "required"
 
 	if input.HasDefault() {
-		result = *input.Default
+		result = string(input.Default)
 	}
 
 	return result
@@ -117,7 +117,7 @@ func printInputs(buffer *bytes.Buffer, inputs []*tfconf.Input, settings *print.S
 				format,
 				input.Name,
 				getInputDefaultValue(input, settings),
-				getDescription(input.Description),
+				getDescription(string(input.Description)),
 			),
 		)
 	}
@@ -137,7 +137,7 @@ func printOutputs(buffer *bytes.Buffer, outputs []*tfconf.Output, settings *prin
 			fmt.Sprintf(
 				format,
 				output.Name,
-				getDescription(output.Description),
+				getDescription(string(output.Description)),
 			),
 		)
 	}

--- a/internal/pkg/tfconf/input.go
+++ b/internal/pkg/tfconf/input.go
@@ -3,15 +3,15 @@ package tfconf
 // Input represents a Terraform input.
 type Input struct {
 	Name        string   `json:"name"`
-	Type        string   `json:"type"`
-	Description string   `json:"description"`
-	Default     *string  `json:"default"`
+	Type        String   `json:"type"`
+	Description String   `json:"description"`
+	Default     String   `json:"default"`
 	Position    Position `json:"-"`
 }
 
 // HasDefault indicates if a Terraform variable has a default value set.
 func (i *Input) HasDefault() bool {
-	return i.Default != nil
+	return i.Default != ""
 }
 
 type inputsSortedByName []*Input

--- a/internal/pkg/tfconf/module.go
+++ b/internal/pkg/tfconf/module.go
@@ -83,13 +83,13 @@ func CreateModule(path string) (*Module, error) {
 			inputType = "any"
 		}
 
-		var defaultValue = new(string)
+		var defaultValue string
 		if input.Default != nil {
 			marshaled, err := json.MarshalIndent(input.Default, "", "  ")
 			if err != nil {
 				return nil, err
 			}
-			*defaultValue = string(marshaled)
+			defaultValue = string(marshaled)
 
 			if inputType == "any" {
 				switch xType := fmt.Sprintf("%T", input.Default); xType {
@@ -105,8 +105,6 @@ func CreateModule(path string) (*Module, error) {
 					inputType = "map"
 				}
 			}
-		} else {
-			defaultValue = nil
 		}
 
 		inputDescription := input.Description
@@ -116,9 +114,9 @@ func CreateModule(path string) (*Module, error) {
 
 		i := &Input{
 			Name:        input.Name,
-			Type:        inputType,
-			Description: inputDescription,
-			Default:     defaultValue,
+			Type:        String(inputType),
+			Description: String(inputDescription),
+			Default:     String(defaultValue),
 			Position: Position{
 				Filename: input.Pos.Filename,
 				Line:     input.Pos.Line,
@@ -141,7 +139,7 @@ func CreateModule(path string) (*Module, error) {
 		}
 		outputs = append(outputs, &Output{
 			Name:        output.Name,
-			Description: outputDescription,
+			Description: String(outputDescription),
 			Position: Position{
 				Filename: output.Pos.Filename,
 				Line:     output.Pos.Line,
@@ -179,14 +177,14 @@ func loadProviders(requiredProviders map[string]*tfconfig.ProviderRequirement, r
 	for _, resource := range resources {
 		for _, r := range resource {
 			var version = ""
-			if requiredVersion, ok := requiredProviders[r.Provider.Name]; ok {
+			if requiredVersion, ok := requiredProviders[r.Provider.Name]; ok && len(requiredVersion.VersionConstraints) > 0 {
 				version = strings.Join(requiredVersion.VersionConstraints, " ")
 			}
 			key := fmt.Sprintf("%s.%s", r.Provider.Name, r.Provider.Alias)
 			providers[key] = &Provider{
 				Name:    r.Provider.Name,
-				Alias:   r.Provider.Alias,
-				Version: version,
+				Alias:   String(r.Provider.Alias),
+				Version: String(version),
 				Position: Position{
 					Filename: r.Pos.Filename,
 					Line:     r.Pos.Line,

--- a/internal/pkg/tfconf/output.go
+++ b/internal/pkg/tfconf/output.go
@@ -3,7 +3,7 @@ package tfconf
 // Output represents a Terraform output.
 type Output struct {
 	Name        string   `json:"name"`
-	Description string   `json:"description,omitempty"`
+	Description String   `json:"description"`
 	Position    Position `json:"-"`
 }
 

--- a/internal/pkg/tfconf/provider.go
+++ b/internal/pkg/tfconf/provider.go
@@ -7,14 +7,14 @@ import (
 // Provider represents a Terraform output.
 type Provider struct {
 	Name     string   `json:"name"`
-	Alias    string   `json:"alias,omitempty"`
-	Version  string   `json:"version,omitempty"`
+	Alias    String   `json:"alias"`
+	Version  String   `json:"version"`
 	Position Position `json:"-"`
 }
 
 // GetName returns full name of the provider, with alias if available
 func (p *Provider) GetName() string {
-	if len(p.Alias) > 0 {
+	if p.Alias != "" {
 		return fmt.Sprintf("%s.%s", p.Name, p.Alias)
 	}
 	return p.Name

--- a/internal/pkg/tfconf/string.go
+++ b/internal/pkg/tfconf/string.go
@@ -6,7 +6,7 @@ import (
 )
 
 // String represents a 'string' value which
-// JSON marshalled to `null` when empty
+// JSON marshaled to `null` when empty
 type String string
 
 // MarshalJSON custom marshal function which

--- a/internal/pkg/tfconf/string.go
+++ b/internal/pkg/tfconf/string.go
@@ -1,0 +1,42 @@
+package tfconf
+
+import (
+	"bytes"
+	"strings"
+)
+
+// String represents a 'string' value which
+// JSON marshalled to `null` when empty
+type String string
+
+// MarshalJSON custom marshal function which
+// sets the value to literal `null` when empty
+func (s String) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	if len(string(s)) == 0 {
+		buf.WriteString(`null`)
+	} else {
+		normalize := string(s)
+		normalize = strings.Replace(normalize, "\n", "\\n", -1)
+		normalize = strings.Replace(normalize, "\"", "\\\"", -1)
+		buf.WriteString(`"` + normalize + `"`) // add double quation mark as json format required
+	}
+	return buf.Bytes(), nil
+}
+
+// UnmarshalJSON custom unmarshal function which
+// sets the value to `""` when the json property
+// is `null`
+func (s *String) UnmarshalJSON(in []byte) error {
+	str := string(in)
+	if str == `null` {
+		*s = ""
+		return nil
+	}
+	res := String(str)
+	if len(res) >= 2 {
+		res = res[1 : len(res)-1] // remove the wrapped qutation
+	}
+	*s = res
+	return nil
+}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

This is an amendment of #160 . Setting empty properties in `outputs` and `providers` to `null` were missing in the original PR which was added here. Also This PR makes sure that if the property is `empty` it sets it to `null` rather than `""` (empty string)

### Issues Resolved

Related to #158 

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [ ] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
