### PR TITLE
Do not escape markdown table inside module header

### DIFF
--- a/docs/formats/json.md
+++ b/docs/formats/json.md
@@ -35,7 +35,7 @@ generates the following output:
 
 ```json
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.\n\n| Name | Description     |\n|------|-----------------|\n| Foo  | Foo description |\n| Bar  | Bar description |",
   "inputs": [
     {
       "name": "input-with-code-block",

--- a/docs/formats/markdown-document.md
+++ b/docs/formats/markdown-document.md
@@ -71,6 +71,11 @@ generates the following output:
     Here is some trailing text after code block,
     followed by another line of text.
 
+    | Name | Description     |
+    |------|-----------------|
+    | Foo  | Foo description |
+    | Bar  | Bar description |
+
     ## Providers
 
     The following providers are used by this module:

--- a/docs/formats/markdown-table.md
+++ b/docs/formats/markdown-table.md
@@ -71,6 +71,11 @@ generates the following output:
     Here is some trailing text after code block,
     followed by another line of text.
 
+    | Name | Description     |
+    |------|-----------------|
+    | Foo  | Foo description |
+    | Bar  | Bar description |
+
     ## Providers
 
     | Name | Version |

--- a/docs/formats/pretty.md
+++ b/docs/formats/pretty.md
@@ -66,6 +66,11 @@ generates the following output:
     Here is some trailing text after code block,
     followed by another line of text.
 
+    | Name | Description     |
+    |------|-----------------|
+    | Foo  | Foo description |
+    | Bar  | Bar description |
+
 
 
     provider.aws (>= 2.15.0)

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -31,6 +31,11 @@
  *
  * Here is some trailing text after code block,
  * followed by another line of text.
+ *
+ * | Name | Description     |
+ * |------|-----------------|
+ * | Foo  | Foo description |
+ * | Bar  | Bar description |
  */
 
 resource "tls_private_key" "baz" {}

--- a/internal/pkg/print/json/json_test.go
+++ b/internal/pkg/print/json/json_test.go
@@ -11,6 +11,7 @@ import (
 func TestJson(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
@@ -30,6 +31,7 @@ func TestJsonSortByName(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		SortByName:    true,
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
@@ -50,6 +52,7 @@ func TestJsonSortByRequired(t *testing.T) {
 	settings := &print.Settings{
 		SortByName:     true,
 		SortByRequired: true,
+		EscapePipe:     true,
 		ShowHeader:     true,
 		ShowProviders:  true,
 		ShowInputs:     true,
@@ -68,6 +71,7 @@ func TestJsonSortByRequired(t *testing.T) {
 func TestJsonNoHeader(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    false,
 		ShowProviders: true,
 		ShowInputs:    true,
@@ -86,6 +90,7 @@ func TestJsonNoHeader(t *testing.T) {
 func TestJsonNoProviders(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: false,
 		ShowInputs:    true,
@@ -104,6 +109,7 @@ func TestJsonNoProviders(t *testing.T) {
 func TestJsonNoInputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    false,
@@ -122,6 +128,7 @@ func TestJsonNoInputs(t *testing.T) {
 func TestJsonNoOutputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
@@ -140,6 +147,7 @@ func TestJsonNoOutputs(t *testing.T) {
 func TestJsonOnlyHeader(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: false,
 		ShowInputs:    false,
@@ -158,6 +166,7 @@ func TestJsonOnlyHeader(t *testing.T) {
 func TestJsonOnlyProviders(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    false,
 		ShowProviders: true,
 		ShowInputs:    false,
@@ -176,6 +185,7 @@ func TestJsonOnlyProviders(t *testing.T) {
 func TestJsonOnlyInputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    false,
 		ShowProviders: false,
 		ShowInputs:    true,
@@ -194,6 +204,7 @@ func TestJsonOnlyInputs(t *testing.T) {
 func TestJsonOnlyOutputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    false,
 		ShowProviders: false,
 		ShowInputs:    false,
@@ -213,6 +224,7 @@ func TestJsonEscapeCharacters(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		EscapeCharacters: true,
+		EscapePipe:       true,
 		ShowHeader:       true,
 		ShowProviders:    true,
 		ShowInputs:       true,

--- a/internal/pkg/print/json/testdata/json-EscapeCharacters.golden
+++ b/internal/pkg/print/json/testdata/json-EscapeCharacters.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.\n\n| Name | Description     |\n|------|-----------------|\n| Foo  | Foo description |\n| Bar  | Bar description |",
   "inputs": [
     {
       "name": "unquoted",

--- a/internal/pkg/print/json/testdata/json-NoInputs.golden
+++ b/internal/pkg/print/json/testdata/json-NoInputs.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.\n\n| Name | Description     |\n|------|-----------------|\n| Foo  | Foo description |\n| Bar  | Bar description |",
   "inputs": [],
   "outputs": [
     {

--- a/internal/pkg/print/json/testdata/json-NoOutputs.golden
+++ b/internal/pkg/print/json/testdata/json-NoOutputs.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.\n\n| Name | Description     |\n|------|-----------------|\n| Foo  | Foo description |\n| Bar  | Bar description |",
   "inputs": [
     {
       "name": "unquoted",

--- a/internal/pkg/print/json/testdata/json-NoProviders.golden
+++ b/internal/pkg/print/json/testdata/json-NoProviders.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.\n\n| Name | Description     |\n|------|-----------------|\n| Foo  | Foo description |\n| Bar  | Bar description |",
   "inputs": [
     {
       "name": "unquoted",

--- a/internal/pkg/print/json/testdata/json-OnlyHeader.golden
+++ b/internal/pkg/print/json/testdata/json-OnlyHeader.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.\n\n| Name | Description     |\n|------|-----------------|\n| Foo  | Foo description |\n| Bar  | Bar description |",
   "inputs": [],
   "outputs": [],
   "providers": []

--- a/internal/pkg/print/json/testdata/json-SortByName.golden
+++ b/internal/pkg/print/json/testdata/json-SortByName.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.\n\n| Name | Description     |\n|------|-----------------|\n| Foo  | Foo description |\n| Bar  | Bar description |",
   "inputs": [
     {
       "name": "input-with-code-block",

--- a/internal/pkg/print/json/testdata/json-SortByRequired.golden
+++ b/internal/pkg/print/json/testdata/json-SortByRequired.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.\n\n| Name | Description     |\n|------|-----------------|\n| Foo  | Foo description |\n| Bar  | Bar description |",
   "inputs": [
     {
       "name": "input_with_underscores",

--- a/internal/pkg/print/json/testdata/json.golden
+++ b/internal/pkg/print/json/testdata/json.golden
@@ -1,5 +1,5 @@
 {
-  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.",
+  "header": "Usage:\n\nExample of 'foo_bar' module in `foo_bar.tf`.\n\n- list item 1\n- list item 2\n\nEven inline **formatting** in _here_ is possible.\nand some [link](https://domain.com/)\n\n* list item 3\n* list item 4\n\n```hcl\nmodule \"foo_bar\" {\n  source = \"github.com/foo/bar\"\n\n  id   = \"1234567890\"\n  name = \"baz\"\n\n  zones = [\"us-east-1\", \"us-west-1\"]\n\n  tags = {\n    Name         = \"baz\"\n    Created-By   = \"first.last@email.com\"\n    Date-Created = \"20180101\"\n  }\n}\n```\n\nHere is some trailing text after code block,\nfollowed by another line of text.\n\n| Name | Description     |\n|------|-----------------|\n| Foo  | Foo description |\n| Bar  | Bar description |",
   "inputs": [
     {
       "name": "unquoted",

--- a/internal/pkg/print/markdown/document/document.go
+++ b/internal/pkg/print/markdown/document/document.go
@@ -123,7 +123,9 @@ func printHeader(buffer *bytes.Buffer, header string, settings *print.Settings) 
 	if len(header) == 0 {
 		return
 	}
+	settings.EscapePipe = false
 	buffer.WriteString(fmt.Sprintf("%s", markdown.SanitizeItemForDocument(header, settings)))
+	settings.EscapePipe = true
 	buffer.WriteString("\n\n")
 }
 

--- a/internal/pkg/print/markdown/document/document_test.go
+++ b/internal/pkg/print/markdown/document/document_test.go
@@ -11,6 +11,7 @@ import (
 func TestDocument(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
@@ -29,6 +30,7 @@ func TestDocument(t *testing.T) {
 func TestDocumentWithRequired(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowRequired:  true,
 		ShowProviders: true,
@@ -49,6 +51,7 @@ func TestDocumentSortByName(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		SortByName:    true,
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
@@ -69,6 +72,7 @@ func TestDocumentSortByRequired(t *testing.T) {
 	settings := &print.Settings{
 		SortByName:     true,
 		SortByRequired: true,
+		EscapePipe:     true,
 		ShowHeader:     true,
 		ShowProviders:  true,
 		ShowInputs:     true,
@@ -87,6 +91,7 @@ func TestDocumentSortByRequired(t *testing.T) {
 func TestDocumentNoHeader(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    false,
 		ShowProviders: true,
 		ShowInputs:    true,
@@ -105,6 +110,7 @@ func TestDocumentNoHeader(t *testing.T) {
 func TestDocumentNoProviders(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: false,
 		ShowInputs:    true,
@@ -123,6 +129,7 @@ func TestDocumentNoProviders(t *testing.T) {
 func TestDocumentNoInputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    false,
@@ -141,6 +148,7 @@ func TestDocumentNoInputs(t *testing.T) {
 func TestDocumentNoOutputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
@@ -159,6 +167,7 @@ func TestDocumentNoOutputs(t *testing.T) {
 func TestDocumentOnlyHeader(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: false,
 		ShowInputs:    false,
@@ -177,6 +186,7 @@ func TestDocumentOnlyHeader(t *testing.T) {
 func TestDocumentOnlyProviders(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    false,
 		ShowProviders: true,
 		ShowInputs:    false,
@@ -195,6 +205,7 @@ func TestDocumentOnlyProviders(t *testing.T) {
 func TestDocumentOnlyInputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    false,
 		ShowProviders: false,
 		ShowInputs:    true,
@@ -213,6 +224,7 @@ func TestDocumentOnlyInputs(t *testing.T) {
 func TestDocumentOnlyOutputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    false,
 		ShowProviders: false,
 		ShowInputs:    false,
@@ -232,6 +244,7 @@ func TestDocumentEscapeCharacters(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		EscapeCharacters: true,
+		EscapePipe:       true,
 		ShowHeader:       true,
 		ShowProviders:    true,
 		ShowInputs:       true,
@@ -251,6 +264,7 @@ func TestDocumentIndentationBellowAllowed(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		MarkdownIndent: 0,
+		EscapePipe:     true,
 		ShowHeader:     true,
 		ShowProviders:  true,
 		ShowInputs:     true,
@@ -270,6 +284,7 @@ func TestDocumentIndentationAboveAllowed(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		MarkdownIndent: 10,
+		EscapePipe:     true,
 		ShowHeader:     true,
 		ShowProviders:  true,
 		ShowInputs:     true,
@@ -289,6 +304,7 @@ func TestDocumentIndentationOfFour(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		MarkdownIndent: 4,
+		EscapePipe:     true,
 		ShowHeader:     true,
 		ShowProviders:  true,
 		ShowInputs:     true,

--- a/internal/pkg/print/markdown/document/testdata/document-EscapeCharacters.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-EscapeCharacters.golden
@@ -31,6 +31,11 @@ module "foo_bar" {
 Here is some trailing text after code block,  
 followed by another line of text.
 
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
 ## Providers
 
 The following providers are used by this module:

--- a/internal/pkg/print/markdown/document/testdata/document-IndentationAboveAllowed.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-IndentationAboveAllowed.golden
@@ -31,6 +31,11 @@ module "foo_bar" {
 Here is some trailing text after code block,  
 followed by another line of text.
 
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
 ## Providers
 
 The following providers are used by this module:

--- a/internal/pkg/print/markdown/document/testdata/document-IndentationBellowAllowed.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-IndentationBellowAllowed.golden
@@ -31,6 +31,11 @@ module "foo_bar" {
 Here is some trailing text after code block,  
 followed by another line of text.
 
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
 ## Providers
 
 The following providers are used by this module:

--- a/internal/pkg/print/markdown/document/testdata/document-IndentationOfFour.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-IndentationOfFour.golden
@@ -31,6 +31,11 @@ module "foo_bar" {
 Here is some trailing text after code block,  
 followed by another line of text.
 
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
 #### Providers
 
 The following providers are used by this module:

--- a/internal/pkg/print/markdown/document/testdata/document-NoInputs.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-NoInputs.golden
@@ -31,6 +31,11 @@ module "foo_bar" {
 Here is some trailing text after code block,  
 followed by another line of text.
 
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
 ## Providers
 
 The following providers are used by this module:

--- a/internal/pkg/print/markdown/document/testdata/document-NoOutputs.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-NoOutputs.golden
@@ -31,6 +31,11 @@ module "foo_bar" {
 Here is some trailing text after code block,  
 followed by another line of text.
 
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
 ## Providers
 
 The following providers are used by this module:

--- a/internal/pkg/print/markdown/document/testdata/document-NoProviders.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-NoProviders.golden
@@ -31,6 +31,11 @@ module "foo_bar" {
 Here is some trailing text after code block,  
 followed by another line of text.
 
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
 ## Inputs
 
 The following input variables are supported:

--- a/internal/pkg/print/markdown/document/testdata/document-OnlyHeader.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-OnlyHeader.golden
@@ -30,3 +30,8 @@ module "foo_bar" {
 
 Here is some trailing text after code block,  
 followed by another line of text.
+
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |

--- a/internal/pkg/print/markdown/document/testdata/document-SortByName.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-SortByName.golden
@@ -31,6 +31,11 @@ module "foo_bar" {
 Here is some trailing text after code block,  
 followed by another line of text.
 
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
 ## Providers
 
 The following providers are used by this module:

--- a/internal/pkg/print/markdown/document/testdata/document-SortByRequired.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-SortByRequired.golden
@@ -31,6 +31,11 @@ module "foo_bar" {
 Here is some trailing text after code block,  
 followed by another line of text.
 
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
 ## Providers
 
 The following providers are used by this module:

--- a/internal/pkg/print/markdown/document/testdata/document-WithRequired.golden
+++ b/internal/pkg/print/markdown/document/testdata/document-WithRequired.golden
@@ -31,6 +31,11 @@ module "foo_bar" {
 Here is some trailing text after code block,  
 followed by another line of text.
 
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
 ## Providers
 
 The following providers are used by this module:

--- a/internal/pkg/print/markdown/document/testdata/document.golden
+++ b/internal/pkg/print/markdown/document/testdata/document.golden
@@ -31,6 +31,11 @@ module "foo_bar" {
 Here is some trailing text after code block,  
 followed by another line of text.
 
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
 ## Providers
 
 The following providers are used by this module:

--- a/internal/pkg/print/markdown/markdown.go
+++ b/internal/pkg/print/markdown/markdown.go
@@ -128,7 +128,9 @@ func ConvertMultiLineText(s string, isTable bool) string {
 // EscapeIllegalCharacters escapes characters which have special meaning in Markdown into their corresponding literal.
 func EscapeIllegalCharacters(s string, settings *print.Settings) string {
 	// Escape pipe
-	s = strings.Replace(s, "|", "\\|", -1)
+	if settings.EscapePipe {
+		s = strings.Replace(s, "|", "\\|", -1)
+	}
 
 	if settings.EscapeCharacters {
 		s = processSegments(

--- a/internal/pkg/print/markdown/table/table.go
+++ b/internal/pkg/print/markdown/table/table.go
@@ -64,7 +64,9 @@ func printHeader(buffer *bytes.Buffer, header string, settings *print.Settings) 
 	if len(header) == 0 {
 		return
 	}
+	settings.EscapePipe = false
 	buffer.WriteString(fmt.Sprintf("%s", markdown.SanitizeItemForDocument(header, settings)))
+	settings.EscapePipe = true
 	buffer.WriteString("\n\n")
 }
 

--- a/internal/pkg/print/markdown/table/table_test.go
+++ b/internal/pkg/print/markdown/table/table_test.go
@@ -11,6 +11,7 @@ import (
 func TestTable(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
@@ -30,6 +31,7 @@ func TestTableWithRequired(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		ShowRequired:  true,
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
@@ -49,6 +51,7 @@ func TestTableSortByName(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		SortByName:    true,
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
@@ -69,6 +72,7 @@ func TestTableSortByRequired(t *testing.T) {
 	settings := &print.Settings{
 		SortByName:     true,
 		SortByRequired: true,
+		EscapePipe:     true,
 		ShowHeader:     true,
 		ShowProviders:  true,
 		ShowInputs:     true,
@@ -87,6 +91,7 @@ func TestTableSortByRequired(t *testing.T) {
 func TestTableNoHeader(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    false,
 		ShowProviders: true,
 		ShowInputs:    true,
@@ -105,6 +110,7 @@ func TestTableNoHeader(t *testing.T) {
 func TestTableNoProviders(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: false,
 		ShowInputs:    true,
@@ -123,6 +129,7 @@ func TestTableNoProviders(t *testing.T) {
 func TestTableNoInputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    false,
@@ -141,6 +148,7 @@ func TestTableNoInputs(t *testing.T) {
 func TestTableNoOutputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
@@ -159,6 +167,7 @@ func TestTableNoOutputs(t *testing.T) {
 func TestTableOnlyHeader(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: false,
 		ShowInputs:    false,
@@ -177,6 +186,7 @@ func TestTableOnlyHeader(t *testing.T) {
 func TestTableOnlyProviders(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    false,
 		ShowProviders: true,
 		ShowInputs:    false,
@@ -195,6 +205,7 @@ func TestTableOnlyProviders(t *testing.T) {
 func TestTableOnlyInputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    false,
 		ShowProviders: false,
 		ShowInputs:    true,
@@ -213,6 +224,7 @@ func TestTableOnlyInputs(t *testing.T) {
 func TestTableOnlyOutputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    false,
 		ShowProviders: false,
 		ShowInputs:    false,
@@ -232,6 +244,7 @@ func TestTableEscapeCharacters(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		EscapeCharacters: true,
+		EscapePipe:       true,
 		ShowHeader:       true,
 		ShowProviders:    true,
 		ShowInputs:       true,
@@ -251,6 +264,7 @@ func TestTableIndentationBellowAllowed(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		MarkdownIndent: 0,
+		EscapePipe:     true,
 		ShowHeader:     true,
 		ShowProviders:  true,
 		ShowInputs:     true,
@@ -270,6 +284,7 @@ func TestTableIndentationAboveAllowed(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		MarkdownIndent: 10,
+		EscapePipe:     true,
 		ShowHeader:     true,
 		ShowProviders:  true,
 		ShowInputs:     true,
@@ -289,6 +304,7 @@ func TestTableIndentationOfFour(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		MarkdownIndent: 4,
+		EscapePipe:     true,
 		ShowHeader:     true,
 		ShowProviders:  true,
 		ShowInputs:     true,

--- a/internal/pkg/print/markdown/table/testdata/table-EscapeCharacters.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-EscapeCharacters.golden
@@ -31,6 +31,11 @@ module "foo_bar" {
 Here is some trailing text after code block,  
 followed by another line of text.
 
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
 ## Providers
 
 | Name | Version |

--- a/internal/pkg/print/markdown/table/testdata/table-IndentationAboveAllowed.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-IndentationAboveAllowed.golden
@@ -31,6 +31,11 @@ module "foo_bar" {
 Here is some trailing text after code block,  
 followed by another line of text.
 
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
 ## Providers
 
 | Name | Version |

--- a/internal/pkg/print/markdown/table/testdata/table-IndentationBellowAllowed.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-IndentationBellowAllowed.golden
@@ -31,6 +31,11 @@ module "foo_bar" {
 Here is some trailing text after code block,  
 followed by another line of text.
 
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
 ## Providers
 
 | Name | Version |

--- a/internal/pkg/print/markdown/table/testdata/table-IndentationOfFour.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-IndentationOfFour.golden
@@ -31,6 +31,11 @@ module "foo_bar" {
 Here is some trailing text after code block,  
 followed by another line of text.
 
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
 #### Providers
 
 | Name | Version |

--- a/internal/pkg/print/markdown/table/testdata/table-NoInputs.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoInputs.golden
@@ -31,6 +31,11 @@ module "foo_bar" {
 Here is some trailing text after code block,  
 followed by another line of text.
 
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
 ## Providers
 
 | Name | Version |

--- a/internal/pkg/print/markdown/table/testdata/table-NoOutputs.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoOutputs.golden
@@ -31,6 +31,11 @@ module "foo_bar" {
 Here is some trailing text after code block,  
 followed by another line of text.
 
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
 ## Providers
 
 | Name | Version |

--- a/internal/pkg/print/markdown/table/testdata/table-NoProviders.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-NoProviders.golden
@@ -31,6 +31,11 @@ module "foo_bar" {
 Here is some trailing text after code block,  
 followed by another line of text.
 
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
 ## Inputs
 
 | Name | Description | Type | Default |

--- a/internal/pkg/print/markdown/table/testdata/table-OnlyHeader.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-OnlyHeader.golden
@@ -30,3 +30,8 @@ module "foo_bar" {
 
 Here is some trailing text after code block,  
 followed by another line of text.
+
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |

--- a/internal/pkg/print/markdown/table/testdata/table-SortByName.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-SortByName.golden
@@ -31,6 +31,11 @@ module "foo_bar" {
 Here is some trailing text after code block,  
 followed by another line of text.
 
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
 ## Providers
 
 | Name | Version |

--- a/internal/pkg/print/markdown/table/testdata/table-SortByRequired.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-SortByRequired.golden
@@ -31,6 +31,11 @@ module "foo_bar" {
 Here is some trailing text after code block,  
 followed by another line of text.
 
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
 ## Providers
 
 | Name | Version |

--- a/internal/pkg/print/markdown/table/testdata/table-WithRequired.golden
+++ b/internal/pkg/print/markdown/table/testdata/table-WithRequired.golden
@@ -31,6 +31,11 @@ module "foo_bar" {
 Here is some trailing text after code block,  
 followed by another line of text.
 
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
 ## Providers
 
 | Name | Version |

--- a/internal/pkg/print/markdown/table/testdata/table.golden
+++ b/internal/pkg/print/markdown/table/testdata/table.golden
@@ -31,6 +31,11 @@ module "foo_bar" {
 Here is some trailing text after code block,  
 followed by another line of text.
 
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
 ## Providers
 
 | Name | Version |

--- a/internal/pkg/print/pretty/pretty_test.go
+++ b/internal/pkg/print/pretty/pretty_test.go
@@ -11,6 +11,7 @@ import (
 func TestPretty(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
@@ -31,6 +32,7 @@ func TestPrettySortByName(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
 		SortByName:    true,
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
@@ -52,6 +54,7 @@ func TestPrettySortByRequired(t *testing.T) {
 	settings := &print.Settings{
 		SortByName:     true,
 		SortByRequired: true,
+		EscapePipe:     true,
 		ShowHeader:     true,
 		ShowProviders:  true,
 		ShowInputs:     true,
@@ -71,8 +74,9 @@ func TestPrettySortByRequired(t *testing.T) {
 func TestPrettyNoHeader(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
-		ShowProviders: false,
+		EscapePipe:    true,
 		ShowHeader:    false,
+		ShowProviders: true,
 		ShowInputs:    true,
 		ShowOutputs:   true,
 		ShowColor:     true,
@@ -90,6 +94,7 @@ func TestPrettyNoHeader(t *testing.T) {
 func TestPrettyNoProviders(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: false,
 		ShowInputs:    true,
@@ -109,6 +114,7 @@ func TestPrettyNoProviders(t *testing.T) {
 func TestPrettyNoInputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    false,
@@ -128,6 +134,7 @@ func TestPrettyNoInputs(t *testing.T) {
 func TestPrettyNoOutputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,
@@ -147,6 +154,7 @@ func TestPrettyNoOutputs(t *testing.T) {
 func TestPrettyOnlyHeader(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: false,
 		ShowInputs:    false,
@@ -166,6 +174,7 @@ func TestPrettyOnlyHeader(t *testing.T) {
 func TestPrettyOnlyProviders(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    false,
 		ShowProviders: true,
 		ShowInputs:    false,
@@ -185,6 +194,7 @@ func TestPrettyOnlyProviders(t *testing.T) {
 func TestPrettyOnlyInputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    false,
 		ShowProviders: false,
 		ShowInputs:    true,
@@ -204,6 +214,7 @@ func TestPrettyOnlyInputs(t *testing.T) {
 func TestPrettyOnlyOutputs(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    false,
 		ShowProviders: false,
 		ShowInputs:    false,
@@ -223,6 +234,7 @@ func TestPrettyOnlyOutputs(t *testing.T) {
 func TestPrettyNoColor(t *testing.T) {
 	assert := assert.New(t)
 	settings := &print.Settings{
+		EscapePipe:    true,
 		ShowHeader:    true,
 		ShowProviders: true,
 		ShowInputs:    true,

--- a/internal/pkg/print/pretty/testdata/pretty-NoColor.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoColor.golden
@@ -33,6 +33,11 @@ module "foo_bar" {
 Here is some trailing text after code block,
 followed by another line of text.
 
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
 
 
 provider.tls

--- a/internal/pkg/print/pretty/testdata/pretty-NoHeader.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoHeader.golden
@@ -1,5 +1,15 @@
 
 
+[36mprovider.tls[0m
+
+[36mprovider.aws[0m (>= 2.15.0)
+
+[36mprovider.aws.ident[0m (>= 2.15.0)
+
+[36mprovider.null[0m
+
+
+
 [36minput.unquoted[0m (required)
 [90mn/a[0m
 

--- a/internal/pkg/print/pretty/testdata/pretty-NoInputs.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoInputs.golden
@@ -32,6 +32,11 @@
 [90m[0m
 [90mHere is some trailing text after code block,[0m
 [90mfollowed by another line of text.[0m
+[90m[0m
+[90m| Name | Description     |[0m
+[90m|------|-----------------|[0m
+[90m| Foo  | Foo description |[0m
+[90m| Bar  | Bar description |[0m
 
 
 

--- a/internal/pkg/print/pretty/testdata/pretty-NoOutputs.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoOutputs.golden
@@ -32,6 +32,11 @@
 [90m[0m
 [90mHere is some trailing text after code block,[0m
 [90mfollowed by another line of text.[0m
+[90m[0m
+[90m| Name | Description     |[0m
+[90m|------|-----------------|[0m
+[90m| Foo  | Foo description |[0m
+[90m| Bar  | Bar description |[0m
 
 
 

--- a/internal/pkg/print/pretty/testdata/pretty-NoProviders.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-NoProviders.golden
@@ -32,6 +32,11 @@
 [90m[0m
 [90mHere is some trailing text after code block,[0m
 [90mfollowed by another line of text.[0m
+[90m[0m
+[90m| Name | Description     |[0m
+[90m|------|-----------------|[0m
+[90m| Foo  | Foo description |[0m
+[90m| Bar  | Bar description |[0m
 
 
 

--- a/internal/pkg/print/pretty/testdata/pretty-OnlyHeader.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-OnlyHeader.golden
@@ -32,4 +32,9 @@
 [90m[0m
 [90mHere is some trailing text after code block,[0m
 [90mfollowed by another line of text.[0m
+[90m[0m
+[90m| Name | Description     |[0m
+[90m|------|-----------------|[0m
+[90m| Foo  | Foo description |[0m
+[90m| Bar  | Bar description |[0m
 

--- a/internal/pkg/print/pretty/testdata/pretty-SortByName.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-SortByName.golden
@@ -32,6 +32,11 @@
 [90m[0m
 [90mHere is some trailing text after code block,[0m
 [90mfollowed by another line of text.[0m
+[90m[0m
+[90m| Name | Description     |[0m
+[90m|------|-----------------|[0m
+[90m| Foo  | Foo description |[0m
+[90m| Bar  | Bar description |[0m
 
 
 

--- a/internal/pkg/print/pretty/testdata/pretty-SortByRequired.golden
+++ b/internal/pkg/print/pretty/testdata/pretty-SortByRequired.golden
@@ -32,6 +32,11 @@
 [90m[0m
 [90mHere is some trailing text after code block,[0m
 [90mfollowed by another line of text.[0m
+[90m[0m
+[90m| Name | Description     |[0m
+[90m|------|-----------------|[0m
+[90m| Foo  | Foo description |[0m
+[90m| Bar  | Bar description |[0m
 
 
 

--- a/internal/pkg/print/pretty/testdata/pretty.golden
+++ b/internal/pkg/print/pretty/testdata/pretty.golden
@@ -32,6 +32,11 @@
 [90m[0m
 [90mHere is some trailing text after code block,[0m
 [90mfollowed by another line of text.[0m
+[90m[0m
+[90m| Name | Description     |[0m
+[90m|------|-----------------|[0m
+[90m| Foo  | Foo description |[0m
+[90m| Bar  | Bar description |[0m
 
 
 

--- a/internal/pkg/print/settings.go
+++ b/internal/pkg/print/settings.go
@@ -2,9 +2,13 @@ package print
 
 // Settings represents all settings
 type Settings struct {
-	// EscapeCharacters escapes special characters (such as | _ * in Markdown and > < in JSON) (default: true)
+	// EscapeCharacters escapes special characters (such as _ * in Markdown and > < in JSON) (default: true)
 	// scope: Markdown
 	EscapeCharacters bool
+
+	// EscapePipe escapes pipe character in Markdown (default: true)
+	// scope: Markdown
+	EscapePipe bool
 
 	// MarkdownIndent control the indentation of Markdown headers [available: 1, 2, 3, 4, 5] (default: 2)
 	// scope: Markdown
@@ -47,6 +51,7 @@ type Settings struct {
 func NewSettings() *Settings {
 	return &Settings{
 		EscapeCharacters: true,
+		EscapePipe:       true,
 		MarkdownIndent:   2,
 		ShowColor:        true,
 		ShowHeader:       true,


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

Describe what this pull request achieves. Ensure you have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md) document before submitting.

### Issues Resolved

Previously if there's a markdown table defined inside the module header all the pipes (`|`) were escaped and the table didn't actually get rendered as a _table_, this PR adds a new internal flag in the `print.Settings` called `EscapePipe` which controls this functionality.

Note that this is an internal flag and there's no control over it from outside.

as an example this will get rendered properly:

`main.tf`:

```hcl
/**
 * Here is some trailing text after code block,
 * followed by another line of text.
 *
 * | Name | Description     |
 * |------|-----------------|
 * | Foo  | Foo description |
 * | Bar  | Bar description |
 */

resources "foo" ...
```

as

Here is some trailing text after code block,
followed by another line of text.

| Name | Description     |
|------|-----------------|
| Foo  | Foo description |
| Bar  | Bar description |

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [x] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

#### Code Style

- [ ] My code follows the code style of this project.
