### PR TITLE
Put reference to usage, cli, etc. in user guide

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1,6 +1,8 @@
 # User Guide
 
-TBA
+## Syntax, Usage, and Output Formats
+
+Please refer to [docs/README.md](/docs/README.md) for guidance on output formats, execution syntax, CLI options, etc.
 
 ## Integrating With Your Terraform Repository
 


### PR DESCRIPTION
resolves #180

### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

Resolves discoverability issue in locating usage info and description of output formats.

The root [README.md](README.me) has no reference to [docs/README.md](docs/README.md) and only referred to [docs/USAGE_GUIDE.md](docs/USAGE_GUIDE.md) which only contained git hook info, but nothing about actually using the tool.

This PR resolves the issue, and takes a minimally-invasive approach to resolving basic discoverability of CLI usage and output format info. Previously you would have to know to ignore `README.md` and `docs/USAGE_GUIDE.md`, manually navigating to `docs/README.md`.

### Issues Resolved

resolves #180 

### Checklist

Put an `x` into all boxes that apply:

- [x] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

`n/a`

- [ ] I have added tests to cover my changes.
- [ ] All tests pass when I run `make test`.

#### Documentation

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

#### Code Style

- [x] My code follows the code style of this project.
