### PR TITLE
Render formatted results with go templates

### DIFF
--- a/internal/pkg/print/json/json.go
+++ b/internal/pkg/print/json/json.go
@@ -9,11 +9,6 @@ import (
 	"github.com/segmentio/terraform-docs/internal/pkg/tfconf"
 )
 
-const (
-	indent string = "  "
-	prefix string = ""
-)
-
 // Print prints a document as json.
 func Print(module *tfconf.Module, settings *print.Settings) (string, error) {
 	module.Sort(settings)
@@ -41,7 +36,7 @@ func Print(module *tfconf.Module, settings *print.Settings) (string, error) {
 	buffer := new(bytes.Buffer)
 
 	encoder := json.NewEncoder(buffer)
-	encoder.SetIndent(prefix, indent)
+	encoder.SetIndent("", "  ")
 	encoder.SetEscapeHTML(settings.EscapeCharacters)
 
 	err := encoder.Encode(copy)

--- a/internal/pkg/print/markdown/document/document.go
+++ b/internal/pkg/print/markdown/document/document.go
@@ -1,174 +1,162 @@
 package document
 
 import (
-	"bytes"
-	"fmt"
+	"text/template"
 
 	"github.com/segmentio/terraform-docs/internal/pkg/print"
 	"github.com/segmentio/terraform-docs/internal/pkg/print/markdown"
 	"github.com/segmentio/terraform-docs/internal/pkg/tfconf"
+	"github.com/segmentio/terraform-docs/internal/pkg/tmpl"
+)
+
+const (
+	headerTpl = `
+	{{- if .Settings.ShowHeader -}}
+		{{- with .Module.Header -}}
+			{{ sanitizeHeader . }}
+			{{ printf "\n" }}
+		{{- end -}}
+	{{ end -}}
+	`
+
+	providersTpl = `
+	{{- if .Settings.ShowProviders -}}
+		{{ indent 0 }} Providers
+		{{ if not .Module.Providers }}
+			No provider.
+		{{ else }}
+			The following providers are used by this module:
+			{{- range .Module.Providers }}
+				{{ $version := ternary (tostring .Version) (printf " (%s)" .Version) "" }}
+				- {{ name .FullName }}{{ $version }}
+			{{- end }}
+		{{ end }}
+	{{ end -}}
+	`
+
+	inputsTpl = `
+	{{- if .Settings.ShowInputs -}}
+		{{- if .Settings.ShowRequired -}}
+			{{ indent 0 }} Required Inputs
+			{{ if not .Module.RequiredInputs }}
+				No required input.
+			{{ else }}
+				The following input variables are required:
+				{{- range .Module.RequiredInputs }}
+					{{ template "input" . }}
+				{{- end }}
+			{{- end }}
+			{{ indent 0 }} Optional Inputs
+			{{ if not .Module.OptionalInputs }}
+				No optional input.
+			{{ else }}
+				The following input variables are optional (have default values):
+				{{- range .Module.OptionalInputs }}
+					{{ template "input" . }}
+				{{- end }}
+			{{ end }}
+		{{ else -}}
+			{{ indent 0 }} Inputs
+			{{ if not .Module.Inputs }}
+				No input.
+			{{ else }}
+				The following input variables are supported:
+				{{- range .Module.Inputs }}
+					{{ template "input" . }}
+				{{- end }}
+			{{ end }}
+		{{- end }}
+	{{ end -}}
+	`
+
+	inputTpl = `
+	{{ printf "\n" }}
+	{{ indent 1 }} {{ name .Name }}
+
+	Description: {{ tostring .Description | sanitizeDoc }}
+
+	Type: {{ tostring .Type | type }}
+
+	{{ if or .HasDefault (not isRequired) }}
+		Default: {{ default "n/a" .Value | value }}
+	{{- end }}
+	`
+
+	outputsTpl = `
+	{{- if .Settings.ShowOutputs -}}
+		{{ indent 0 }} Outputs
+		{{ if not .Module.Outputs }}
+			No output.
+		{{ else }}
+			The following outputs are exported:
+			{{- range .Module.Outputs }}
+
+				{{ indent 1 }} {{ name .Name }}
+
+				Description: {{ tostring .Description | sanitizeDoc }}
+			{{- end }}
+		{{ end }}
+	{{ end -}}
+	`
+
+	documentTpl = `
+	{{- template "header" . -}}
+	{{- template "providers" . -}}
+	{{- template "inputs" . -}}
+	{{- template "outputs" . -}}
+	`
 )
 
 // Print prints a document as Markdown document.
 func Print(module *tfconf.Module, settings *print.Settings) (string, error) {
-	var buffer bytes.Buffer
-
 	module.Sort(settings)
 
-	if settings.ShowHeader {
-		printHeader(&buffer, module.Header, settings)
-	}
-	if settings.ShowProviders {
-		printProviders(&buffer, module.Providers, settings)
-	}
-	if settings.ShowInputs {
-		printInputs(&buffer, module, settings)
-	}
-	if settings.ShowOutputs {
-		printOutputs(&buffer, module.Outputs, settings)
-	}
-
-	return markdown.Sanitize(buffer.String()), nil
-}
-
-func getProviderVersion(provider *tfconf.Provider) string {
-	var result = ""
-	if provider.Version != "" {
-		result = fmt.Sprintf(" (%s)", provider.Version)
-	}
-	return result
-}
-
-func getInputType(input *tfconf.Input) string {
-	var result = ""
-	var extraline = false
-
-	if result, extraline = markdown.PrintFencedCodeBlock(input.Type.String(), "hcl"); !extraline {
-		result += "\n"
-	}
-	return result
-}
-
-func getInputValue(input *tfconf.Input) string {
-	var result = "n/a\n"
-	var extraline = false
-
-	if input.HasDefault() {
-		if result, extraline = markdown.PrintFencedCodeBlock(tfconf.ValueOf(input.Default), "json"); !extraline {
-			result += "\n"
-		}
-	}
-	return result
-}
-
-func printInput(buffer *bytes.Buffer, input *tfconf.Input, settings *print.Settings) {
-	buffer.WriteString("\n")
-	buffer.WriteString(fmt.Sprintf("%s %s\n\n", markdown.GenerateIndentation(1, settings), markdown.SanitizeName(input.Name, settings)))
-	buffer.WriteString(fmt.Sprintf("Description: %s\n\n", markdown.SanitizeItemForDocument(input.Description.String(), settings)))
-	buffer.WriteString(fmt.Sprintf("Type: %s", getInputType(input)))
-
-	// Don't print defaults for required inputs when we're already explicit about it being required
-	if input.HasDefault() || !settings.ShowRequired {
-		buffer.WriteString(fmt.Sprintf("\nDefault: %s", getInputValue(input)))
-	}
-}
-
-func printInputsRequired(buffer *bytes.Buffer, inputs []*tfconf.Input, settings *print.Settings) {
-	buffer.WriteString(fmt.Sprintf("%s Required Inputs\n\n", markdown.GenerateIndentation(0, settings)))
-
-	if len(inputs) == 0 {
-		buffer.WriteString("No required input.\n\n")
-		return
+	t := tmpl.NewTemplate(&tmpl.Item{
+		Name: "document",
+		Text: documentTpl,
+	}, &tmpl.Item{
+		Name: "header",
+		Text: headerTpl,
+	}, &tmpl.Item{
+		Name: "providers",
+		Text: providersTpl,
+	}, &tmpl.Item{
+		Name: "inputs",
+		Text: inputsTpl,
+	}, &tmpl.Item{
+		Name: "input",
+		Text: inputTpl,
+	}, &tmpl.Item{
+		Name: "outputs",
+		Text: outputsTpl,
+	})
+	t.Settings(settings)
+	t.CustomFunc(template.FuncMap{
+		"type": func(t string) string {
+			result, extraline := markdown.PrintFencedCodeBlock(t, "hcl")
+			if !extraline {
+				result += "\n"
+			}
+			return result
+		},
+		"value": func(v string) string {
+			if v == "n/a" {
+				return v
+			}
+			result, extraline := markdown.PrintFencedCodeBlock(v, "json")
+			if !extraline {
+				result += "\n"
+			}
+			return result
+		},
+		"isRequired": func() bool {
+			return settings.ShowRequired
+		},
+	})
+	rendered, err := t.Render(module)
+	if err != nil {
+		return "", err
 	}
 
-	buffer.WriteString("The following input variables are required:\n")
-
-	for _, input := range inputs {
-		printInput(buffer, input, settings)
-	}
-}
-
-func printInputsOptional(buffer *bytes.Buffer, inputs []*tfconf.Input, settings *print.Settings) {
-	buffer.WriteString("\n")
-	buffer.WriteString(fmt.Sprintf("%s Optional Inputs\n\n", markdown.GenerateIndentation(0, settings)))
-
-	if len(inputs) == 0 {
-		buffer.WriteString("No optional input.\n\n")
-		return
-	}
-
-	buffer.WriteString("The following input variables are optional (have default values):\n")
-
-	for _, input := range inputs {
-		printInput(buffer, input, settings)
-	}
-}
-
-func printInputsAll(buffer *bytes.Buffer, inputs []*tfconf.Input, settings *print.Settings) {
-	buffer.WriteString(fmt.Sprintf("%s Inputs\n\n", markdown.GenerateIndentation(0, settings)))
-
-	if len(inputs) == 0 {
-		buffer.WriteString("No input.\n\n")
-		return
-	}
-
-	buffer.WriteString("The following input variables are supported:\n")
-
-	for _, input := range inputs {
-		printInput(buffer, input, settings)
-	}
-}
-
-func printHeader(buffer *bytes.Buffer, header string, settings *print.Settings) {
-	if len(header) == 0 {
-		return
-	}
-	settings.EscapePipe = false
-	buffer.WriteString(fmt.Sprintf("%s", markdown.SanitizeItemForDocument(header, settings)))
-	settings.EscapePipe = true
-	buffer.WriteString("\n\n")
-}
-
-func printProviders(buffer *bytes.Buffer, providers []*tfconf.Provider, settings *print.Settings) {
-	buffer.WriteString(fmt.Sprintf("%s Providers\n\n", markdown.GenerateIndentation(0, settings)))
-
-	if len(providers) == 0 {
-		buffer.WriteString("No provider.\n\n")
-		return
-	}
-
-	buffer.WriteString("The following providers are used by this module:\n")
-
-	for _, provider := range providers {
-		buffer.WriteString("\n")
-		buffer.WriteString(fmt.Sprintf("- %s%s\n", markdown.SanitizeName(provider.GetName(), settings), getProviderVersion(provider)))
-	}
-	buffer.WriteString("\n")
-}
-
-func printInputs(buffer *bytes.Buffer, module *tfconf.Module, settings *print.Settings) {
-	if settings.ShowRequired {
-		printInputsRequired(buffer, module.RequiredInputs, settings)
-		printInputsOptional(buffer, module.OptionalInputs, settings)
-	} else {
-		printInputsAll(buffer, module.Inputs, settings)
-	}
-	buffer.WriteString("\n")
-}
-
-func printOutputs(buffer *bytes.Buffer, outputs []*tfconf.Output, settings *print.Settings) {
-	buffer.WriteString(fmt.Sprintf("%s Outputs\n\n", markdown.GenerateIndentation(0, settings)))
-
-	if len(outputs) == 0 {
-		buffer.WriteString("No output.\n\n")
-		return
-	}
-
-	buffer.WriteString("The following outputs are exported:\n")
-
-	for _, output := range outputs {
-		buffer.WriteString("\n")
-		buffer.WriteString(fmt.Sprintf("%s %s\n\n", markdown.GenerateIndentation(1, settings), markdown.SanitizeName(output.Name, settings)))
-		buffer.WriteString(fmt.Sprintf("Description: %s\n", markdown.SanitizeItemForDocument(output.Description.String(), settings)))
-	}
+	return markdown.Sanitize(rendered), nil
 }

--- a/internal/pkg/print/markdown/table/table.go
+++ b/internal/pkg/print/markdown/table/table.go
@@ -1,160 +1,124 @@
 package table
 
 import (
-	"bytes"
-	"fmt"
+	"text/template"
 
 	"github.com/segmentio/terraform-docs/internal/pkg/print"
 	"github.com/segmentio/terraform-docs/internal/pkg/print/markdown"
 	"github.com/segmentio/terraform-docs/internal/pkg/tfconf"
+	"github.com/segmentio/terraform-docs/internal/pkg/tmpl"
+)
+
+const (
+	headerTpl = `
+	{{- if .Settings.ShowHeader -}}
+		{{- with .Module.Header -}}
+			{{ sanitizeHeader . }}
+			{{ printf "\n" }}
+		{{- end -}}
+	{{ end -}}
+	`
+
+	providersTpl = `
+	{{- if .Settings.ShowProviders -}}
+		{{ indent 0 }} Providers
+		{{ if not .Module.Providers }}
+			No provider.
+		{{ else }}
+			| Name | Version |
+			|------|---------|
+			{{- range .Module.Providers }}
+				| {{ name .FullName }} | {{ tostring .Version | default "n/a" }} |
+			{{- end }}
+		{{ end }}
+	{{ end -}}
+	`
+
+	inputsTpl = `
+	{{- if .Settings.ShowInputs -}}
+		{{ indent 0 }} Inputs
+		{{ if not .Module.Inputs }}
+			No input.
+		{{ else }}
+			{{ if not .Settings.ShowRequired }}
+				| Name | Description | Type | Default |
+				|------|-------------|------|---------|
+			{{- else }}
+				| Name | Description | Type | Default | Required |
+				|------|-------------|------|---------|:--------:|
+			{{- end }}
+			{{- range .Module.Inputs }}
+				{{- if not $.Settings.ShowRequired }}
+					| {{ name .Name }} | {{ tostring .Description | sanitizeTbl }} | {{ tostring .Type | type | sanitizeTbl }} | {{ value .Value | sanitizeTbl }} |
+				{{- else }}
+					| {{ name .Name }} | {{ tostring .Description | sanitizeTbl }} | {{ tostring .Type | type | sanitizeTbl }} | {{ value .Value | sanitizeTbl }} | {{ ternary (.Value) "no" "yes" }} |
+				{{- end }}
+			{{- end }}
+		{{ end }}
+	{{ end -}}
+	`
+
+	outputsTpl = `
+	{{- if .Settings.ShowOutputs -}}
+		{{ indent 0 }} Outputs
+		{{ if not .Module.Outputs }}
+			No output.
+		{{ else }}
+			| Name | Description |
+			|------|-------------|
+			{{- range .Module.Outputs }}
+				| {{ name .Name }} | {{ tostring .Description | sanitizeTbl }} |
+			{{- end }}
+		{{ end }}
+	{{ end -}}
+	`
+
+	tableTpl = `
+	{{- template "header" . -}}
+	{{- template "providers" . -}}
+	{{- template "inputs" . -}}
+	{{- template "outputs" . -}}
+	`
 )
 
 // Print prints a document as Markdown tables.
 func Print(module *tfconf.Module, settings *print.Settings) (string, error) {
-	var buffer bytes.Buffer
-
 	module.Sort(settings)
 
-	if settings.ShowHeader {
-		printHeader(&buffer, module.Header, settings)
-	}
-	if settings.ShowProviders {
-		printProviders(&buffer, module.Providers, settings)
-	}
-	if settings.ShowInputs {
-		printInputs(&buffer, module.Inputs, settings)
-	}
-	if settings.ShowOutputs {
-		printOutputs(&buffer, module.Outputs, settings)
-	}
-
-	return markdown.Sanitize(buffer.String()), nil
-}
-
-func getProviderVersion(provider *tfconf.Provider) string {
-	var result = "n/a"
-	if provider.Version != "" {
-		result = provider.Version.String()
-	}
-	return result
-}
-
-func getInputType(input *tfconf.Input) string {
-	inputType, _ := markdown.PrintFencedCodeBlock(input.Type.String(), "")
-	return inputType
-}
-
-func getInputValue(input *tfconf.Input) string {
-	var result = "n/a"
-
-	if input.HasDefault() {
-		result, _ = markdown.PrintFencedCodeBlock(tfconf.ValueOf(input.Default), "")
-	}
-	return result
-}
-
-func printIsInputRequired(input *tfconf.Input) string {
-	if !input.HasDefault() {
-		return "yes"
-	}
-	return "no"
-}
-
-func printHeader(buffer *bytes.Buffer, header string, settings *print.Settings) {
-	if len(header) == 0 {
-		return
-	}
-	settings.EscapePipe = false
-	buffer.WriteString(fmt.Sprintf("%s", markdown.SanitizeItemForDocument(header, settings)))
-	settings.EscapePipe = true
-	buffer.WriteString("\n\n")
-}
-
-func printProviders(buffer *bytes.Buffer, providers []*tfconf.Provider, settings *print.Settings) {
-	buffer.WriteString(fmt.Sprintf("%s Providers\n\n", markdown.GenerateIndentation(0, settings)))
-
-	if len(providers) == 0 {
-		buffer.WriteString("No provider.\n\n")
-		return
+	t := tmpl.NewTemplate(&tmpl.Item{
+		Name: "table",
+		Text: tableTpl,
+	}, &tmpl.Item{
+		Name: "header",
+		Text: headerTpl,
+	}, &tmpl.Item{
+		Name: "providers",
+		Text: providersTpl,
+	}, &tmpl.Item{
+		Name: "inputs",
+		Text: inputsTpl,
+	}, &tmpl.Item{
+		Name: "outputs",
+		Text: outputsTpl,
+	})
+	t.Settings(settings)
+	t.CustomFunc(template.FuncMap{
+		"type": func(t string) string {
+			inputType, _ := markdown.PrintFencedCodeBlock(t, "")
+			return inputType
+		},
+		"value": func(v string) string {
+			var result = "n/a"
+			if v != "" {
+				result, _ = markdown.PrintFencedCodeBlock(v, "")
+			}
+			return result
+		},
+	})
+	rendered, err := t.Render(module)
+	if err != nil {
+		return "", err
 	}
 
-	buffer.WriteString("| Name | Version |\n")
-	buffer.WriteString("|------|---------|\n")
-
-	for _, provider := range providers {
-		buffer.WriteString(
-			fmt.Sprintf(
-				"| %s | %s |\n",
-				markdown.SanitizeName(provider.GetName(), settings),
-				getProviderVersion(provider),
-			),
-		)
-	}
-	buffer.WriteString("\n")
-}
-
-func printInputs(buffer *bytes.Buffer, inputs []*tfconf.Input, settings *print.Settings) {
-	buffer.WriteString(fmt.Sprintf("%s Inputs\n\n", markdown.GenerateIndentation(0, settings)))
-
-	if len(inputs) == 0 {
-		buffer.WriteString("No input.\n\n")
-		return
-	}
-
-	buffer.WriteString("| Name | Description | Type | Default |")
-
-	if settings.ShowRequired {
-		buffer.WriteString(" Required |\n")
-	} else {
-		buffer.WriteString("\n")
-	}
-
-	buffer.WriteString("|------|-------------|------|---------|")
-
-	if settings.ShowRequired {
-		buffer.WriteString(":-----:|\n")
-	} else {
-		buffer.WriteString("\n")
-	}
-
-	for _, input := range inputs {
-		buffer.WriteString(
-			fmt.Sprintf(
-				"| %s | %s | %s | %s |",
-				markdown.SanitizeName(input.Name, settings),
-				markdown.SanitizeItemForTable(input.Description.String(), settings),
-				markdown.SanitizeItemForTable(getInputType(input), settings),
-				markdown.SanitizeItemForTable(getInputValue(input), settings),
-			),
-		)
-
-		if settings.ShowRequired {
-			buffer.WriteString(fmt.Sprintf(" %v |\n", printIsInputRequired(input)))
-		} else {
-			buffer.WriteString("\n")
-		}
-	}
-	buffer.WriteString("\n")
-}
-
-func printOutputs(buffer *bytes.Buffer, outputs []*tfconf.Output, settings *print.Settings) {
-	buffer.WriteString(fmt.Sprintf("%s Outputs\n\n", markdown.GenerateIndentation(0, settings)))
-
-	if len(outputs) == 0 {
-		buffer.WriteString("No output.\n\n")
-		return
-	}
-
-	buffer.WriteString("| Name | Description |\n")
-	buffer.WriteString("|------|-------------|\n")
-
-	for _, output := range outputs {
-		buffer.WriteString(
-			fmt.Sprintf(
-				"| %s | %s |\n",
-				markdown.SanitizeName(output.Name, settings),
-				markdown.SanitizeItemForTable(output.Description.String(), settings),
-			),
-		)
-	}
+	return markdown.Sanitize(rendered), nil
 }

--- a/internal/pkg/print/markdown/table/testdata/table-WithRequired.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-WithRequired.golden
@@ -48,7 +48,7 @@ followed by another line of text.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | unquoted | n/a | `any` | n/a | yes |
 | string-3 | n/a | `string` | `""` | no |
 | string-2 | It's string number two. | `string` | n/a | yes |

--- a/internal/pkg/print/pretty/pretty.go
+++ b/internal/pkg/print/pretty/pretty.go
@@ -1,144 +1,106 @@
 package pretty
 
 import (
-	"bytes"
 	"fmt"
-	"strings"
+	"text/template"
 
 	"github.com/segmentio/terraform-docs/internal/pkg/print"
 	"github.com/segmentio/terraform-docs/internal/pkg/tfconf"
+	"github.com/segmentio/terraform-docs/internal/pkg/tmpl"
+)
+
+const (
+	headerTpl = `
+	{{- if .Settings.ShowHeader -}}
+		{{- with .Module.Header }}
+			{{- printf "\n" }}
+			{{ colorize "\033[90m" . }}
+			{{- printf "\n" }}
+		{{ end -}}
+	{{ end -}}
+	`
+
+	providersTpl = `
+	{{- if .Settings.ShowProviders -}}
+		{{- with .Module.Providers }}
+			{{- printf "\n" -}}
+			{{- range . }}
+				{{- $version := ternary (tostring .Version) (printf " (%s)" .Version) "" }}
+				{{ printf "provider.%s" .FullName | colorize "\033[36m" }}{{ $version }}
+			{{ end }}
+			{{- printf "\n" -}}
+		{{ end -}}
+	{{ end -}}
+	`
+
+	inputsTpl = `
+	{{- if .Settings.ShowInputs -}}
+		{{- with .Module.Inputs }}
+			{{- printf "\n" -}}
+			{{- range . }}
+				{{ printf "input.%s" .Name | colorize "\033[36m" }} ({{ default "required" .Value }})
+				{{ tostring .Description | trimSuffix "\n" | default "n/a" | colorize "\033[90m" }}
+			{{ end }}
+			{{- printf "\n" -}}
+		{{ end -}}
+	{{ end -}}
+	`
+
+	outputsTpl = `
+	{{- if .Settings.ShowOutputs -}}
+		{{- with .Module.Outputs }}
+			{{- printf "\n" -}}
+			{{- range . }}
+				{{ printf "output.%s" .Name | colorize "\033[36m" }}
+				{{ tostring .Description | trimSuffix "\n" | default "n/a" | colorize "\033[90m" }}
+			{{ end }}
+		{{ end -}}
+	{{ end -}}
+	`
+
+	prettyTpl = `
+	{{- template "header" . -}}
+	{{- template "providers" . -}}
+	{{- template "inputs" . -}}
+	{{- template "outputs" . -}}
+	`
 )
 
 // Print prints a pretty document.
 func Print(module *tfconf.Module, settings *print.Settings) (string, error) {
-	var buffer bytes.Buffer
-
 	module.Sort(settings)
 
-	if settings.ShowHeader {
-		printHeader(&buffer, module.Header, settings)
-	}
-	if settings.ShowProviders {
-		printProviders(&buffer, module.Providers, settings)
-	}
-	if settings.ShowInputs {
-		printInputs(&buffer, module.Inputs, settings)
-	}
-	if settings.ShowOutputs {
-		printOutputs(&buffer, module.Outputs, settings)
-	}
-
-	return buffer.String(), nil
-}
-
-func getProviderVersion(provider *tfconf.Provider) string {
-	var result = ""
-	if provider.Version != "" {
-		result = fmt.Sprintf(" (%s)", provider.Version)
-	}
-	return result
-}
-
-func getInputDefaultValue(input *tfconf.Input, settings *print.Settings) string {
-	var result = "required"
-
-	if input.HasDefault() {
-		result = tfconf.ValueOf(input.Default)
-	}
-
-	return result
-}
-
-func getDescription(description string) string {
-	var result = "n/a"
-
-	if description != "" {
-		result = strings.TrimSuffix(description, "\n")
+	t := tmpl.NewTemplate(&tmpl.Item{
+		Name: "pretty",
+		Text: prettyTpl,
+	}, &tmpl.Item{
+		Name: "header",
+		Text: headerTpl,
+	}, &tmpl.Item{
+		Name: "providers",
+		Text: providersTpl,
+	}, &tmpl.Item{
+		Name: "inputs",
+		Text: inputsTpl,
+	}, &tmpl.Item{
+		Name: "outputs",
+		Text: outputsTpl,
+	})
+	t.Settings(settings)
+	t.CustomFunc(template.FuncMap{
+		"colorize": func(c string, s string) string {
+			r := "\033[0m"
+			if !settings.ShowColor {
+				c = ""
+				r = ""
+			}
+			return fmt.Sprintf("%s%s%s", c, s, r)
+		},
+	})
+	rendered, err := t.Render(module)
+	if err != nil {
+		return "", err
 	}
 
-	return result
-}
-
-func printHeader(buffer *bytes.Buffer, header string, settings *print.Settings) {
-	if len(header) == 0 {
-		return
-	}
-	buffer.WriteString("\n\n")
-
-	for _, line := range strings.Split(header, "\n") {
-		var format string
-		if settings.ShowColor {
-			format = "\033[90m%s\033[0m\n"
-		} else {
-			format = "%s\n"
-		}
-		buffer.WriteString(
-			fmt.Sprintf(
-				format,
-				line,
-			),
-		)
-	}
-	buffer.WriteString("\n")
-}
-
-func printProviders(buffer *bytes.Buffer, providers []*tfconf.Provider, settings *print.Settings) {
-	buffer.WriteString("\n\n")
-
-	for _, provider := range providers {
-		var format string
-		if settings.ShowColor {
-			format = "\033[36mprovider.%s\033[0m%s\n\n"
-		} else {
-			format = "provider.%s%s\n\n"
-		}
-		buffer.WriteString(
-			fmt.Sprintf(
-				format,
-				provider.GetName(),
-				getProviderVersion(provider),
-			),
-		)
-	}
-}
-
-func printInputs(buffer *bytes.Buffer, inputs []*tfconf.Input, settings *print.Settings) {
-	buffer.WriteString("\n\n")
-
-	for _, input := range inputs {
-		var format string
-		if settings.ShowColor {
-			format = "\033[36minput.%s\033[0m (%s)\n\033[90m%s\033[0m\n\n"
-		} else {
-			format = "input.%s (%s)\n%s\n\n"
-		}
-		buffer.WriteString(
-			fmt.Sprintf(
-				format,
-				input.Name,
-				getInputDefaultValue(input, settings),
-				getDescription(input.Description.String()),
-			),
-		)
-	}
-}
-
-func printOutputs(buffer *bytes.Buffer, outputs []*tfconf.Output, settings *print.Settings) {
-	buffer.WriteString("\n\n")
-
-	for _, output := range outputs {
-		var format string
-		if settings.ShowColor {
-			format = "\033[36moutput.%s\033[0m\n\033[90m%s\033[0m\n\n"
-		} else {
-			format = "output.%s\n%s\n\n"
-		}
-		buffer.WriteString(
-			fmt.Sprintf(
-				format,
-				output.Name,
-				getDescription(output.Description.String()),
-			),
-		)
-	}
+	return rendered, nil
 }

--- a/internal/pkg/print/pretty/testdata/pretty-NoInputs.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoInputs.golden
@@ -1,42 +1,42 @@
 
 
-[90mUsage:[0m
-[90m[0m
-[90mExample of 'foo_bar' module in `foo_bar.tf`.[0m
-[90m[0m
-[90m- list item 1[0m
-[90m- list item 2[0m
-[90m[0m
-[90mEven inline **formatting** in _here_ is possible.[0m
-[90mand some [link](https://domain.com/)[0m
-[90m[0m
-[90m* list item 3[0m
-[90m* list item 4[0m
-[90m[0m
-[90m```hcl[0m
-[90mmodule "foo_bar" {[0m
-[90m  source = "github.com/foo/bar"[0m
-[90m[0m
-[90m  id   = "1234567890"[0m
-[90m  name = "baz"[0m
-[90m[0m
-[90m  zones = ["us-east-1", "us-west-1"][0m
-[90m[0m
-[90m  tags = {[0m
-[90m    Name         = "baz"[0m
-[90m    Created-By   = "first.last@email.com"[0m
-[90m    Date-Created = "20180101"[0m
-[90m  }[0m
-[90m}[0m
-[90m```[0m
-[90m[0m
-[90mHere is some trailing text after code block,[0m
-[90mfollowed by another line of text.[0m
-[90m[0m
-[90m| Name | Description     |[0m
-[90m|------|-----------------|[0m
-[90m| Foo  | Foo description |[0m
-[90m| Bar  | Bar description |[0m
+[90mUsage:
+
+Example of 'foo_bar' module in `foo_bar.tf`.
+
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
+```hcl
+module "foo_bar" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+```
+
+Here is some trailing text after code block,
+followed by another line of text.
+
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |[0m
 
 
 

--- a/internal/pkg/print/pretty/testdata/pretty-NoOutputs.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoOutputs.golden
@@ -1,42 +1,42 @@
 
 
-[90mUsage:[0m
-[90m[0m
-[90mExample of 'foo_bar' module in `foo_bar.tf`.[0m
-[90m[0m
-[90m- list item 1[0m
-[90m- list item 2[0m
-[90m[0m
-[90mEven inline **formatting** in _here_ is possible.[0m
-[90mand some [link](https://domain.com/)[0m
-[90m[0m
-[90m* list item 3[0m
-[90m* list item 4[0m
-[90m[0m
-[90m```hcl[0m
-[90mmodule "foo_bar" {[0m
-[90m  source = "github.com/foo/bar"[0m
-[90m[0m
-[90m  id   = "1234567890"[0m
-[90m  name = "baz"[0m
-[90m[0m
-[90m  zones = ["us-east-1", "us-west-1"][0m
-[90m[0m
-[90m  tags = {[0m
-[90m    Name         = "baz"[0m
-[90m    Created-By   = "first.last@email.com"[0m
-[90m    Date-Created = "20180101"[0m
-[90m  }[0m
-[90m}[0m
-[90m```[0m
-[90m[0m
-[90mHere is some trailing text after code block,[0m
-[90mfollowed by another line of text.[0m
-[90m[0m
-[90m| Name | Description     |[0m
-[90m|------|-----------------|[0m
-[90m| Foo  | Foo description |[0m
-[90m| Bar  | Bar description |[0m
+[90mUsage:
+
+Example of 'foo_bar' module in `foo_bar.tf`.
+
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
+```hcl
+module "foo_bar" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+```
+
+Here is some trailing text after code block,
+followed by another line of text.
+
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |[0m
 
 
 

--- a/internal/pkg/print/pretty/testdata/pretty-NoProviders.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoProviders.golden
@@ -1,42 +1,42 @@
 
 
-[90mUsage:[0m
-[90m[0m
-[90mExample of 'foo_bar' module in `foo_bar.tf`.[0m
-[90m[0m
-[90m- list item 1[0m
-[90m- list item 2[0m
-[90m[0m
-[90mEven inline **formatting** in _here_ is possible.[0m
-[90mand some [link](https://domain.com/)[0m
-[90m[0m
-[90m* list item 3[0m
-[90m* list item 4[0m
-[90m[0m
-[90m```hcl[0m
-[90mmodule "foo_bar" {[0m
-[90m  source = "github.com/foo/bar"[0m
-[90m[0m
-[90m  id   = "1234567890"[0m
-[90m  name = "baz"[0m
-[90m[0m
-[90m  zones = ["us-east-1", "us-west-1"][0m
-[90m[0m
-[90m  tags = {[0m
-[90m    Name         = "baz"[0m
-[90m    Created-By   = "first.last@email.com"[0m
-[90m    Date-Created = "20180101"[0m
-[90m  }[0m
-[90m}[0m
-[90m```[0m
-[90m[0m
-[90mHere is some trailing text after code block,[0m
-[90mfollowed by another line of text.[0m
-[90m[0m
-[90m| Name | Description     |[0m
-[90m|------|-----------------|[0m
-[90m| Foo  | Foo description |[0m
-[90m| Bar  | Bar description |[0m
+[90mUsage:
+
+Example of 'foo_bar' module in `foo_bar.tf`.
+
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
+```hcl
+module "foo_bar" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+```
+
+Here is some trailing text after code block,
+followed by another line of text.
+
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |[0m
 
 
 

--- a/internal/pkg/print/pretty/testdata/pretty-OnlyHeader.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-OnlyHeader.golden
@@ -1,40 +1,40 @@
 
 
-[90mUsage:[0m
-[90m[0m
-[90mExample of 'foo_bar' module in `foo_bar.tf`.[0m
-[90m[0m
-[90m- list item 1[0m
-[90m- list item 2[0m
-[90m[0m
-[90mEven inline **formatting** in _here_ is possible.[0m
-[90mand some [link](https://domain.com/)[0m
-[90m[0m
-[90m* list item 3[0m
-[90m* list item 4[0m
-[90m[0m
-[90m```hcl[0m
-[90mmodule "foo_bar" {[0m
-[90m  source = "github.com/foo/bar"[0m
-[90m[0m
-[90m  id   = "1234567890"[0m
-[90m  name = "baz"[0m
-[90m[0m
-[90m  zones = ["us-east-1", "us-west-1"][0m
-[90m[0m
-[90m  tags = {[0m
-[90m    Name         = "baz"[0m
-[90m    Created-By   = "first.last@email.com"[0m
-[90m    Date-Created = "20180101"[0m
-[90m  }[0m
-[90m}[0m
-[90m```[0m
-[90m[0m
-[90mHere is some trailing text after code block,[0m
-[90mfollowed by another line of text.[0m
-[90m[0m
-[90m| Name | Description     |[0m
-[90m|------|-----------------|[0m
-[90m| Foo  | Foo description |[0m
-[90m| Bar  | Bar description |[0m
+[90mUsage:
+
+Example of 'foo_bar' module in `foo_bar.tf`.
+
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
+```hcl
+module "foo_bar" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+```
+
+Here is some trailing text after code block,
+followed by another line of text.
+
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |[0m
 

--- a/internal/pkg/print/pretty/testdata/pretty-SortByName.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-SortByName.golden
@@ -1,42 +1,42 @@
 
 
-[90mUsage:[0m
-[90m[0m
-[90mExample of 'foo_bar' module in `foo_bar.tf`.[0m
-[90m[0m
-[90m- list item 1[0m
-[90m- list item 2[0m
-[90m[0m
-[90mEven inline **formatting** in _here_ is possible.[0m
-[90mand some [link](https://domain.com/)[0m
-[90m[0m
-[90m* list item 3[0m
-[90m* list item 4[0m
-[90m[0m
-[90m```hcl[0m
-[90mmodule "foo_bar" {[0m
-[90m  source = "github.com/foo/bar"[0m
-[90m[0m
-[90m  id   = "1234567890"[0m
-[90m  name = "baz"[0m
-[90m[0m
-[90m  zones = ["us-east-1", "us-west-1"][0m
-[90m[0m
-[90m  tags = {[0m
-[90m    Name         = "baz"[0m
-[90m    Created-By   = "first.last@email.com"[0m
-[90m    Date-Created = "20180101"[0m
-[90m  }[0m
-[90m}[0m
-[90m```[0m
-[90m[0m
-[90mHere is some trailing text after code block,[0m
-[90mfollowed by another line of text.[0m
-[90m[0m
-[90m| Name | Description     |[0m
-[90m|------|-----------------|[0m
-[90m| Foo  | Foo description |[0m
-[90m| Bar  | Bar description |[0m
+[90mUsage:
+
+Example of 'foo_bar' module in `foo_bar.tf`.
+
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
+```hcl
+module "foo_bar" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+```
+
+Here is some trailing text after code block,
+followed by another line of text.
+
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |[0m
 
 
 

--- a/internal/pkg/print/pretty/testdata/pretty-SortByRequired.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-SortByRequired.golden
@@ -1,42 +1,42 @@
 
 
-[90mUsage:[0m
-[90m[0m
-[90mExample of 'foo_bar' module in `foo_bar.tf`.[0m
-[90m[0m
-[90m- list item 1[0m
-[90m- list item 2[0m
-[90m[0m
-[90mEven inline **formatting** in _here_ is possible.[0m
-[90mand some [link](https://domain.com/)[0m
-[90m[0m
-[90m* list item 3[0m
-[90m* list item 4[0m
-[90m[0m
-[90m```hcl[0m
-[90mmodule "foo_bar" {[0m
-[90m  source = "github.com/foo/bar"[0m
-[90m[0m
-[90m  id   = "1234567890"[0m
-[90m  name = "baz"[0m
-[90m[0m
-[90m  zones = ["us-east-1", "us-west-1"][0m
-[90m[0m
-[90m  tags = {[0m
-[90m    Name         = "baz"[0m
-[90m    Created-By   = "first.last@email.com"[0m
-[90m    Date-Created = "20180101"[0m
-[90m  }[0m
-[90m}[0m
-[90m```[0m
-[90m[0m
-[90mHere is some trailing text after code block,[0m
-[90mfollowed by another line of text.[0m
-[90m[0m
-[90m| Name | Description     |[0m
-[90m|------|-----------------|[0m
-[90m| Foo  | Foo description |[0m
-[90m| Bar  | Bar description |[0m
+[90mUsage:
+
+Example of 'foo_bar' module in `foo_bar.tf`.
+
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
+```hcl
+module "foo_bar" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+```
+
+Here is some trailing text after code block,
+followed by another line of text.
+
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |[0m
 
 
 

--- a/internal/pkg/print/pretty/testdata/pretty.golden
+++ b/internal/pkg/print/pretty/testdata/pretty.golden
@@ -1,42 +1,42 @@
 
 
-[90mUsage:[0m
-[90m[0m
-[90mExample of 'foo_bar' module in `foo_bar.tf`.[0m
-[90m[0m
-[90m- list item 1[0m
-[90m- list item 2[0m
-[90m[0m
-[90mEven inline **formatting** in _here_ is possible.[0m
-[90mand some [link](https://domain.com/)[0m
-[90m[0m
-[90m* list item 3[0m
-[90m* list item 4[0m
-[90m[0m
-[90m```hcl[0m
-[90mmodule "foo_bar" {[0m
-[90m  source = "github.com/foo/bar"[0m
-[90m[0m
-[90m  id   = "1234567890"[0m
-[90m  name = "baz"[0m
-[90m[0m
-[90m  zones = ["us-east-1", "us-west-1"][0m
-[90m[0m
-[90m  tags = {[0m
-[90m    Name         = "baz"[0m
-[90m    Created-By   = "first.last@email.com"[0m
-[90m    Date-Created = "20180101"[0m
-[90m  }[0m
-[90m}[0m
-[90m```[0m
-[90m[0m
-[90mHere is some trailing text after code block,[0m
-[90mfollowed by another line of text.[0m
-[90m[0m
-[90m| Name | Description     |[0m
-[90m|------|-----------------|[0m
-[90m| Foo  | Foo description |[0m
-[90m| Bar  | Bar description |[0m
+[90mUsage:
+
+Example of 'foo_bar' module in `foo_bar.tf`.
+
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
+```hcl
+module "foo_bar" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+```
+
+Here is some trailing text after code block,
+followed by another line of text.
+
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |[0m
 
 
 

--- a/internal/pkg/tfconf/input.go
+++ b/internal/pkg/tfconf/input.go
@@ -13,13 +13,18 @@ type Input struct {
 	Position    Position    `json:"-" yaml:"-"`
 }
 
-// ValueOf returns JSON representation of the 'Default' value, which is an 'interface'.
-func ValueOf(v interface{}) string {
-	marshaled, err := json.MarshalIndent(v, "", "  ")
+// Value returns JSON representation of the 'Default' value, which is an 'interface'.
+// If 'Default' is a primitive type, the primitive value of 'Default' will be returned
+// and not the JSON formatted of it.
+func (i *Input) Value() string {
+	marshaled, err := json.MarshalIndent(i.Default, "", "  ")
 	if err != nil {
 		panic(err)
 	}
-	return string(marshaled)
+	if value := string(marshaled); value != "null" {
+		return value
+	}
+	return ""
 }
 
 // HasDefault indicates if a Terraform variable has a default value set.

--- a/internal/pkg/tfconf/provider.go
+++ b/internal/pkg/tfconf/provider.go
@@ -12,8 +12,8 @@ type Provider struct {
 	Position Position `json:"-" yaml:"-"`
 }
 
-// GetName returns full name of the provider, with alias if available
-func (p *Provider) GetName() string {
+// FullName returns full name of the provider, with alias if available
+func (p *Provider) FullName() string {
 	if p.Alias != "" {
 		return fmt.Sprintf("%s.%s", p.Name, p.Alias)
 	}

--- a/internal/pkg/tmpl/template.go
+++ b/internal/pkg/tmpl/template.go
@@ -1,0 +1,177 @@
+package tmpl
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/segmentio/terraform-docs/internal/pkg/print"
+	"github.com/segmentio/terraform-docs/internal/pkg/print/markdown"
+	"github.com/segmentio/terraform-docs/internal/pkg/tfconf"
+)
+
+// Item represents a named templated which can reference
+// other named templated too
+type Item struct {
+	Name string
+	Text string
+}
+
+// Template represents a new Template with given name and content
+// to be rendered with provided settings with use of built-in and
+// custom functions
+type Template struct {
+	Items    []*Item
+	settings *print.Settings
+	funcMap  map[string]interface{}
+}
+
+// NewTemplate returns new instance of Template
+func NewTemplate(items ...*Item) *Template {
+	settings := print.NewSettings()
+	return &Template{
+		Items:    items,
+		settings: settings,
+		funcMap:  builtinFuncs(settings),
+	}
+}
+
+// CustomFunc adds new custom functions to the template
+// if functions with the same names didn't exist
+func (t *Template) CustomFunc(funcs map[string]interface{}) {
+	for name, fn := range funcs {
+		if t.funcMap[name] == nil {
+			t.funcMap[name] = fn
+		}
+	}
+}
+
+// Settings adds current user-selected settings to the Template
+func (t *Template) Settings(settings *print.Settings) {
+	t.settings = settings
+	if settings != nil {
+		t.funcMap = builtinFuncs(settings)
+	}
+}
+
+// Render renders the Template with given Module struct
+func (t *Template) Render(module *tfconf.Module) (string, error) {
+	if len(t.Items) < 1 {
+		return "", fmt.Errorf("base template not found")
+	}
+	var buffer bytes.Buffer
+	tmpl := template.New(t.Items[0].Name)
+	tmpl.Funcs(t.funcMap)
+	template.Must(tmpl.Parse(normalize(t.Items[0].Text)))
+	for i, item := range t.Items {
+		if i == 0 {
+			continue
+		}
+		tt := tmpl.New(item.Name)
+		tt.Funcs(t.funcMap)
+		template.Must(tt.Parse(normalize(item.Text)))
+	}
+	err := tmpl.ExecuteTemplate(&buffer, t.Items[0].Name, struct {
+		Module   *tfconf.Module
+		Settings *print.Settings
+	}{
+		Module:   module,
+		Settings: t.settings,
+	})
+	if err != nil {
+		return "", err
+	}
+	return buffer.String(), nil
+}
+
+func builtinFuncs(settings *print.Settings) map[string]interface{} {
+	return template.FuncMap{
+		"default": func(d string, s string) string {
+			if s != "" {
+				return s
+			}
+			return d
+		},
+		"ternary": func(c interface{}, t string, f string) string {
+			var condition bool
+			switch x := fmt.Sprintf("%T", c); x {
+			case "string":
+				condition = c.(string) != ""
+			case "int":
+				condition = c.(int) != 0
+			case "bool":
+				condition = c.(bool)
+			}
+			if condition {
+				return t
+			}
+			return f
+		},
+		"tostring": func(s tfconf.String) string {
+			return string(s)
+		},
+		"trim": func(t string, s string) string {
+			if s != "" {
+				return strings.Trim(s, t)
+			}
+			return s
+		},
+		"trimLeft": func(t string, s string) string {
+			if s != "" {
+				return strings.TrimLeft(s, t)
+			}
+			return s
+		},
+		"trimRight": func(t string, s string) string {
+			if s != "" {
+				return strings.TrimRight(s, t)
+			}
+			return s
+		},
+		"trimPrefix": func(t string, s string) string {
+			if s != "" {
+				return strings.TrimPrefix(s, t)
+			}
+			return s
+		},
+		"trimSuffix": func(t string, s string) string {
+			if s != "" {
+				return strings.TrimSuffix(s, t)
+			}
+			return s
+		},
+
+		"indent": func(l int) string {
+			return markdown.GenerateIndentation(l, settings)
+		},
+		"name": func(n string) string {
+			return markdown.SanitizeName(n, settings)
+		},
+		"sanitizeHeader": func(s string) string {
+			settings.EscapePipe = false
+			s = markdown.SanitizeItemForDocument(s, settings)
+			settings.EscapePipe = true
+			return s
+		},
+		"sanitizeDoc": func(s string) string {
+			return markdown.SanitizeItemForDocument(s, settings)
+		},
+		"sanitizeTbl": func(s string) string {
+			return markdown.SanitizeItemForTable(s, settings)
+		},
+	}
+}
+
+// Normalizes the template and remove any space from all the lines.
+// This makes it possible to have a indented, human-readable template
+// which doesn't affect the rendering of them.
+func normalize(s string) string {
+	segments := strings.Split(s, "\n")
+	buffer := bytes.NewBufferString("")
+	for _, segment := range segments {
+		buffer.WriteString(strings.TrimSpace(segment))
+		buffer.WriteString("\n")
+	}
+	return buffer.String()
+}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [x] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

This PR refactors the way different printers work and introduces template rendering engine as opposed to `functions + buffer.WriteString` which have been heavily used. There are some benefits with this approach:

- the code is cleaner and smaller
- the templates are more human friendly
- as a result any changes in the layout would be more natural

For example this is part of a code for rendering `providers` in `table` format:

```tpl
{{- if .Settings.ShowProviders -}}
	{{ indent 0 }} Providers
	{{ if not .Module.Providers }}
		No provider.
	{{ else }}
		| Name | Version |
		|------|---------|
		{{- range .Module.Providers }}
			| {{ name .FullName }} | {{ tostring .Version | default "n/a" }} |
		{{- end }}
	{{ end }}
{{ end -}}
```

Also this is the basic foundation of moving towards plugin system which makes the plugin development easier for external developers.

### Issues Resolved

#149 is blocked by this.

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [ ] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
