### PR TITLE
Add double space only at the end of paragraph lines

### DIFF
--- a/internal/pkg/print/markdown/document/testdata/document-EscapeCharacters.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-EscapeCharacters.golden
@@ -5,7 +5,7 @@ Example of 'foo\_bar' module in `foo_bar.tf`.
 - list item 1
 - list item 2
 
-Even inline **formatting** in _here_ is possible.
+Even inline **formatting** in _here_ is possible.  
 and some [link](https://domain.com/)
 
 * list item 3
@@ -28,7 +28,7 @@ module "foo_bar" {
 }
 ```
 
-Here is some trailing text after code block,
+Here is some trailing text after code block,  
 followed by another line of text.
 
 ## Providers

--- a/internal/pkg/print/markdown/document/testdata/document-IndentationAboveAllowed.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-IndentationAboveAllowed.golden
@@ -5,7 +5,7 @@ Example of 'foo_bar' module in `foo_bar.tf`.
 - list item 1
 - list item 2
 
-Even inline **formatting** in _here_ is possible.
+Even inline **formatting** in _here_ is possible.  
 and some [link](https://domain.com/)
 
 * list item 3
@@ -28,7 +28,7 @@ module "foo_bar" {
 }
 ```
 
-Here is some trailing text after code block,
+Here is some trailing text after code block,  
 followed by another line of text.
 
 ## Providers

--- a/internal/pkg/print/markdown/document/testdata/document-IndentationBellowAllowed.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-IndentationBellowAllowed.golden
@@ -5,7 +5,7 @@ Example of 'foo_bar' module in `foo_bar.tf`.
 - list item 1
 - list item 2
 
-Even inline **formatting** in _here_ is possible.
+Even inline **formatting** in _here_ is possible.  
 and some [link](https://domain.com/)
 
 * list item 3
@@ -28,7 +28,7 @@ module "foo_bar" {
 }
 ```
 
-Here is some trailing text after code block,
+Here is some trailing text after code block,  
 followed by another line of text.
 
 ## Providers

--- a/internal/pkg/print/markdown/document/testdata/document-IndentationOfFour.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-IndentationOfFour.golden
@@ -5,7 +5,7 @@ Example of 'foo_bar' module in `foo_bar.tf`.
 - list item 1
 - list item 2
 
-Even inline **formatting** in _here_ is possible.
+Even inline **formatting** in _here_ is possible.  
 and some [link](https://domain.com/)
 
 * list item 3
@@ -28,7 +28,7 @@ module "foo_bar" {
 }
 ```
 
-Here is some trailing text after code block,
+Here is some trailing text after code block,  
 followed by another line of text.
 
 #### Providers

--- a/internal/pkg/print/markdown/document/testdata/document-NoInputs.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-NoInputs.golden
@@ -5,7 +5,7 @@ Example of 'foo_bar' module in `foo_bar.tf`.
 - list item 1
 - list item 2
 
-Even inline **formatting** in _here_ is possible.
+Even inline **formatting** in _here_ is possible.  
 and some [link](https://domain.com/)
 
 * list item 3
@@ -28,7 +28,7 @@ module "foo_bar" {
 }
 ```
 
-Here is some trailing text after code block,
+Here is some trailing text after code block,  
 followed by another line of text.
 
 ## Providers

--- a/internal/pkg/print/markdown/document/testdata/document-NoOutputs.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-NoOutputs.golden
@@ -5,7 +5,7 @@ Example of 'foo_bar' module in `foo_bar.tf`.
 - list item 1
 - list item 2
 
-Even inline **formatting** in _here_ is possible.
+Even inline **formatting** in _here_ is possible.  
 and some [link](https://domain.com/)
 
 * list item 3
@@ -28,7 +28,7 @@ module "foo_bar" {
 }
 ```
 
-Here is some trailing text after code block,
+Here is some trailing text after code block,  
 followed by another line of text.
 
 ## Providers

--- a/internal/pkg/print/markdown/document/testdata/document-NoProviders.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-NoProviders.golden
@@ -5,7 +5,7 @@ Example of 'foo_bar' module in `foo_bar.tf`.
 - list item 1
 - list item 2
 
-Even inline **formatting** in _here_ is possible.
+Even inline **formatting** in _here_ is possible.  
 and some [link](https://domain.com/)
 
 * list item 3
@@ -28,7 +28,7 @@ module "foo_bar" {
 }
 ```
 
-Here is some trailing text after code block,
+Here is some trailing text after code block,  
 followed by another line of text.
 
 ## Inputs

--- a/internal/pkg/print/markdown/document/testdata/document-OnlyHeader.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-OnlyHeader.golden
@@ -5,7 +5,7 @@ Example of 'foo_bar' module in `foo_bar.tf`.
 - list item 1
 - list item 2
 
-Even inline **formatting** in _here_ is possible.
+Even inline **formatting** in _here_ is possible.  
 and some [link](https://domain.com/)
 
 * list item 3
@@ -28,5 +28,5 @@ module "foo_bar" {
 }
 ```
 
-Here is some trailing text after code block,
+Here is some trailing text after code block,  
 followed by another line of text.

--- a/internal/pkg/print/markdown/document/testdata/document-SortByName.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-SortByName.golden
@@ -5,7 +5,7 @@ Example of 'foo_bar' module in `foo_bar.tf`.
 - list item 1
 - list item 2
 
-Even inline **formatting** in _here_ is possible.
+Even inline **formatting** in _here_ is possible.  
 and some [link](https://domain.com/)
 
 * list item 3
@@ -28,7 +28,7 @@ module "foo_bar" {
 }
 ```
 
-Here is some trailing text after code block,
+Here is some trailing text after code block,  
 followed by another line of text.
 
 ## Providers

--- a/internal/pkg/print/markdown/document/testdata/document-SortByRequired.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-SortByRequired.golden
@@ -5,7 +5,7 @@ Example of 'foo_bar' module in `foo_bar.tf`.
 - list item 1
 - list item 2
 
-Even inline **formatting** in _here_ is possible.
+Even inline **formatting** in _here_ is possible.  
 and some [link](https://domain.com/)
 
 * list item 3
@@ -28,7 +28,7 @@ module "foo_bar" {
 }
 ```
 
-Here is some trailing text after code block,
+Here is some trailing text after code block,  
 followed by another line of text.
 
 ## Providers

--- a/internal/pkg/print/markdown/document/testdata/document-WithRequired.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-WithRequired.golden
@@ -5,7 +5,7 @@ Example of 'foo_bar' module in `foo_bar.tf`.
 - list item 1
 - list item 2
 
-Even inline **formatting** in _here_ is possible.
+Even inline **formatting** in _here_ is possible.  
 and some [link](https://domain.com/)
 
 * list item 3
@@ -28,7 +28,7 @@ module "foo_bar" {
 }
 ```
 
-Here is some trailing text after code block,
+Here is some trailing text after code block,  
 followed by another line of text.
 
 ## Providers

--- a/internal/pkg/print/markdown/document/testdata/document.golden
+++ b/internal/pkg/print/markdown/document/testdata/document.golden
@@ -5,7 +5,7 @@ Example of 'foo_bar' module in `foo_bar.tf`.
 - list item 1
 - list item 2
 
-Even inline **formatting** in _here_ is possible.
+Even inline **formatting** in _here_ is possible.  
 and some [link](https://domain.com/)
 
 * list item 3
@@ -28,7 +28,7 @@ module "foo_bar" {
 }
 ```
 
-Here is some trailing text after code block,
+Here is some trailing text after code block,  
 followed by another line of text.
 
 ## Providers

--- a/internal/pkg/print/markdown/markdown.go
+++ b/internal/pkg/print/markdown/markdown.go
@@ -106,6 +106,14 @@ func ConvertMultiLineText(s string, isTable bool) string {
 	// Convert double newlines to <br><br>.
 	s = strings.Replace(s, "\n\n", "<br><br>", -1)
 
+	// Convert line-break on a non-empty line followed by another line
+	// starting with "alphanumeric" word into space-space-newline
+	// which is a know convention of Markdown for multi-lines paragprah.
+	// This doesn't apply on a markdown list for example, because all the
+	// consecutive lines start with hyphen which is a special character.
+	s = regexp.MustCompile(`(\S*)(\r?\n)(\w+)`).ReplaceAllString(s, "$1  $2$3")
+	s = strings.Replace(s, "    \n", "  \n", -1)
+
 	if isTable {
 		// Convert space-space-newline to <br>
 		s = strings.Replace(s, "  \n", "<br>", -1)

--- a/internal/pkg/print/markdown/table/testdata/table-EscapeCharacters.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-EscapeCharacters.golden
@@ -5,7 +5,7 @@ Example of 'foo\_bar' module in `foo_bar.tf`.
 - list item 1
 - list item 2
 
-Even inline **formatting** in _here_ is possible.
+Even inline **formatting** in _here_ is possible.  
 and some [link](https://domain.com/)
 
 * list item 3
@@ -28,7 +28,7 @@ module "foo_bar" {
 }
 ```
 
-Here is some trailing text after code block,
+Here is some trailing text after code block,  
 followed by another line of text.
 
 ## Providers

--- a/internal/pkg/print/markdown/table/testdata/table-IndentationAboveAllowed.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-IndentationAboveAllowed.golden
@@ -5,7 +5,7 @@ Example of 'foo_bar' module in `foo_bar.tf`.
 - list item 1
 - list item 2
 
-Even inline **formatting** in _here_ is possible.
+Even inline **formatting** in _here_ is possible.  
 and some [link](https://domain.com/)
 
 * list item 3
@@ -28,7 +28,7 @@ module "foo_bar" {
 }
 ```
 
-Here is some trailing text after code block,
+Here is some trailing text after code block,  
 followed by another line of text.
 
 ## Providers

--- a/internal/pkg/print/markdown/table/testdata/table-IndentationBellowAllowed.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-IndentationBellowAllowed.golden
@@ -5,7 +5,7 @@ Example of 'foo_bar' module in `foo_bar.tf`.
 - list item 1
 - list item 2
 
-Even inline **formatting** in _here_ is possible.
+Even inline **formatting** in _here_ is possible.  
 and some [link](https://domain.com/)
 
 * list item 3
@@ -28,7 +28,7 @@ module "foo_bar" {
 }
 ```
 
-Here is some trailing text after code block,
+Here is some trailing text after code block,  
 followed by another line of text.
 
 ## Providers

--- a/internal/pkg/print/markdown/table/testdata/table-IndentationOfFour.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-IndentationOfFour.golden
@@ -5,7 +5,7 @@ Example of 'foo_bar' module in `foo_bar.tf`.
 - list item 1
 - list item 2
 
-Even inline **formatting** in _here_ is possible.
+Even inline **formatting** in _here_ is possible.  
 and some [link](https://domain.com/)
 
 * list item 3
@@ -28,7 +28,7 @@ module "foo_bar" {
 }
 ```
 
-Here is some trailing text after code block,
+Here is some trailing text after code block,  
 followed by another line of text.
 
 #### Providers

--- a/internal/pkg/print/markdown/table/testdata/table-NoInputs.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoInputs.golden
@@ -5,7 +5,7 @@ Example of 'foo_bar' module in `foo_bar.tf`.
 - list item 1
 - list item 2
 
-Even inline **formatting** in _here_ is possible.
+Even inline **formatting** in _here_ is possible.  
 and some [link](https://domain.com/)
 
 * list item 3
@@ -28,7 +28,7 @@ module "foo_bar" {
 }
 ```
 
-Here is some trailing text after code block,
+Here is some trailing text after code block,  
 followed by another line of text.
 
 ## Providers

--- a/internal/pkg/print/markdown/table/testdata/table-NoOutputs.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoOutputs.golden
@@ -5,7 +5,7 @@ Example of 'foo_bar' module in `foo_bar.tf`.
 - list item 1
 - list item 2
 
-Even inline **formatting** in _here_ is possible.
+Even inline **formatting** in _here_ is possible.  
 and some [link](https://domain.com/)
 
 * list item 3
@@ -28,7 +28,7 @@ module "foo_bar" {
 }
 ```
 
-Here is some trailing text after code block,
+Here is some trailing text after code block,  
 followed by another line of text.
 
 ## Providers

--- a/internal/pkg/print/markdown/table/testdata/table-NoProviders.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoProviders.golden
@@ -5,7 +5,7 @@ Example of 'foo_bar' module in `foo_bar.tf`.
 - list item 1
 - list item 2
 
-Even inline **formatting** in _here_ is possible.
+Even inline **formatting** in _here_ is possible.  
 and some [link](https://domain.com/)
 
 * list item 3
@@ -28,7 +28,7 @@ module "foo_bar" {
 }
 ```
 
-Here is some trailing text after code block,
+Here is some trailing text after code block,  
 followed by another line of text.
 
 ## Inputs

--- a/internal/pkg/print/markdown/table/testdata/table-OnlyHeader.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-OnlyHeader.golden
@@ -5,7 +5,7 @@ Example of 'foo_bar' module in `foo_bar.tf`.
 - list item 1
 - list item 2
 
-Even inline **formatting** in _here_ is possible.
+Even inline **formatting** in _here_ is possible.  
 and some [link](https://domain.com/)
 
 * list item 3
@@ -28,5 +28,5 @@ module "foo_bar" {
 }
 ```
 
-Here is some trailing text after code block,
+Here is some trailing text after code block,  
 followed by another line of text.

--- a/internal/pkg/print/markdown/table/testdata/table-SortByName.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-SortByName.golden
@@ -5,7 +5,7 @@ Example of 'foo_bar' module in `foo_bar.tf`.
 - list item 1
 - list item 2
 
-Even inline **formatting** in _here_ is possible.
+Even inline **formatting** in _here_ is possible.  
 and some [link](https://domain.com/)
 
 * list item 3
@@ -28,7 +28,7 @@ module "foo_bar" {
 }
 ```
 
-Here is some trailing text after code block,
+Here is some trailing text after code block,  
 followed by another line of text.
 
 ## Providers

--- a/internal/pkg/print/markdown/table/testdata/table-SortByRequired.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-SortByRequired.golden
@@ -5,7 +5,7 @@ Example of 'foo_bar' module in `foo_bar.tf`.
 - list item 1
 - list item 2
 
-Even inline **formatting** in _here_ is possible.
+Even inline **formatting** in _here_ is possible.  
 and some [link](https://domain.com/)
 
 * list item 3
@@ -28,7 +28,7 @@ module "foo_bar" {
 }
 ```
 
-Here is some trailing text after code block,
+Here is some trailing text after code block,  
 followed by another line of text.
 
 ## Providers

--- a/internal/pkg/print/markdown/table/testdata/table-WithRequired.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-WithRequired.golden
@@ -5,7 +5,7 @@ Example of 'foo_bar' module in `foo_bar.tf`.
 - list item 1
 - list item 2
 
-Even inline **formatting** in _here_ is possible.
+Even inline **formatting** in _here_ is possible.  
 and some [link](https://domain.com/)
 
 * list item 3
@@ -28,7 +28,7 @@ module "foo_bar" {
 }
 ```
 
-Here is some trailing text after code block,
+Here is some trailing text after code block,  
 followed by another line of text.
 
 ## Providers

--- a/internal/pkg/print/markdown/table/testdata/table.golden
+++ b/internal/pkg/print/markdown/table/testdata/table.golden
@@ -5,7 +5,7 @@ Example of 'foo_bar' module in `foo_bar.tf`.
 - list item 1
 - list item 2
 
-Even inline **formatting** in _here_ is possible.
+Even inline **formatting** in _here_ is possible.  
 and some [link](https://domain.com/)
 
 * list item 3
@@ -28,7 +28,7 @@ module "foo_bar" {
 }
 ```
 
-Here is some trailing text after code block,
+Here is some trailing text after code block,  
 followed by another line of text.
 
 ## Providers


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

This PR fixes a regression added in #169 and only append double spaces at the end of lines of a paragraph. Lines of a paragraph are the ones:

- followed immediately by another line
- there's no empty lines between them
- the next line starts with a alphanumeric

This, for example, doesn't add any extra spaces at the end of a markdown list (all the lines start with `-`)

### Issues Resolved

Fixes #178 

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [ ] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
