### PR TITLE
Preserve asterisk list in header and fix escaping

### DIFF
--- a/docs/formats/json.md
+++ b/docs/formats/json.md
@@ -35,7 +35,7 @@ generates the following output:
 
 ```json
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
   "inputs": [
     {
       "name": "input-with-code-block",

--- a/docs/formats/markdown-document.md
+++ b/docs/formats/markdown-document.md
@@ -42,6 +42,15 @@ generates the following output:
 
     Example of 'foo\_bar' module in `foo_bar.tf`.
 
+    - list item 1
+    - list item 2
+
+    Even inline **formatting** in _here_ is possible.
+    and some [link](https://domain.com/)
+
+    * list item 3
+    * list item 4
+
     ```hcl
     module "foo_bar" {
         source = "github.com/foo/bar"

--- a/docs/formats/markdown-table.md
+++ b/docs/formats/markdown-table.md
@@ -42,6 +42,15 @@ generates the following output:
 
     Example of 'foo\_bar' module in `foo_bar.tf`.
 
+    - list item 1
+    - list item 2
+
+    Even inline **formatting** in _here_ is possible.
+    and some [link](https://domain.com/)
+
+    * list item 3
+    * list item 4
+
     ```hcl
     module "foo_bar" {
         source = "github.com/foo/bar"

--- a/docs/formats/pretty.md
+++ b/docs/formats/pretty.md
@@ -37,6 +37,15 @@ generates the following output:
 
     Example of 'foo_bar' module in `foo_bar.tf`.
 
+    - list item 1
+    - list item 2
+
+    Even inline **formatting** in _here_ is possible.
+    and some [link](https://domain.com/)
+
+    * list item 3
+    * list item 4
+
     ```
     module "foo_bar" {
         source = "github.com/foo/bar"

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -3,6 +3,15 @@
  *
  * Example of 'foo_bar' module in `foo_bar.tf`.
  *
+ * - list item 1
+ * - list item 2
+ *
+ * Even inline **formatting** in _here_ is possible.
+ * and some [link](https://domain.com/)
+ *
+ * * list item 3
+ * * list item 4
+ *
  * ```hcl
  * module "foo_bar" {
  *   source = "github.com/foo/bar"

--- a/internal/pkg/print/json/testdata/json-EscapeCharacters.golden
+++ b/internal/pkg/print/json/testdata/json-EscapeCharacters.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
   "inputs": [
     {
       "name": "unquoted",

--- a/internal/pkg/print/json/testdata/json-NoInputs.golden
+++ b/internal/pkg/print/json/testdata/json-NoInputs.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
   "inputs": [],
   "outputs": [
     {

--- a/internal/pkg/print/json/testdata/json-NoOutputs.golden
+++ b/internal/pkg/print/json/testdata/json-NoOutputs.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
   "inputs": [
     {
       "name": "unquoted",

--- a/internal/pkg/print/json/testdata/json-NoProviders.golden
+++ b/internal/pkg/print/json/testdata/json-NoProviders.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
   "inputs": [
     {
       "name": "unquoted",

--- a/internal/pkg/print/json/testdata/json-OnlyHeader.golden
+++ b/internal/pkg/print/json/testdata/json-OnlyHeader.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
   "inputs": [],
   "outputs": [],
   "providers": []

--- a/internal/pkg/print/json/testdata/json-SortByName.golden
+++ b/internal/pkg/print/json/testdata/json-SortByName.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
   "inputs": [
     {
       "name": "input-with-code-block",

--- a/internal/pkg/print/json/testdata/json-SortByRequired.golden
+++ b/internal/pkg/print/json/testdata/json-SortByRequired.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
   "inputs": [
     {
       "name": "input_with_underscores",

--- a/internal/pkg/print/json/testdata/json.golden
+++ b/internal/pkg/print/json/testdata/json.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
   "inputs": [
     {
       "name": "unquoted",

--- a/internal/pkg/print/markdown/document/testdata/document-EscapeCharacters.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-EscapeCharacters.golden
@@ -2,6 +2,15 @@ Usage:
 
 Example of 'foo\_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/markdown/document/testdata/document-IndentationAboveAllowed.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-IndentationAboveAllowed.golden
@@ -2,6 +2,15 @@ Usage:
 
 Example of 'foo_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/markdown/document/testdata/document-IndentationBellowAllowed.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-IndentationBellowAllowed.golden
@@ -2,6 +2,15 @@ Usage:
 
 Example of 'foo_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/markdown/document/testdata/document-IndentationOfFour.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-IndentationOfFour.golden
@@ -2,6 +2,15 @@ Usage:
 
 Example of 'foo_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/markdown/document/testdata/document-NoInputs.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-NoInputs.golden
@@ -2,6 +2,15 @@ Usage:
 
 Example of 'foo_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/markdown/document/testdata/document-NoOutputs.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-NoOutputs.golden
@@ -2,6 +2,15 @@ Usage:
 
 Example of 'foo_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/markdown/document/testdata/document-NoProviders.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-NoProviders.golden
@@ -2,6 +2,15 @@ Usage:
 
 Example of 'foo_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/markdown/document/testdata/document-OnlyHeader.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-OnlyHeader.golden
@@ -2,6 +2,15 @@ Usage:
 
 Example of 'foo_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/markdown/document/testdata/document-SortByName.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-SortByName.golden
@@ -2,6 +2,15 @@ Usage:
 
 Example of 'foo_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/markdown/document/testdata/document-SortByRequired.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-SortByRequired.golden
@@ -2,6 +2,15 @@ Usage:
 
 Example of 'foo_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/markdown/document/testdata/document-WithRequired.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-WithRequired.golden
@@ -2,6 +2,15 @@ Usage:
 
 Example of 'foo_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/markdown/document/testdata/document.golden
+++ b/internal/pkg/print/markdown/document/testdata/document.golden
@@ -2,6 +2,15 @@ Usage:
 
 Example of 'foo_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/markdown/markdown.go
+++ b/internal/pkg/print/markdown/markdown.go
@@ -127,10 +127,17 @@ func EscapeIllegalCharacters(s string, settings *print.Settings) string {
 			s,
 			"`",
 			func(segment string) string {
+				escape := func(char string) {
+					segment = strings.Replace(segment, char+char, "‡‡", -1)
+					segment = strings.Replace(segment, " "+char, " ‡", -1)
+					segment = strings.Replace(segment, char+" ", "‡ ", -1)
+					segment = strings.Replace(segment, char, "\\"+char, -1)
+					segment = strings.Replace(segment, "‡", char, -1)
+				}
 				// Escape underscore
-				segment = strings.Replace(segment, "_", "\\_", -1)
+				escape("_")
 				// Escape asterisk
-				segment = strings.Replace(segment, "*", "\\*", -1)
+				escape("*")
 				return segment
 			},
 			func(segment string) string {

--- a/internal/pkg/print/markdown/table/testdata/table-EscapeCharacters.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-EscapeCharacters.golden
@@ -2,6 +2,15 @@ Usage:
 
 Example of 'foo\_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/markdown/table/testdata/table-IndentationAboveAllowed.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-IndentationAboveAllowed.golden
@@ -2,6 +2,15 @@ Usage:
 
 Example of 'foo_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/markdown/table/testdata/table-IndentationBellowAllowed.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-IndentationBellowAllowed.golden
@@ -2,6 +2,15 @@ Usage:
 
 Example of 'foo_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/markdown/table/testdata/table-IndentationOfFour.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-IndentationOfFour.golden
@@ -2,6 +2,15 @@ Usage:
 
 Example of 'foo_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/markdown/table/testdata/table-NoInputs.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoInputs.golden
@@ -2,6 +2,15 @@ Usage:
 
 Example of 'foo_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/markdown/table/testdata/table-NoOutputs.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoOutputs.golden
@@ -2,6 +2,15 @@ Usage:
 
 Example of 'foo_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/markdown/table/testdata/table-NoProviders.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoProviders.golden
@@ -2,6 +2,15 @@ Usage:
 
 Example of 'foo_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/markdown/table/testdata/table-OnlyHeader.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-OnlyHeader.golden
@@ -2,6 +2,15 @@ Usage:
 
 Example of 'foo_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/markdown/table/testdata/table-SortByName.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-SortByName.golden
@@ -2,6 +2,15 @@ Usage:
 
 Example of 'foo_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/markdown/table/testdata/table-SortByRequired.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-SortByRequired.golden
@@ -2,6 +2,15 @@ Usage:
 
 Example of 'foo_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/markdown/table/testdata/table-WithRequired.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-WithRequired.golden
@@ -2,6 +2,15 @@ Usage:
 
 Example of 'foo_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/markdown/table/testdata/table.golden
+++ b/internal/pkg/print/markdown/table/testdata/table.golden
@@ -2,6 +2,15 @@ Usage:
 
 Example of 'foo_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/pretty/testdata/pretty-NoColor.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoColor.golden
@@ -4,6 +4,15 @@ Usage:
 
 Example of 'foo_bar' module in `foo_bar.tf`.
 
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
 ```hcl
 module "foo_bar" {
   source = "github.com/foo/bar"

--- a/internal/pkg/print/pretty/testdata/pretty-NoInputs.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoInputs.golden
@@ -4,6 +4,15 @@
 [90m[0m
 [90mExample of 'foo_bar' module in `foo_bar.tf`.[0m
 [90m[0m
+[90m- list item 1[0m
+[90m- list item 2[0m
+[90m[0m
+[90mEven inline **formatting** in _here_ is possible.[0m
+[90mand some [link](https://domain.com/)[0m
+[90m[0m
+[90m* list item 3[0m
+[90m* list item 4[0m
+[90m[0m
 [90m```hcl[0m
 [90mmodule "foo_bar" {[0m
 [90m  source = "github.com/foo/bar"[0m

--- a/internal/pkg/print/pretty/testdata/pretty-NoOutputs.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoOutputs.golden
@@ -4,6 +4,15 @@
 [90m[0m
 [90mExample of 'foo_bar' module in `foo_bar.tf`.[0m
 [90m[0m
+[90m- list item 1[0m
+[90m- list item 2[0m
+[90m[0m
+[90mEven inline **formatting** in _here_ is possible.[0m
+[90mand some [link](https://domain.com/)[0m
+[90m[0m
+[90m* list item 3[0m
+[90m* list item 4[0m
+[90m[0m
 [90m```hcl[0m
 [90mmodule "foo_bar" {[0m
 [90m  source = "github.com/foo/bar"[0m

--- a/internal/pkg/print/pretty/testdata/pretty-NoProviders.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoProviders.golden
@@ -4,6 +4,15 @@
 [90m[0m
 [90mExample of 'foo_bar' module in `foo_bar.tf`.[0m
 [90m[0m
+[90m- list item 1[0m
+[90m- list item 2[0m
+[90m[0m
+[90mEven inline **formatting** in _here_ is possible.[0m
+[90mand some [link](https://domain.com/)[0m
+[90m[0m
+[90m* list item 3[0m
+[90m* list item 4[0m
+[90m[0m
 [90m```hcl[0m
 [90mmodule "foo_bar" {[0m
 [90m  source = "github.com/foo/bar"[0m

--- a/internal/pkg/print/pretty/testdata/pretty-OnlyHeader.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-OnlyHeader.golden
@@ -4,6 +4,15 @@
 [90m[0m
 [90mExample of 'foo_bar' module in `foo_bar.tf`.[0m
 [90m[0m
+[90m- list item 1[0m
+[90m- list item 2[0m
+[90m[0m
+[90mEven inline **formatting** in _here_ is possible.[0m
+[90mand some [link](https://domain.com/)[0m
+[90m[0m
+[90m* list item 3[0m
+[90m* list item 4[0m
+[90m[0m
 [90m```hcl[0m
 [90mmodule "foo_bar" {[0m
 [90m  source = "github.com/foo/bar"[0m

--- a/internal/pkg/print/pretty/testdata/pretty-SortByName.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-SortByName.golden
@@ -4,6 +4,15 @@
 [90m[0m
 [90mExample of 'foo_bar' module in `foo_bar.tf`.[0m
 [90m[0m
+[90m- list item 1[0m
+[90m- list item 2[0m
+[90m[0m
+[90mEven inline **formatting** in _here_ is possible.[0m
+[90mand some [link](https://domain.com/)[0m
+[90m[0m
+[90m* list item 3[0m
+[90m* list item 4[0m
+[90m[0m
 [90m```hcl[0m
 [90mmodule "foo_bar" {[0m
 [90m  source = "github.com/foo/bar"[0m

--- a/internal/pkg/print/pretty/testdata/pretty-SortByRequired.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-SortByRequired.golden
@@ -4,6 +4,15 @@
 [90m[0m
 [90mExample of 'foo_bar' module in `foo_bar.tf`.[0m
 [90m[0m
+[90m- list item 1[0m
+[90m- list item 2[0m
+[90m[0m
+[90mEven inline **formatting** in _here_ is possible.[0m
+[90mand some [link](https://domain.com/)[0m
+[90m[0m
+[90m* list item 3[0m
+[90m* list item 4[0m
+[90m[0m
 [90m```hcl[0m
 [90mmodule "foo_bar" {[0m
 [90m  source = "github.com/foo/bar"[0m

--- a/internal/pkg/print/pretty/testdata/pretty.golden
+++ b/internal/pkg/print/pretty/testdata/pretty.golden
@@ -4,6 +4,15 @@
 [90m[0m
 [90mExample of 'foo_bar' module in `foo_bar.tf`.[0m
 [90m[0m
+[90m- list item 1[0m
+[90m- list item 2[0m
+[90m[0m
+[90mEven inline **formatting** in _here_ is possible.[0m
+[90mand some [link](https://domain.com/)[0m
+[90m[0m
+[90m* list item 3[0m
+[90m* list item 4[0m
+[90m[0m
 [90m```hcl[0m
 [90mmodule "foo_bar" {[0m
 [90m  source = "github.com/foo/bar"[0m

--- a/internal/pkg/tfconf/header.go
+++ b/internal/pkg/tfconf/header.go
@@ -26,8 +26,10 @@ func readHeader(path string) string {
 			if strings.HasPrefix(line, "/*") || strings.HasPrefix(line, "*/") {
 				return "", false
 			}
+			if line == "*" {
+				return "", true
+			}
 			line = strings.TrimPrefix(line, "* ")
-			line = strings.TrimPrefix(line, "*")
 			return line, true
 		},
 	}


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

Previously when parsing and escaping module header, resource comments or directly description, any `*` was getting escaped or removed (if it was first characters of the line), this is to fix that.

Now if any `*` or `_` immediately between characters will be escaped otherwise it will not. This results to flexibility to start using bullet lists with `*` or formatting comment/header with proper `**bold**` or `__italic__` notions.

### Issues Resolved

Fixes the "bullet" part of #178 

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [x] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
