### PR TITLE
Show native map and list as default value in JSON

### DIFF
--- a/docs/formats/json.md
+++ b/docs/formats/json.md
@@ -41,13 +41,15 @@ generates the following output:
       "name": "input-with-code-block",
       "type": "list",
       "description": "This is a complicated one. We need a newline.  \nAnd an example in a code block\n```\ndefault     = [\n  \"machine rack01:neptune\"\n]\n```\n",
-      "default": "[\n  \"name rack:location\"\n]"
+      "default": [
+        "name rack:location"
+      ]
     },
     {
       "name": "input-with-pipe",
       "type": "string",
       "description": "It includes v1 | v2 | v3",
-      "default": "\"v1\""
+      "default": "v1"
     },
     {
       "name": "input_with_underscores",
@@ -59,7 +61,11 @@ generates the following output:
       "name": "list-1",
       "type": "list",
       "description": "It's list number one.",
-      "default": "[\n  \"a\",\n  \"b\",\n  \"c\"\n]"
+      "default": [
+        "a",
+        "b",
+        "c"
+      ]
     },
     {
       "name": "list-2",
@@ -71,19 +77,38 @@ generates the following output:
       "name": "list-3",
       "type": "list",
       "description": null,
-      "default": "[]"
+      "default": []
     },
     {
       "name": "long_type",
       "type": "object({\n    name = string,\n    foo  = object({ foo = string, bar = string }),\n    bar  = object({ foo = string, bar = string }),\n    fizz = list(string),\n    buzz = list(string)\n  })",
       "description": "This description is itself markdown.\n\nIt spans over multiple lines.\n",
-      "default": "{\n  \"bar\": {\n    \"bar\": \"bar\",\n    \"foo\": \"bar\"\n  },\n  \"buzz\": [\n    \"fizz\",\n    \"buzz\"\n  ],\n  \"fizz\": [],\n  \"foo\": {\n    \"bar\": \"foo\",\n    \"foo\": \"foo\"\n  },\n  \"name\": \"hello\"\n}"
+      "default": {
+        "bar": {
+          "bar": "bar",
+          "foo": "bar"
+        },
+        "buzz": [
+          "fizz",
+          "buzz"
+        ],
+        "fizz": [],
+        "foo": {
+          "bar": "foo",
+          "foo": "foo"
+        },
+        "name": "hello"
+      }
     },
     {
       "name": "map-1",
       "type": "map",
       "description": "It's map number one.",
-      "default": "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3\n}"
+      "default": {
+        "a": 1,
+        "b": 2,
+        "c": 3
+      }
     },
     {
       "name": "map-2",
@@ -95,19 +120,19 @@ generates the following output:
       "name": "map-3",
       "type": "map",
       "description": null,
-      "default": "{}"
+      "default": {}
     },
     {
       "name": "no-escape-default-value",
       "type": "string",
       "description": "The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'.",
-      "default": "\"VALUE_WITH_UNDERSCORE\""
+      "default": "VALUE_WITH_UNDERSCORE"
     },
     {
       "name": "string-1",
       "type": "string",
       "description": "It's string number one.",
-      "default": "\"bar\""
+      "default": "bar"
     },
     {
       "name": "string-2",
@@ -119,7 +144,7 @@ generates the following output:
       "name": "string-3",
       "type": "string",
       "description": null,
-      "default": "\"\""
+      "default": ""
     },
     {
       "name": "unquoted",
@@ -131,7 +156,7 @@ generates the following output:
       "name": "with-url",
       "type": "string",
       "description": "The description contains url. https://www.domain.com/foo/bar_baz.html",
-      "default": "\"\""
+      "default": ""
     }
   ],
   "outputs": [

--- a/internal/pkg/print/json/testdata/json-EscapeCharacters.golden
+++ b/internal/pkg/print/json/testdata/json-EscapeCharacters.golden
@@ -11,7 +11,7 @@
       "name": "string-3",
       "type": "string",
       "description": null,
-      "default": "\"\""
+      "default": ""
     },
     {
       "name": "string-2",
@@ -23,13 +23,13 @@
       "name": "string-1",
       "type": "string",
       "description": "It's string number one.",
-      "default": "\"bar\""
+      "default": "bar"
     },
     {
       "name": "map-3",
       "type": "map",
       "description": null,
-      "default": "{}"
+      "default": {}
     },
     {
       "name": "map-2",
@@ -41,13 +41,17 @@
       "name": "map-1",
       "type": "map",
       "description": "It's map number one.",
-      "default": "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3\n}"
+      "default": {
+        "a": 1,
+        "b": 2,
+        "c": 3
+      }
     },
     {
       "name": "list-3",
       "type": "list",
       "description": null,
-      "default": "[]"
+      "default": []
     },
     {
       "name": "list-2",
@@ -59,7 +63,11 @@
       "name": "list-1",
       "type": "list",
       "description": "It's list number one.",
-      "default": "[\n  \"a\",\n  \"b\",\n  \"c\"\n]"
+      "default": [
+        "a",
+        "b",
+        "c"
+      ]
     },
     {
       "name": "input_with_underscores",
@@ -71,31 +79,48 @@
       "name": "input-with-pipe",
       "type": "string",
       "description": "It includes v1 | v2 | v3",
-      "default": "\"v1\""
+      "default": "v1"
     },
     {
       "name": "input-with-code-block",
       "type": "list",
       "description": "This is a complicated one. We need a newline.  \nAnd an example in a code block\n```\ndefault     = [\n  \"machine rack01:neptune\"\n]\n```\n",
-      "default": "[\n  \"name rack:location\"\n]"
+      "default": [
+        "name rack:location"
+      ]
     },
     {
       "name": "long_type",
       "type": "object({\n    name = string,\n    foo  = object({ foo = string, bar = string }),\n    bar  = object({ foo = string, bar = string }),\n    fizz = list(string),\n    buzz = list(string)\n  })",
       "description": "This description is itself markdown.\n\nIt spans over multiple lines.\n",
-      "default": "{\n  \"bar\": {\n    \"bar\": \"bar\",\n    \"foo\": \"bar\"\n  },\n  \"buzz\": [\n    \"fizz\",\n    \"buzz\"\n  ],\n  \"fizz\": [],\n  \"foo\": {\n    \"bar\": \"foo\",\n    \"foo\": \"foo\"\n  },\n  \"name\": \"hello\"\n}"
+      "default": {
+        "bar": {
+          "bar": "bar",
+          "foo": "bar"
+        },
+        "buzz": [
+          "fizz",
+          "buzz"
+        ],
+        "fizz": [],
+        "foo": {
+          "bar": "foo",
+          "foo": "foo"
+        },
+        "name": "hello"
+      }
     },
     {
       "name": "no-escape-default-value",
       "type": "string",
       "description": "The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'.",
-      "default": "\"VALUE_WITH_UNDERSCORE\""
+      "default": "VALUE_WITH_UNDERSCORE"
     },
     {
       "name": "with-url",
       "type": "string",
       "description": "The description contains url. https://www.domain.com/foo/bar_baz.html",
-      "default": "\"\""
+      "default": ""
     }
   ],
   "outputs": [

--- a/internal/pkg/print/json/testdata/json-NoHeader.golden
+++ b/internal/pkg/print/json/testdata/json-NoHeader.golden
@@ -11,7 +11,7 @@
       "name": "string-3",
       "type": "string",
       "description": null,
-      "default": "\"\""
+      "default": ""
     },
     {
       "name": "string-2",
@@ -23,13 +23,13 @@
       "name": "string-1",
       "type": "string",
       "description": "It's string number one.",
-      "default": "\"bar\""
+      "default": "bar"
     },
     {
       "name": "map-3",
       "type": "map",
       "description": null,
-      "default": "{}"
+      "default": {}
     },
     {
       "name": "map-2",
@@ -41,13 +41,17 @@
       "name": "map-1",
       "type": "map",
       "description": "It's map number one.",
-      "default": "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3\n}"
+      "default": {
+        "a": 1,
+        "b": 2,
+        "c": 3
+      }
     },
     {
       "name": "list-3",
       "type": "list",
       "description": null,
-      "default": "[]"
+      "default": []
     },
     {
       "name": "list-2",
@@ -59,7 +63,11 @@
       "name": "list-1",
       "type": "list",
       "description": "It's list number one.",
-      "default": "[\n  \"a\",\n  \"b\",\n  \"c\"\n]"
+      "default": [
+        "a",
+        "b",
+        "c"
+      ]
     },
     {
       "name": "input_with_underscores",
@@ -71,31 +79,48 @@
       "name": "input-with-pipe",
       "type": "string",
       "description": "It includes v1 | v2 | v3",
-      "default": "\"v1\""
+      "default": "v1"
     },
     {
       "name": "input-with-code-block",
       "type": "list",
       "description": "This is a complicated one. We need a newline.  \nAnd an example in a code block\n```\ndefault     = [\n  \"machine rack01:neptune\"\n]\n```\n",
-      "default": "[\n  \"name rack:location\"\n]"
+      "default": [
+        "name rack:location"
+      ]
     },
     {
       "name": "long_type",
       "type": "object({\n    name = string,\n    foo  = object({ foo = string, bar = string }),\n    bar  = object({ foo = string, bar = string }),\n    fizz = list(string),\n    buzz = list(string)\n  })",
       "description": "This description is itself markdown.\n\nIt spans over multiple lines.\n",
-      "default": "{\n  \"bar\": {\n    \"bar\": \"bar\",\n    \"foo\": \"bar\"\n  },\n  \"buzz\": [\n    \"fizz\",\n    \"buzz\"\n  ],\n  \"fizz\": [],\n  \"foo\": {\n    \"bar\": \"foo\",\n    \"foo\": \"foo\"\n  },\n  \"name\": \"hello\"\n}"
+      "default": {
+        "bar": {
+          "bar": "bar",
+          "foo": "bar"
+        },
+        "buzz": [
+          "fizz",
+          "buzz"
+        ],
+        "fizz": [],
+        "foo": {
+          "bar": "foo",
+          "foo": "foo"
+        },
+        "name": "hello"
+      }
     },
     {
       "name": "no-escape-default-value",
       "type": "string",
       "description": "The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'.",
-      "default": "\"VALUE_WITH_UNDERSCORE\""
+      "default": "VALUE_WITH_UNDERSCORE"
     },
     {
       "name": "with-url",
       "type": "string",
       "description": "The description contains url. https://www.domain.com/foo/bar_baz.html",
-      "default": "\"\""
+      "default": ""
     }
   ],
   "outputs": [

--- a/internal/pkg/print/json/testdata/json-NoOutputs.golden
+++ b/internal/pkg/print/json/testdata/json-NoOutputs.golden
@@ -11,7 +11,7 @@
       "name": "string-3",
       "type": "string",
       "description": null,
-      "default": "\"\""
+      "default": ""
     },
     {
       "name": "string-2",
@@ -23,13 +23,13 @@
       "name": "string-1",
       "type": "string",
       "description": "It's string number one.",
-      "default": "\"bar\""
+      "default": "bar"
     },
     {
       "name": "map-3",
       "type": "map",
       "description": null,
-      "default": "{}"
+      "default": {}
     },
     {
       "name": "map-2",
@@ -41,13 +41,17 @@
       "name": "map-1",
       "type": "map",
       "description": "It's map number one.",
-      "default": "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3\n}"
+      "default": {
+        "a": 1,
+        "b": 2,
+        "c": 3
+      }
     },
     {
       "name": "list-3",
       "type": "list",
       "description": null,
-      "default": "[]"
+      "default": []
     },
     {
       "name": "list-2",
@@ -59,7 +63,11 @@
       "name": "list-1",
       "type": "list",
       "description": "It's list number one.",
-      "default": "[\n  \"a\",\n  \"b\",\n  \"c\"\n]"
+      "default": [
+        "a",
+        "b",
+        "c"
+      ]
     },
     {
       "name": "input_with_underscores",
@@ -71,31 +79,48 @@
       "name": "input-with-pipe",
       "type": "string",
       "description": "It includes v1 | v2 | v3",
-      "default": "\"v1\""
+      "default": "v1"
     },
     {
       "name": "input-with-code-block",
       "type": "list",
       "description": "This is a complicated one. We need a newline.  \nAnd an example in a code block\n```\ndefault     = [\n  \"machine rack01:neptune\"\n]\n```\n",
-      "default": "[\n  \"name rack:location\"\n]"
+      "default": [
+        "name rack:location"
+      ]
     },
     {
       "name": "long_type",
       "type": "object({\n    name = string,\n    foo  = object({ foo = string, bar = string }),\n    bar  = object({ foo = string, bar = string }),\n    fizz = list(string),\n    buzz = list(string)\n  })",
       "description": "This description is itself markdown.\n\nIt spans over multiple lines.\n",
-      "default": "{\n  \"bar\": {\n    \"bar\": \"bar\",\n    \"foo\": \"bar\"\n  },\n  \"buzz\": [\n    \"fizz\",\n    \"buzz\"\n  ],\n  \"fizz\": [],\n  \"foo\": {\n    \"bar\": \"foo\",\n    \"foo\": \"foo\"\n  },\n  \"name\": \"hello\"\n}"
+      "default": {
+        "bar": {
+          "bar": "bar",
+          "foo": "bar"
+        },
+        "buzz": [
+          "fizz",
+          "buzz"
+        ],
+        "fizz": [],
+        "foo": {
+          "bar": "foo",
+          "foo": "foo"
+        },
+        "name": "hello"
+      }
     },
     {
       "name": "no-escape-default-value",
       "type": "string",
       "description": "The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'.",
-      "default": "\"VALUE_WITH_UNDERSCORE\""
+      "default": "VALUE_WITH_UNDERSCORE"
     },
     {
       "name": "with-url",
       "type": "string",
       "description": "The description contains url. https://www.domain.com/foo/bar_baz.html",
-      "default": "\"\""
+      "default": ""
     }
   ],
   "outputs": [],

--- a/internal/pkg/print/json/testdata/json-NoProviders.golden
+++ b/internal/pkg/print/json/testdata/json-NoProviders.golden
@@ -11,7 +11,7 @@
       "name": "string-3",
       "type": "string",
       "description": null,
-      "default": "\"\""
+      "default": ""
     },
     {
       "name": "string-2",
@@ -23,13 +23,13 @@
       "name": "string-1",
       "type": "string",
       "description": "It's string number one.",
-      "default": "\"bar\""
+      "default": "bar"
     },
     {
       "name": "map-3",
       "type": "map",
       "description": null,
-      "default": "{}"
+      "default": {}
     },
     {
       "name": "map-2",
@@ -41,13 +41,17 @@
       "name": "map-1",
       "type": "map",
       "description": "It's map number one.",
-      "default": "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3\n}"
+      "default": {
+        "a": 1,
+        "b": 2,
+        "c": 3
+      }
     },
     {
       "name": "list-3",
       "type": "list",
       "description": null,
-      "default": "[]"
+      "default": []
     },
     {
       "name": "list-2",
@@ -59,7 +63,11 @@
       "name": "list-1",
       "type": "list",
       "description": "It's list number one.",
-      "default": "[\n  \"a\",\n  \"b\",\n  \"c\"\n]"
+      "default": [
+        "a",
+        "b",
+        "c"
+      ]
     },
     {
       "name": "input_with_underscores",
@@ -71,31 +79,48 @@
       "name": "input-with-pipe",
       "type": "string",
       "description": "It includes v1 | v2 | v3",
-      "default": "\"v1\""
+      "default": "v1"
     },
     {
       "name": "input-with-code-block",
       "type": "list",
       "description": "This is a complicated one. We need a newline.  \nAnd an example in a code block\n```\ndefault     = [\n  \"machine rack01:neptune\"\n]\n```\n",
-      "default": "[\n  \"name rack:location\"\n]"
+      "default": [
+        "name rack:location"
+      ]
     },
     {
       "name": "long_type",
       "type": "object({\n    name = string,\n    foo  = object({ foo = string, bar = string }),\n    bar  = object({ foo = string, bar = string }),\n    fizz = list(string),\n    buzz = list(string)\n  })",
       "description": "This description is itself markdown.\n\nIt spans over multiple lines.\n",
-      "default": "{\n  \"bar\": {\n    \"bar\": \"bar\",\n    \"foo\": \"bar\"\n  },\n  \"buzz\": [\n    \"fizz\",\n    \"buzz\"\n  ],\n  \"fizz\": [],\n  \"foo\": {\n    \"bar\": \"foo\",\n    \"foo\": \"foo\"\n  },\n  \"name\": \"hello\"\n}"
+      "default": {
+        "bar": {
+          "bar": "bar",
+          "foo": "bar"
+        },
+        "buzz": [
+          "fizz",
+          "buzz"
+        ],
+        "fizz": [],
+        "foo": {
+          "bar": "foo",
+          "foo": "foo"
+        },
+        "name": "hello"
+      }
     },
     {
       "name": "no-escape-default-value",
       "type": "string",
       "description": "The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'.",
-      "default": "\"VALUE_WITH_UNDERSCORE\""
+      "default": "VALUE_WITH_UNDERSCORE"
     },
     {
       "name": "with-url",
       "type": "string",
       "description": "The description contains url. https://www.domain.com/foo/bar_baz.html",
-      "default": "\"\""
+      "default": ""
     }
   ],
   "outputs": [

--- a/internal/pkg/print/json/testdata/json-OnlyInputs.golden
+++ b/internal/pkg/print/json/testdata/json-OnlyInputs.golden
@@ -11,7 +11,7 @@
       "name": "string-3",
       "type": "string",
       "description": null,
-      "default": "\"\""
+      "default": ""
     },
     {
       "name": "string-2",
@@ -23,13 +23,13 @@
       "name": "string-1",
       "type": "string",
       "description": "It's string number one.",
-      "default": "\"bar\""
+      "default": "bar"
     },
     {
       "name": "map-3",
       "type": "map",
       "description": null,
-      "default": "{}"
+      "default": {}
     },
     {
       "name": "map-2",
@@ -41,13 +41,17 @@
       "name": "map-1",
       "type": "map",
       "description": "It's map number one.",
-      "default": "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3\n}"
+      "default": {
+        "a": 1,
+        "b": 2,
+        "c": 3
+      }
     },
     {
       "name": "list-3",
       "type": "list",
       "description": null,
-      "default": "[]"
+      "default": []
     },
     {
       "name": "list-2",
@@ -59,7 +63,11 @@
       "name": "list-1",
       "type": "list",
       "description": "It's list number one.",
-      "default": "[\n  \"a\",\n  \"b\",\n  \"c\"\n]"
+      "default": [
+        "a",
+        "b",
+        "c"
+      ]
     },
     {
       "name": "input_with_underscores",
@@ -71,31 +79,48 @@
       "name": "input-with-pipe",
       "type": "string",
       "description": "It includes v1 | v2 | v3",
-      "default": "\"v1\""
+      "default": "v1"
     },
     {
       "name": "input-with-code-block",
       "type": "list",
       "description": "This is a complicated one. We need a newline.  \nAnd an example in a code block\n```\ndefault     = [\n  \"machine rack01:neptune\"\n]\n```\n",
-      "default": "[\n  \"name rack:location\"\n]"
+      "default": [
+        "name rack:location"
+      ]
     },
     {
       "name": "long_type",
       "type": "object({\n    name = string,\n    foo  = object({ foo = string, bar = string }),\n    bar  = object({ foo = string, bar = string }),\n    fizz = list(string),\n    buzz = list(string)\n  })",
       "description": "This description is itself markdown.\n\nIt spans over multiple lines.\n",
-      "default": "{\n  \"bar\": {\n    \"bar\": \"bar\",\n    \"foo\": \"bar\"\n  },\n  \"buzz\": [\n    \"fizz\",\n    \"buzz\"\n  ],\n  \"fizz\": [],\n  \"foo\": {\n    \"bar\": \"foo\",\n    \"foo\": \"foo\"\n  },\n  \"name\": \"hello\"\n}"
+      "default": {
+        "bar": {
+          "bar": "bar",
+          "foo": "bar"
+        },
+        "buzz": [
+          "fizz",
+          "buzz"
+        ],
+        "fizz": [],
+        "foo": {
+          "bar": "foo",
+          "foo": "foo"
+        },
+        "name": "hello"
+      }
     },
     {
       "name": "no-escape-default-value",
       "type": "string",
       "description": "The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'.",
-      "default": "\"VALUE_WITH_UNDERSCORE\""
+      "default": "VALUE_WITH_UNDERSCORE"
     },
     {
       "name": "with-url",
       "type": "string",
       "description": "The description contains url. https://www.domain.com/foo/bar_baz.html",
-      "default": "\"\""
+      "default": ""
     }
   ],
   "outputs": [],

--- a/internal/pkg/print/json/testdata/json-SortByName.golden
+++ b/internal/pkg/print/json/testdata/json-SortByName.golden
@@ -5,13 +5,15 @@
       "name": "input-with-code-block",
       "type": "list",
       "description": "This is a complicated one. We need a newline.  \nAnd an example in a code block\n```\ndefault     = [\n  \"machine rack01:neptune\"\n]\n```\n",
-      "default": "[\n  \"name rack:location\"\n]"
+      "default": [
+        "name rack:location"
+      ]
     },
     {
       "name": "input-with-pipe",
       "type": "string",
       "description": "It includes v1 | v2 | v3",
-      "default": "\"v1\""
+      "default": "v1"
     },
     {
       "name": "input_with_underscores",
@@ -23,7 +25,11 @@
       "name": "list-1",
       "type": "list",
       "description": "It's list number one.",
-      "default": "[\n  \"a\",\n  \"b\",\n  \"c\"\n]"
+      "default": [
+        "a",
+        "b",
+        "c"
+      ]
     },
     {
       "name": "list-2",
@@ -35,19 +41,38 @@
       "name": "list-3",
       "type": "list",
       "description": null,
-      "default": "[]"
+      "default": []
     },
     {
       "name": "long_type",
       "type": "object({\n    name = string,\n    foo  = object({ foo = string, bar = string }),\n    bar  = object({ foo = string, bar = string }),\n    fizz = list(string),\n    buzz = list(string)\n  })",
       "description": "This description is itself markdown.\n\nIt spans over multiple lines.\n",
-      "default": "{\n  \"bar\": {\n    \"bar\": \"bar\",\n    \"foo\": \"bar\"\n  },\n  \"buzz\": [\n    \"fizz\",\n    \"buzz\"\n  ],\n  \"fizz\": [],\n  \"foo\": {\n    \"bar\": \"foo\",\n    \"foo\": \"foo\"\n  },\n  \"name\": \"hello\"\n}"
+      "default": {
+        "bar": {
+          "bar": "bar",
+          "foo": "bar"
+        },
+        "buzz": [
+          "fizz",
+          "buzz"
+        ],
+        "fizz": [],
+        "foo": {
+          "bar": "foo",
+          "foo": "foo"
+        },
+        "name": "hello"
+      }
     },
     {
       "name": "map-1",
       "type": "map",
       "description": "It's map number one.",
-      "default": "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3\n}"
+      "default": {
+        "a": 1,
+        "b": 2,
+        "c": 3
+      }
     },
     {
       "name": "map-2",
@@ -59,19 +84,19 @@
       "name": "map-3",
       "type": "map",
       "description": null,
-      "default": "{}"
+      "default": {}
     },
     {
       "name": "no-escape-default-value",
       "type": "string",
       "description": "The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'.",
-      "default": "\"VALUE_WITH_UNDERSCORE\""
+      "default": "VALUE_WITH_UNDERSCORE"
     },
     {
       "name": "string-1",
       "type": "string",
       "description": "It's string number one.",
-      "default": "\"bar\""
+      "default": "bar"
     },
     {
       "name": "string-2",
@@ -83,7 +108,7 @@
       "name": "string-3",
       "type": "string",
       "description": null,
-      "default": "\"\""
+      "default": ""
     },
     {
       "name": "unquoted",
@@ -95,7 +120,7 @@
       "name": "with-url",
       "type": "string",
       "description": "The description contains url. https://www.domain.com/foo/bar_baz.html",
-      "default": "\"\""
+      "default": ""
     }
   ],
   "outputs": [

--- a/internal/pkg/print/json/testdata/json-SortByRequired.golden
+++ b/internal/pkg/print/json/testdata/json-SortByRequired.golden
@@ -35,67 +35,92 @@
       "name": "input-with-code-block",
       "type": "list",
       "description": "This is a complicated one. We need a newline.  \nAnd an example in a code block\n```\ndefault     = [\n  \"machine rack01:neptune\"\n]\n```\n",
-      "default": "[\n  \"name rack:location\"\n]"
+      "default": [
+        "name rack:location"
+      ]
     },
     {
       "name": "input-with-pipe",
       "type": "string",
       "description": "It includes v1 | v2 | v3",
-      "default": "\"v1\""
+      "default": "v1"
     },
     {
       "name": "list-1",
       "type": "list",
       "description": "It's list number one.",
-      "default": "[\n  \"a\",\n  \"b\",\n  \"c\"\n]"
+      "default": [
+        "a",
+        "b",
+        "c"
+      ]
     },
     {
       "name": "list-3",
       "type": "list",
       "description": null,
-      "default": "[]"
+      "default": []
     },
     {
       "name": "long_type",
       "type": "object({\n    name = string,\n    foo  = object({ foo = string, bar = string }),\n    bar  = object({ foo = string, bar = string }),\n    fizz = list(string),\n    buzz = list(string)\n  })",
       "description": "This description is itself markdown.\n\nIt spans over multiple lines.\n",
-      "default": "{\n  \"bar\": {\n    \"bar\": \"bar\",\n    \"foo\": \"bar\"\n  },\n  \"buzz\": [\n    \"fizz\",\n    \"buzz\"\n  ],\n  \"fizz\": [],\n  \"foo\": {\n    \"bar\": \"foo\",\n    \"foo\": \"foo\"\n  },\n  \"name\": \"hello\"\n}"
+      "default": {
+        "bar": {
+          "bar": "bar",
+          "foo": "bar"
+        },
+        "buzz": [
+          "fizz",
+          "buzz"
+        ],
+        "fizz": [],
+        "foo": {
+          "bar": "foo",
+          "foo": "foo"
+        },
+        "name": "hello"
+      }
     },
     {
       "name": "map-1",
       "type": "map",
       "description": "It's map number one.",
-      "default": "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3\n}"
+      "default": {
+        "a": 1,
+        "b": 2,
+        "c": 3
+      }
     },
     {
       "name": "map-3",
       "type": "map",
       "description": null,
-      "default": "{}"
+      "default": {}
     },
     {
       "name": "no-escape-default-value",
       "type": "string",
       "description": "The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'.",
-      "default": "\"VALUE_WITH_UNDERSCORE\""
+      "default": "VALUE_WITH_UNDERSCORE"
     },
     {
       "name": "string-1",
       "type": "string",
       "description": "It's string number one.",
-      "default": "\"bar\""
+      "default": "bar"
     },
     {
       "name": "string-3",
       "type": "string",
       "description": null,
-      "default": "\"\""
+      "default": ""
     },
     {
       "name": "with-url",
       "type": "string",
       "description": "The description contains url. https://www.domain.com/foo/bar_baz.html",
-      "default": "\"\""
+      "default": ""
     }
   ],
   "outputs": [

--- a/internal/pkg/print/json/testdata/json.golden
+++ b/internal/pkg/print/json/testdata/json.golden
@@ -11,7 +11,7 @@
       "name": "string-3",
       "type": "string",
       "description": null,
-      "default": "\"\""
+      "default": ""
     },
     {
       "name": "string-2",
@@ -23,13 +23,13 @@
       "name": "string-1",
       "type": "string",
       "description": "It's string number one.",
-      "default": "\"bar\""
+      "default": "bar"
     },
     {
       "name": "map-3",
       "type": "map",
       "description": null,
-      "default": "{}"
+      "default": {}
     },
     {
       "name": "map-2",
@@ -41,13 +41,17 @@
       "name": "map-1",
       "type": "map",
       "description": "It's map number one.",
-      "default": "{\n  \"a\": 1,\n  \"b\": 2,\n  \"c\": 3\n}"
+      "default": {
+        "a": 1,
+        "b": 2,
+        "c": 3
+      }
     },
     {
       "name": "list-3",
       "type": "list",
       "description": null,
-      "default": "[]"
+      "default": []
     },
     {
       "name": "list-2",
@@ -59,7 +63,11 @@
       "name": "list-1",
       "type": "list",
       "description": "It's list number one.",
-      "default": "[\n  \"a\",\n  \"b\",\n  \"c\"\n]"
+      "default": [
+        "a",
+        "b",
+        "c"
+      ]
     },
     {
       "name": "input_with_underscores",
@@ -71,31 +79,48 @@
       "name": "input-with-pipe",
       "type": "string",
       "description": "It includes v1 | v2 | v3",
-      "default": "\"v1\""
+      "default": "v1"
     },
     {
       "name": "input-with-code-block",
       "type": "list",
       "description": "This is a complicated one. We need a newline.  \nAnd an example in a code block\n```\ndefault     = [\n  \"machine rack01:neptune\"\n]\n```\n",
-      "default": "[\n  \"name rack:location\"\n]"
+      "default": [
+        "name rack:location"
+      ]
     },
     {
       "name": "long_type",
       "type": "object({\n    name = string,\n    foo  = object({ foo = string, bar = string }),\n    bar  = object({ foo = string, bar = string }),\n    fizz = list(string),\n    buzz = list(string)\n  })",
       "description": "This description is itself markdown.\n\nIt spans over multiple lines.\n",
-      "default": "{\n  \"bar\": {\n    \"bar\": \"bar\",\n    \"foo\": \"bar\"\n  },\n  \"buzz\": [\n    \"fizz\",\n    \"buzz\"\n  ],\n  \"fizz\": [],\n  \"foo\": {\n    \"bar\": \"foo\",\n    \"foo\": \"foo\"\n  },\n  \"name\": \"hello\"\n}"
+      "default": {
+        "bar": {
+          "bar": "bar",
+          "foo": "bar"
+        },
+        "buzz": [
+          "fizz",
+          "buzz"
+        ],
+        "fizz": [],
+        "foo": {
+          "bar": "foo",
+          "foo": "foo"
+        },
+        "name": "hello"
+      }
     },
     {
       "name": "no-escape-default-value",
       "type": "string",
       "description": "The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'.",
-      "default": "\"VALUE_WITH_UNDERSCORE\""
+      "default": "VALUE_WITH_UNDERSCORE"
     },
     {
       "name": "with-url",
       "type": "string",
       "description": "The description contains url. https://www.domain.com/foo/bar_baz.html",
-      "default": "\"\""
+      "default": ""
     }
   ],
   "outputs": [

--- a/internal/pkg/print/markdown/document/document.go
+++ b/internal/pkg/print/markdown/document/document.go
@@ -43,7 +43,7 @@ func getInputType(input *tfconf.Input) string {
 	var result = ""
 	var extraline = false
 
-	if result, extraline = markdown.PrintFencedCodeBlock(string(input.Type), "hcl"); !extraline {
+	if result, extraline = markdown.PrintFencedCodeBlock(input.Type.String(), "hcl"); !extraline {
 		result += "\n"
 	}
 	return result
@@ -54,7 +54,7 @@ func getInputValue(input *tfconf.Input) string {
 	var extraline = false
 
 	if input.HasDefault() {
-		if result, extraline = markdown.PrintFencedCodeBlock(string(input.Default), "json"); !extraline {
+		if result, extraline = markdown.PrintFencedCodeBlock(tfconf.ValueOf(input.Default), "json"); !extraline {
 			result += "\n"
 		}
 	}
@@ -64,7 +64,7 @@ func getInputValue(input *tfconf.Input) string {
 func printInput(buffer *bytes.Buffer, input *tfconf.Input, settings *print.Settings) {
 	buffer.WriteString("\n")
 	buffer.WriteString(fmt.Sprintf("%s %s\n\n", markdown.GenerateIndentation(1, settings), markdown.SanitizeName(input.Name, settings)))
-	buffer.WriteString(fmt.Sprintf("Description: %s\n\n", markdown.SanitizeItemForDocument(string(input.Description), settings)))
+	buffer.WriteString(fmt.Sprintf("Description: %s\n\n", markdown.SanitizeItemForDocument(input.Description.String(), settings)))
 	buffer.WriteString(fmt.Sprintf("Type: %s", getInputType(input)))
 
 	// Don't print defaults for required inputs when we're already explicit about it being required
@@ -167,6 +167,6 @@ func printOutputs(buffer *bytes.Buffer, outputs []*tfconf.Output, settings *prin
 	for _, output := range outputs {
 		buffer.WriteString("\n")
 		buffer.WriteString(fmt.Sprintf("%s %s\n\n", markdown.GenerateIndentation(1, settings), markdown.SanitizeName(output.Name, settings)))
-		buffer.WriteString(fmt.Sprintf("Description: %s\n", markdown.SanitizeItemForDocument(string(output.Description), settings)))
+		buffer.WriteString(fmt.Sprintf("Description: %s\n", markdown.SanitizeItemForDocument(output.Description.String(), settings)))
 	}
 }

--- a/internal/pkg/print/markdown/table/table.go
+++ b/internal/pkg/print/markdown/table/table.go
@@ -34,13 +34,13 @@ func Print(module *tfconf.Module, settings *print.Settings) (string, error) {
 func getProviderVersion(provider *tfconf.Provider) string {
 	var result = "n/a"
 	if provider.Version != "" {
-		result = string(provider.Version)
+		result = provider.Version.String()
 	}
 	return result
 }
 
 func getInputType(input *tfconf.Input) string {
-	inputType, _ := markdown.PrintFencedCodeBlock(string(input.Type), "")
+	inputType, _ := markdown.PrintFencedCodeBlock(input.Type.String(), "")
 	return inputType
 }
 
@@ -48,7 +48,7 @@ func getInputValue(input *tfconf.Input) string {
 	var result = "n/a"
 
 	if input.HasDefault() {
-		result, _ = markdown.PrintFencedCodeBlock(string(input.Default), "")
+		result, _ = markdown.PrintFencedCodeBlock(tfconf.ValueOf(input.Default), "")
 	}
 	return result
 }
@@ -120,7 +120,7 @@ func printInputs(buffer *bytes.Buffer, inputs []*tfconf.Input, settings *print.S
 			fmt.Sprintf(
 				"| %s | %s | %s | %s |",
 				markdown.SanitizeName(input.Name, settings),
-				markdown.SanitizeItemForTable(string(input.Description), settings),
+				markdown.SanitizeItemForTable(input.Description.String(), settings),
 				markdown.SanitizeItemForTable(getInputType(input), settings),
 				markdown.SanitizeItemForTable(getInputValue(input), settings),
 			),
@@ -151,7 +151,7 @@ func printOutputs(buffer *bytes.Buffer, outputs []*tfconf.Output, settings *prin
 			fmt.Sprintf(
 				"| %s | %s |\n",
 				markdown.SanitizeName(output.Name, settings),
-				markdown.SanitizeItemForTable(string(output.Description), settings),
+				markdown.SanitizeItemForTable(output.Description.String(), settings),
 			),
 		)
 	}

--- a/internal/pkg/print/pretty/pretty.go
+++ b/internal/pkg/print/pretty/pretty.go
@@ -43,7 +43,7 @@ func getInputDefaultValue(input *tfconf.Input, settings *print.Settings) string 
 	var result = "required"
 
 	if input.HasDefault() {
-		result = string(input.Default)
+		result = tfconf.ValueOf(input.Default)
 	}
 
 	return result
@@ -117,7 +117,7 @@ func printInputs(buffer *bytes.Buffer, inputs []*tfconf.Input, settings *print.S
 				format,
 				input.Name,
 				getInputDefaultValue(input, settings),
-				getDescription(string(input.Description)),
+				getDescription(input.Description.String()),
 			),
 		)
 	}
@@ -137,7 +137,7 @@ func printOutputs(buffer *bytes.Buffer, outputs []*tfconf.Output, settings *prin
 			fmt.Sprintf(
 				format,
 				output.Name,
-				getDescription(string(output.Description)),
+				getDescription(output.Description.String()),
 			),
 		)
 	}

--- a/internal/pkg/tfconf/input.go
+++ b/internal/pkg/tfconf/input.go
@@ -1,17 +1,30 @@
 package tfconf
 
+import (
+	"encoding/json"
+)
+
 // Input represents a Terraform input.
 type Input struct {
-	Name        string   `json:"name"`
-	Type        String   `json:"type"`
-	Description String   `json:"description"`
-	Default     String   `json:"default"`
-	Position    Position `json:"-"`
+	Name        string      `json:"name"`
+	Type        String      `json:"type"`
+	Description String      `json:"description"`
+	Default     interface{} `json:"default"`
+	Position    Position    `json:"-"`
+}
+
+// ValueOf returns JSON representation of the 'Default' value, which is an 'interface'.
+func ValueOf(v interface{}) string {
+	marshaled, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	return string(marshaled)
 }
 
 // HasDefault indicates if a Terraform variable has a default value set.
 func (i *Input) HasDefault() bool {
-	return i.Default != ""
+	return i.Default != nil
 }
 
 type inputsSortedByName []*Input

--- a/internal/pkg/tfconf/module.go
+++ b/internal/pkg/tfconf/module.go
@@ -1,7 +1,6 @@
 package tfconf
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"sort"
@@ -81,17 +80,7 @@ func CreateModule(path string) (*Module, error) {
 		inputType := input.Type
 		if input.Type == "" {
 			inputType = "any"
-		}
-
-		var defaultValue string
-		if input.Default != nil {
-			marshaled, err := json.MarshalIndent(input.Default, "", "  ")
-			if err != nil {
-				return nil, err
-			}
-			defaultValue = string(marshaled)
-
-			if inputType == "any" {
+			if input.Default != nil {
 				switch xType := fmt.Sprintf("%T", input.Default); xType {
 				case "string":
 					inputType = "string"
@@ -116,7 +105,7 @@ func CreateModule(path string) (*Module, error) {
 			Name:        input.Name,
 			Type:        String(inputType),
 			Description: String(inputDescription),
-			Default:     String(defaultValue),
+			Default:     input.Default,
 			Position: Position{
 				Filename: input.Pos.Filename,
 				Line:     input.Pos.Line,

--- a/internal/pkg/tfconf/string.go
+++ b/internal/pkg/tfconf/string.go
@@ -9,14 +9,19 @@ import (
 // JSON marshaled to `null` when empty
 type String string
 
+// String returns s as an actual string value
+func (s String) String() string {
+	return string(s)
+}
+
 // MarshalJSON custom marshal function which
 // sets the value to literal `null` when empty
-func (s String) MarshalJSON() ([]byte, error) {
+func (s *String) MarshalJSON() ([]byte, error) {
 	var buf bytes.Buffer
-	if len(string(s)) == 0 {
+	if len(s.String()) == 0 {
 		buf.WriteString(`null`)
 	} else {
-		normalize := string(s)
+		normalize := s.String()
 		normalize = strings.Replace(normalize, "\n", "\\n", -1)
 		normalize = strings.Replace(normalize, "\"", "\\\"", -1)
 		buf.WriteString(`"` + normalize + `"`) // add double quation mark as json format required


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

> If an input variable is defined as list with default value, terraform-docs v0.8.0 defines the array within the json string instead as a json list/ array. Terraform-lists should be json arrays and not defined within strings.

This is actually a regression in `v0.8.0` and this PR fixes it.

### Issues Resolved

Fixes #172 

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [x] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
