### PR TITLE
Add double space at the end of multi-lines paragraph

### DIFF
--- a/internal/pkg/print/markdown/markdown.go
+++ b/internal/pkg/print/markdown/markdown.go
@@ -23,6 +23,9 @@ func Sanitize(markdown string) string {
 	// Preserve double spaces at the end of the line
 	result = regexp.MustCompile(`‡‡(\r?\n)`).ReplaceAllString(result, "  $1")
 
+	// Remove blank line with only double spaces in it
+	result = regexp.MustCompile(`(\r?\n)  (\r?\n)`).ReplaceAllString(result, "$1")
+
 	// Remove multiple consecutive blank lines
 	result = regexp.MustCompile(`(\r?\n){3,}`).ReplaceAllString(result, "$1$1")
 	result = regexp.MustCompile(`(\r?\n){2,}$`).ReplaceAllString(result, "$1")
@@ -93,6 +96,11 @@ func ConvertMultiLineText(s string, convertDoubleSpaces bool) string {
 		"<br><br>",
 		-1,
 	)
+
+	// Convert linebreak followed by another line into space-space-newline
+	// which is a know convention of Markdown for multiline paragprah.
+	s = strings.Replace(s, "\n", "  \n", -1)
+	s = strings.Replace(s, "    \n", "  \n", -1)
 
 	if convertDoubleSpaces {
 		// Convert space-space-newline to <br>


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

This PR normalizes multi-lines paragraph into known Markdown convention and adds `<space><space>` at the end of each line.

### Issues Resolved

Fixes #167 

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [ ] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
