### PR TITLE
Add newline between code block and trailing lines

### DIFF
--- a/docs/formats/json.md
+++ b/docs/formats/json.md
@@ -35,7 +35,7 @@ generates the following output:
 
 ```json
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
   "inputs": [
     {
       "name": "input-with-code-block",

--- a/docs/formats/markdown-document.md
+++ b/docs/formats/markdown-document.md
@@ -59,6 +59,9 @@ generates the following output:
     }
     ```
 
+    Here is some trailing text after code block,
+    followed by another line of text.
+
     ## Providers
 
     The following providers are used by this module:
@@ -113,7 +116,6 @@ generates the following output:
 
     Description: This is a complicated one. We need a newline.
     And an example in a code block
-
     ```
     default     = [
       "machine rack01:neptune"

--- a/docs/formats/markdown-table.md
+++ b/docs/formats/markdown-table.md
@@ -59,6 +59,9 @@ generates the following output:
     }
     ```
 
+    Here is some trailing text after code block,
+    followed by another line of text.
+
     ## Providers
 
     | Name | Version |
@@ -72,14 +75,14 @@ generates the following output:
 
     | Name | Description | Type | Default | Required |
     |------|-------------|------|---------|:-----:|
-    | input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<code><pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre></code> | `list` | <code><pre>[<br>  "name rack:location"<br>]<br></pre></code> | no |
+    | input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]</pre> | `list` | <pre>[<br>  "name rack:location"<br>]</pre> | no |
     | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` | no |
     | input\_with\_underscores | A variable with underscores. | `any` | n/a | yes |
-    | list-1 | It's list number one. | `list` | <code><pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre></code> | no |
+    | list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]</pre> | no |
     | list-2 | It's list number two. | `list` | n/a | yes |
     | list-3 | n/a | `list` | `[]` | no |
-    | long\_type | This description is itself markdown.<br><br>It spans over multiple lines. | <code><pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre></code> | <code><pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre></code> | no |
-    | map-1 | It's map number one. | `map` | <code><pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre></code> | no |
+    | long\_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })</pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}</pre> | no |
+    | map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}</pre> | no |
     | map-2 | It's map number two. | `map` | n/a | yes |
     | map-3 | n/a | `map` | `{}` | no |
     | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE\_WITH\_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` | no |

--- a/docs/formats/pretty.md
+++ b/docs/formats/pretty.md
@@ -54,6 +54,9 @@ generates the following output:
     }
     ```
 
+    Here is some trailing text after code block,
+    followed by another line of text.
+
 
 
     provider.aws (>= 2.15.0)

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -19,6 +19,9 @@
  *   }
  * }
  * ```
+ *
+ * Here is some trailing text after code block,
+ * followed by another line of text.
  */
 
 resource "tls_private_key" "baz" {}

--- a/internal/pkg/print/json/testdata/json-EscapeCharacters.golden
+++ b/internal/pkg/print/json/testdata/json-EscapeCharacters.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
   "inputs": [
     {
       "name": "unquoted",

--- a/internal/pkg/print/json/testdata/json-NoInputs.golden
+++ b/internal/pkg/print/json/testdata/json-NoInputs.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
   "inputs": [],
   "outputs": [
     {

--- a/internal/pkg/print/json/testdata/json-NoOutputs.golden
+++ b/internal/pkg/print/json/testdata/json-NoOutputs.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
   "inputs": [
     {
       "name": "unquoted",

--- a/internal/pkg/print/json/testdata/json-NoProviders.golden
+++ b/internal/pkg/print/json/testdata/json-NoProviders.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
   "inputs": [
     {
       "name": "unquoted",

--- a/internal/pkg/print/json/testdata/json-OnlyHeader.golden
+++ b/internal/pkg/print/json/testdata/json-OnlyHeader.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
   "inputs": [],
   "outputs": [],
   "providers": []

--- a/internal/pkg/print/json/testdata/json-SortByName.golden
+++ b/internal/pkg/print/json/testdata/json-SortByName.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
   "inputs": [
     {
       "name": "input-with-code-block",

--- a/internal/pkg/print/json/testdata/json-SortByRequired.golden
+++ b/internal/pkg/print/json/testdata/json-SortByRequired.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
   "inputs": [
     {
       "name": "input_with_underscores",

--- a/internal/pkg/print/json/testdata/json.golden
+++ b/internal/pkg/print/json/testdata/json.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
   "inputs": [
     {
       "name": "unquoted",

--- a/internal/pkg/print/markdown/document/testdata/document-EscapeCharacters.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-EscapeCharacters.golden
@@ -19,6 +19,9 @@ module "foo_bar" {
 }
 ```
 
+Here is some trailing text after code block,
+followed by another line of text.
+
 ## Providers
 
 The following providers are used by this module:
@@ -151,7 +154,6 @@ Default: `"v1"`
 
 Description: This is a complicated one. We need a newline.  
 And an example in a code block
-
 ```
 default     = [
   "machine rack01:neptune"

--- a/internal/pkg/print/markdown/document/testdata/document-IndentationAboveAllowed.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-IndentationAboveAllowed.golden
@@ -19,6 +19,9 @@ module "foo_bar" {
 }
 ```
 
+Here is some trailing text after code block,
+followed by another line of text.
+
 ## Providers
 
 The following providers are used by this module:
@@ -151,7 +154,6 @@ Default: `"v1"`
 
 Description: This is a complicated one. We need a newline.  
 And an example in a code block
-
 ```
 default     = [
   "machine rack01:neptune"

--- a/internal/pkg/print/markdown/document/testdata/document-IndentationBellowAllowed.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-IndentationBellowAllowed.golden
@@ -19,6 +19,9 @@ module "foo_bar" {
 }
 ```
 
+Here is some trailing text after code block,
+followed by another line of text.
+
 ## Providers
 
 The following providers are used by this module:
@@ -151,7 +154,6 @@ Default: `"v1"`
 
 Description: This is a complicated one. We need a newline.  
 And an example in a code block
-
 ```
 default     = [
   "machine rack01:neptune"

--- a/internal/pkg/print/markdown/document/testdata/document-IndentationOfFour.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-IndentationOfFour.golden
@@ -19,6 +19,9 @@ module "foo_bar" {
 }
 ```
 
+Here is some trailing text after code block,
+followed by another line of text.
+
 #### Providers
 
 The following providers are used by this module:
@@ -151,7 +154,6 @@ Default: `"v1"`
 
 Description: This is a complicated one. We need a newline.  
 And an example in a code block
-
 ```
 default     = [
   "machine rack01:neptune"

--- a/internal/pkg/print/markdown/document/testdata/document-NoHeader.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-NoHeader.golden
@@ -130,7 +130,6 @@ Default: `"v1"`
 
 Description: This is a complicated one. We need a newline.  
 And an example in a code block
-
 ```
 default     = [
   "machine rack01:neptune"

--- a/internal/pkg/print/markdown/document/testdata/document-NoInputs.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-NoInputs.golden
@@ -19,6 +19,9 @@ module "foo_bar" {
 }
 ```
 
+Here is some trailing text after code block,
+followed by another line of text.
+
 ## Providers
 
 The following providers are used by this module:

--- a/internal/pkg/print/markdown/document/testdata/document-NoOutputs.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-NoOutputs.golden
@@ -19,6 +19,9 @@ module "foo_bar" {
 }
 ```
 
+Here is some trailing text after code block,
+followed by another line of text.
+
 ## Providers
 
 The following providers are used by this module:
@@ -151,7 +154,6 @@ Default: `"v1"`
 
 Description: This is a complicated one. We need a newline.  
 And an example in a code block
-
 ```
 default     = [
   "machine rack01:neptune"

--- a/internal/pkg/print/markdown/document/testdata/document-NoProviders.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-NoProviders.golden
@@ -19,6 +19,9 @@ module "foo_bar" {
 }
 ```
 
+Here is some trailing text after code block,
+followed by another line of text.
+
 ## Inputs
 
 The following input variables are supported:
@@ -139,7 +142,6 @@ Default: `"v1"`
 
 Description: This is a complicated one. We need a newline.  
 And an example in a code block
-
 ```
 default     = [
   "machine rack01:neptune"

--- a/internal/pkg/print/markdown/document/testdata/document-OnlyHeader.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-OnlyHeader.golden
@@ -18,3 +18,6 @@ module "foo_bar" {
   }
 }
 ```
+
+Here is some trailing text after code block,
+followed by another line of text.

--- a/internal/pkg/print/markdown/document/testdata/document-OnlyInputs.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-OnlyInputs.golden
@@ -118,7 +118,6 @@ Default: `"v1"`
 
 Description: This is a complicated one. We need a newline.  
 And an example in a code block
-
 ```
 default     = [
   "machine rack01:neptune"

--- a/internal/pkg/print/markdown/document/testdata/document-SortByName.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-SortByName.golden
@@ -19,6 +19,9 @@ module "foo_bar" {
 }
 ```
 
+Here is some trailing text after code block,
+followed by another line of text.
+
 ## Providers
 
 The following providers are used by this module:
@@ -39,7 +42,6 @@ The following input variables are supported:
 
 Description: This is a complicated one. We need a newline.  
 And an example in a code block
-
 ```
 default     = [
   "machine rack01:neptune"

--- a/internal/pkg/print/markdown/document/testdata/document-SortByRequired.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-SortByRequired.golden
@@ -19,6 +19,9 @@ module "foo_bar" {
 }
 ```
 
+Here is some trailing text after code block,
+followed by another line of text.
+
 ## Providers
 
 The following providers are used by this module:
@@ -79,7 +82,6 @@ Default: n/a
 
 Description: This is a complicated one. We need a newline.  
 And an example in a code block
-
 ```
 default     = [
   "machine rack01:neptune"

--- a/internal/pkg/print/markdown/document/testdata/document-WithRequired.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-WithRequired.golden
@@ -19,6 +19,9 @@ module "foo_bar" {
 }
 ```
 
+Here is some trailing text after code block,
+followed by another line of text.
+
 ## Providers
 
 The following providers are used by this module:
@@ -145,7 +148,6 @@ Default: `"v1"`
 
 Description: This is a complicated one. We need a newline.  
 And an example in a code block
-
 ```
 default     = [
   "machine rack01:neptune"

--- a/internal/pkg/print/markdown/document/testdata/document.golden
+++ b/internal/pkg/print/markdown/document/testdata/document.golden
@@ -19,6 +19,9 @@ module "foo_bar" {
 }
 ```
 
+Here is some trailing text after code block,
+followed by another line of text.
+
 ## Providers
 
 The following providers are used by this module:
@@ -151,7 +154,6 @@ Default: `"v1"`
 
 Description: This is a complicated one. We need a newline.  
 And an example in a code block
-
 ```
 default     = [
   "machine rack01:neptune"

--- a/internal/pkg/print/markdown/table/testdata/table-EscapeCharacters.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-EscapeCharacters.golden
@@ -19,6 +19,9 @@ module "foo_bar" {
 }
 ```
 
+Here is some trailing text after code block,
+followed by another line of text.
+
 ## Providers
 
 | Name | Version |
@@ -38,14 +41,14 @@ module "foo_bar" {
 | string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre> |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}</pre> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre> |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]</pre> |
 | input\_with\_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre> | `list` | <pre>[<br>  "name rack:location"<br>]<br></pre> |
-| long\_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre> |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]</pre> | `list` | <pre>[<br>  "name rack:location"<br>]</pre> |
+| long\_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })</pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}</pre> |
 | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE\_WITH\_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` |
 | with-url | The description contains url. https://www.domain.com/foo/bar_baz.html | `string` | `""` |
 

--- a/internal/pkg/print/markdown/table/testdata/table-IndentationAboveAllowed.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-IndentationAboveAllowed.golden
@@ -19,6 +19,9 @@ module "foo_bar" {
 }
 ```
 
+Here is some trailing text after code block,
+followed by another line of text.
+
 ## Providers
 
 | Name | Version |
@@ -38,14 +41,14 @@ module "foo_bar" {
 | string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre> |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}</pre> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre> |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]</pre> |
 | input_with_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre> | `list` | <pre>[<br>  "name rack:location"<br>]<br></pre> |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre> |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]</pre> | `list` | <pre>[<br>  "name rack:location"<br>]</pre> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })</pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}</pre> |
 | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` |
 | with-url | The description contains url. https://www.domain.com/foo/bar_baz.html | `string` | `""` |
 

--- a/internal/pkg/print/markdown/table/testdata/table-IndentationBellowAllowed.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-IndentationBellowAllowed.golden
@@ -19,6 +19,9 @@ module "foo_bar" {
 }
 ```
 
+Here is some trailing text after code block,
+followed by another line of text.
+
 ## Providers
 
 | Name | Version |
@@ -38,14 +41,14 @@ module "foo_bar" {
 | string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre> |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}</pre> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre> |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]</pre> |
 | input_with_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre> | `list` | <pre>[<br>  "name rack:location"<br>]<br></pre> |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre> |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]</pre> | `list` | <pre>[<br>  "name rack:location"<br>]</pre> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })</pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}</pre> |
 | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` |
 | with-url | The description contains url. https://www.domain.com/foo/bar_baz.html | `string` | `""` |
 

--- a/internal/pkg/print/markdown/table/testdata/table-IndentationOfFour.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-IndentationOfFour.golden
@@ -19,6 +19,9 @@ module "foo_bar" {
 }
 ```
 
+Here is some trailing text after code block,
+followed by another line of text.
+
 #### Providers
 
 | Name | Version |
@@ -38,14 +41,14 @@ module "foo_bar" {
 | string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre> |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}</pre> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre> |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]</pre> |
 | input_with_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre> | `list` | <pre>[<br>  "name rack:location"<br>]<br></pre> |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre> |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]</pre> | `list` | <pre>[<br>  "name rack:location"<br>]</pre> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })</pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}</pre> |
 | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` |
 | with-url | The description contains url. https://www.domain.com/foo/bar_baz.html | `string` | `""` |
 

--- a/internal/pkg/print/markdown/table/testdata/table-NoHeader.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoHeader.golden
@@ -17,14 +17,14 @@
 | string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre> |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}</pre> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre> |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]</pre> |
 | input_with_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre> | `list` | <pre>[<br>  "name rack:location"<br>]<br></pre> |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre> |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]</pre> | `list` | <pre>[<br>  "name rack:location"<br>]</pre> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })</pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}</pre> |
 | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` |
 | with-url | The description contains url. https://www.domain.com/foo/bar_baz.html | `string` | `""` |
 

--- a/internal/pkg/print/markdown/table/testdata/table-NoInputs.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoInputs.golden
@@ -19,6 +19,9 @@ module "foo_bar" {
 }
 ```
 
+Here is some trailing text after code block,
+followed by another line of text.
+
 ## Providers
 
 | Name | Version |

--- a/internal/pkg/print/markdown/table/testdata/table-NoOutputs.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoOutputs.golden
@@ -19,6 +19,9 @@ module "foo_bar" {
 }
 ```
 
+Here is some trailing text after code block,
+followed by another line of text.
+
 ## Providers
 
 | Name | Version |
@@ -38,13 +41,13 @@ module "foo_bar" {
 | string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre> |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}</pre> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre> |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]</pre> |
 | input_with_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre> | `list` | <pre>[<br>  "name rack:location"<br>]<br></pre> |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre> |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]</pre> | `list` | <pre>[<br>  "name rack:location"<br>]</pre> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })</pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}</pre> |
 | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` |
 | with-url | The description contains url. https://www.domain.com/foo/bar_baz.html | `string` | `""` |

--- a/internal/pkg/print/markdown/table/testdata/table-NoProviders.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoProviders.golden
@@ -19,6 +19,9 @@ module "foo_bar" {
 }
 ```
 
+Here is some trailing text after code block,
+followed by another line of text.
+
 ## Inputs
 
 | Name | Description | Type | Default |
@@ -29,14 +32,14 @@ module "foo_bar" {
 | string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre> |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}</pre> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre> |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]</pre> |
 | input_with_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre> | `list` | <pre>[<br>  "name rack:location"<br>]<br></pre> |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre> |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]</pre> | `list` | <pre>[<br>  "name rack:location"<br>]</pre> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })</pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}</pre> |
 | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` |
 | with-url | The description contains url. https://www.domain.com/foo/bar_baz.html | `string` | `""` |
 

--- a/internal/pkg/print/markdown/table/testdata/table-OnlyHeader.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-OnlyHeader.golden
@@ -18,3 +18,6 @@ module "foo_bar" {
   }
 }
 ```
+
+Here is some trailing text after code block,
+followed by another line of text.

--- a/internal/pkg/print/markdown/table/testdata/table-OnlyInputs.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-OnlyInputs.golden
@@ -8,13 +8,13 @@
 | string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre> |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}</pre> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre> |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]</pre> |
 | input_with_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre> | `list` | <pre>[<br>  "name rack:location"<br>]<br></pre> |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre> |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]</pre> | `list` | <pre>[<br>  "name rack:location"<br>]</pre> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })</pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}</pre> |
 | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` |
 | with-url | The description contains url. https://www.domain.com/foo/bar_baz.html | `string` | `""` |

--- a/internal/pkg/print/markdown/table/testdata/table-SortByName.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-SortByName.golden
@@ -19,6 +19,9 @@ module "foo_bar" {
 }
 ```
 
+Here is some trailing text after code block,
+followed by another line of text.
+
 ## Providers
 
 | Name | Version |
@@ -32,14 +35,14 @@ module "foo_bar" {
 
 | Name | Description | Type | Default |
 |------|-------------|------|---------|
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre> | `list` | <pre>[<br>  "name rack:location"<br>]<br></pre> |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]</pre> | `list` | <pre>[<br>  "name rack:location"<br>]</pre> |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
 | input_with_underscores | A variable with underscores. | `any` | n/a |
-| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre> |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]</pre> |
 | list-2 | It's list number two. | `list` | n/a |
 | list-3 | n/a | `list` | `[]` |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre> |
-| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })</pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}</pre> |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}</pre> |
 | map-2 | It's map number two. | `map` | n/a |
 | map-3 | n/a | `map` | `{}` |
 | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` |

--- a/internal/pkg/print/markdown/table/testdata/table-SortByRequired.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-SortByRequired.golden
@@ -19,6 +19,9 @@ module "foo_bar" {
 }
 ```
 
+Here is some trailing text after code block,
+followed by another line of text.
+
 ## Providers
 
 | Name | Version |
@@ -37,12 +40,12 @@ module "foo_bar" {
 | map-2 | It's map number two. | `map` | n/a |
 | string-2 | It's string number two. | `string` | n/a |
 | unquoted | n/a | `any` | n/a |
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre> | `list` | <pre>[<br>  "name rack:location"<br>]<br></pre> |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]</pre> | `list` | <pre>[<br>  "name rack:location"<br>]</pre> |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre> |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]</pre> |
 | list-3 | n/a | `list` | `[]` |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre> |
-| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })</pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}</pre> |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}</pre> |
 | map-3 | n/a | `map` | `{}` |
 | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` |
 | string-1 | It's string number one. | `string` | `"bar"` |

--- a/internal/pkg/print/markdown/table/testdata/table-WithRequired.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-WithRequired.golden
@@ -19,6 +19,9 @@ module "foo_bar" {
 }
 ```
 
+Here is some trailing text after code block,
+followed by another line of text.
+
 ## Providers
 
 | Name | Version |
@@ -38,14 +41,14 @@ module "foo_bar" {
 | string-1 | It's string number one. | `string` | `"bar"` | no |
 | map-3 | n/a | `map` | `{}` | no |
 | map-2 | It's map number two. | `map` | n/a | yes |
-| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre> | no |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}</pre> | no |
 | list-3 | n/a | `list` | `[]` | no |
 | list-2 | It's list number two. | `list` | n/a | yes |
-| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre> | no |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]</pre> | no |
 | input_with_underscores | A variable with underscores. | `any` | n/a | yes |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` | no |
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre> | `list` | <pre>[<br>  "name rack:location"<br>]<br></pre> | no |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre> | no |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]</pre> | `list` | <pre>[<br>  "name rack:location"<br>]</pre> | no |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })</pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}</pre> | no |
 | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` | no |
 | with-url | The description contains url. https://www.domain.com/foo/bar_baz.html | `string` | `""` | no |
 

--- a/internal/pkg/print/markdown/table/testdata/table.golden
+++ b/internal/pkg/print/markdown/table/testdata/table.golden
@@ -19,6 +19,9 @@ module "foo_bar" {
 }
 ```
 
+Here is some trailing text after code block,
+followed by another line of text.
+
 ## Providers
 
 | Name | Version |
@@ -38,14 +41,14 @@ module "foo_bar" {
 | string-1 | It's string number one. | `string` | `"bar"` |
 | map-3 | n/a | `map` | `{}` |
 | map-2 | It's map number two. | `map` | n/a |
-| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}<br></pre> |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}</pre> |
 | list-3 | n/a | `list` | `[]` |
 | list-2 | It's list number two. | `list` | n/a |
-| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]<br></pre> |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]</pre> |
 | input_with_underscores | A variable with underscores. | `any` | n/a |
 | input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
-| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]<br></pre> | `list` | <pre>[<br>  "name rack:location"<br>]<br></pre> |
-| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })<br></pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}<br></pre> |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]</pre> | `list` | <pre>[<br>  "name rack:location"<br>]</pre> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })</pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}</pre> |
 | no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` |
 | with-url | The description contains url. https://www.domain.com/foo/bar_baz.html | `string` | `""` |
 

--- a/internal/pkg/print/pretty/testdata/pretty-NoColor.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoColor.golden
@@ -21,6 +21,9 @@ module "foo_bar" {
 }
 ```
 
+Here is some trailing text after code block,
+followed by another line of text.
+
 
 
 provider.tls

--- a/internal/pkg/print/pretty/testdata/pretty-NoInputs.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoInputs.golden
@@ -20,6 +20,9 @@
 [90m  }[0m
 [90m}[0m
 [90m```[0m
+[90m[0m
+[90mHere is some trailing text after code block,[0m
+[90mfollowed by another line of text.[0m
 
 
 

--- a/internal/pkg/print/pretty/testdata/pretty-NoOutputs.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoOutputs.golden
@@ -20,6 +20,9 @@
 [90m  }[0m
 [90m}[0m
 [90m```[0m
+[90m[0m
+[90mHere is some trailing text after code block,[0m
+[90mfollowed by another line of text.[0m
 
 
 

--- a/internal/pkg/print/pretty/testdata/pretty-NoProviders.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoProviders.golden
@@ -20,6 +20,9 @@
 [90m  }[0m
 [90m}[0m
 [90m```[0m
+[90m[0m
+[90mHere is some trailing text after code block,[0m
+[90mfollowed by another line of text.[0m
 
 
 

--- a/internal/pkg/print/pretty/testdata/pretty-OnlyHeader.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-OnlyHeader.golden
@@ -20,4 +20,7 @@
 [90m  }[0m
 [90m}[0m
 [90m```[0m
+[90m[0m
+[90mHere is some trailing text after code block,[0m
+[90mfollowed by another line of text.[0m
 

--- a/internal/pkg/print/pretty/testdata/pretty-SortByName.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-SortByName.golden
@@ -20,6 +20,9 @@
 [90m  }[0m
 [90m}[0m
 [90m```[0m
+[90m[0m
+[90mHere is some trailing text after code block,[0m
+[90mfollowed by another line of text.[0m
 
 
 

--- a/internal/pkg/print/pretty/testdata/pretty-SortByRequired.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-SortByRequired.golden
@@ -20,6 +20,9 @@
 [90m  }[0m
 [90m}[0m
 [90m```[0m
+[90m[0m
+[90mHere is some trailing text after code block,[0m
+[90mfollowed by another line of text.[0m
 
 
 

--- a/internal/pkg/print/pretty/testdata/pretty.golden
+++ b/internal/pkg/print/pretty/testdata/pretty.golden
@@ -20,6 +20,9 @@
 [90m  }[0m
 [90m}[0m
 [90m```[0m
+[90m[0m
+[90mHere is some trailing text after code block,[0m
+[90mfollowed by another line of text.[0m
 
 
 


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

This PR explicitly makes sure a newline (i.e. `\n`) is available between a code block followed by trailing lines when generating header comment.

### Issues Resolved

Fixes #182 

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [x] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
