### PR TITLE
Allow hiding the "Sensitive" column in markdown

### DIFF
--- a/cmd/markdown.go
+++ b/cmd/markdown.go
@@ -37,6 +37,7 @@ var mdDocumentCmd = &cobra.Command{
 
 func init() {
 	markdownCmd.PersistentFlags().BoolVar(new(bool), "no-required", false, "do not show \"Required\" column or section")
+	markdownCmd.PersistentFlags().BoolVar(new(bool), "no-sensitive", false, "do not show \"Sensitive\" column or section")
 	markdownCmd.PersistentFlags().BoolVar(new(bool), "no-escape", false, "do not escape special characters")
 	markdownCmd.PersistentFlags().IntVar(&settings.MarkdownIndent, "indent", 2, "indention level of Markdown sections [1, 2, 3, 4, 5]")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,7 @@ var rootCmd = &cobra.Command{
 		settings.SortByName = oppositeBool("no-sort")
 		settings.ShowRequired = oppositeBool("no-required")
 		settings.EscapeCharacters = oppositeBool("no-escape")
+		settings.ShowSensitivity = oppositeBool("no-sensitive")
 	},
 }
 

--- a/docs/formats/markdown-document.md
+++ b/docs/formats/markdown-document.md
@@ -27,6 +27,7 @@ terraform-docs markdown document [PATH] [flags]
       --no-outputs                     do not show outputs
       --no-providers                   do not show providers
       --no-required                    do not show "Required" column or section
+      --no-sensitive                   do not show "Sensitive" column or section
       --no-requirements                do not show module requirements
       --no-sort                        do no sort items
       --output-values                  inject output values into outputs

--- a/docs/formats/markdown-table.md
+++ b/docs/formats/markdown-table.md
@@ -27,6 +27,7 @@ terraform-docs markdown table [PATH] [flags]
       --no-outputs                     do not show outputs
       --no-providers                   do not show providers
       --no-required                    do not show "Required" column or section
+      --no-sensitive                   do not show "Sensitive" column or section
       --no-requirements                do not show module requirements
       --no-sort                        do no sort items
       --output-values                  inject output values into outputs

--- a/docs/formats/markdown.md
+++ b/docs/formats/markdown.md
@@ -17,6 +17,7 @@ terraform-docs markdown [PATH] [flags]
       --indent int    indention level of Markdown sections [1, 2, 3, 4, 5] (default 2)
       --no-escape     do not escape special characters
       --no-required   do not show "Required" column or section
+      --no-sensitive  do not show "Sensitive" column or section
 ```
 
 ### Options inherited from parent commands

--- a/internal/format/document.go
+++ b/internal/format/document.go
@@ -113,7 +113,9 @@ const (
 					{{- $sensitive := ternary .Sensitive "<sensitive>" .GetValue -}}
 					Value: {{ value $sensitive | sanitizeDoc }}
 
-					{{ if $.Settings.ShowSensitivity }}Sensitive: {{ ternary (.Sensitive) "yes" "no" }}{{ end }}
+					{{ if $.Settings.ShowSensitivity -}}
+						Sensitive: {{ ternary (.Sensitive) "yes" "no" }}
+					{{- end }}
 				{{ end }}
 			{{ end }}
 		{{ end }}

--- a/internal/format/document.go
+++ b/internal/format/document.go
@@ -113,7 +113,7 @@ const (
 					{{- $sensitive := ternary .Sensitive "<sensitive>" .GetValue -}}
 					Value: {{ value $sensitive | sanitizeDoc }}
 
-					Sensitive: {{ ternary (.Sensitive) "yes" "no" }}
+					{{ if $.Settings.ShowSensitivity }}Sensitive: {{ ternary (.Sensitive) "yes" "no" }}{{ end }}
 				{{ end }}
 			{{ end }}
 		{{ end }}

--- a/internal/format/document_test.go
+++ b/internal/format/document_test.go
@@ -424,7 +424,8 @@ func TestDocumentIndentationOfFour(t *testing.T) {
 func TestDocumentOutputValues(t *testing.T) {
 	assert := assert.New(t)
 	settings := testutil.Settings().WithSections().With(&print.Settings{
-		OutputValues: true,
+		OutputValues:    true,
+		ShowSensitivity: true,
 	}).Build()
 
 	expected, err := testutil.GetExpected("document", "document-OutputValues")
@@ -458,6 +459,30 @@ func TestDocumentHeaderFromFile(t *testing.T) {
 	})
 	assert.Nil(err)
 
+	module, err := testutil.GetModule(options)
+	assert.Nil(err)
+
+	printer := NewDocument(settings)
+	actual, err := printer.Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestDocumentOutputValuesNoSensitivity(t *testing.T) {
+	assert := assert.New(t)
+	settings := testutil.Settings().WithSections().With(&print.Settings{
+		OutputValues:    true,
+		ShowSensitivity: false,
+	}).Build()
+
+	expected, err := testutil.GetExpected("document", "document-OutputValuesNoSensitivity")
+	assert.Nil(err)
+
+	options := module.NewOptions().With(&module.Options{
+		OutputValues:     true,
+		OutputValuesPath: "output_values.json",
+	})
 	module, err := testutil.GetModule(options)
 	assert.Nil(err)
 

--- a/internal/format/document_test.go
+++ b/internal/format/document_test.go
@@ -476,17 +476,19 @@ func TestDocumentOutputValuesNoSensitivity(t *testing.T) {
 		ShowSensitivity: false,
 	}).Build()
 
-	expected, err := testutil.GetExpected("document", "document-OutputValuesNoSensitivity")
+	expected, err := testutil.GetExpected("table", "table-OutputValuesNoSensitivity")
 	assert.Nil(err)
 
-	options := module.NewOptions().With(&module.Options{
+	options, err := module.NewOptions().With(&module.Options{
 		OutputValues:     true,
 		OutputValuesPath: "output_values.json",
 	})
+	assert.Nil(err)
+
 	module, err := testutil.GetModule(options)
 	assert.Nil(err)
 
-	printer := NewDocument(settings)
+	printer := NewTable(settings)
 	actual, err := printer.Print(module, settings)
 
 	assert.Nil(err)

--- a/internal/format/document_test.go
+++ b/internal/format/document_test.go
@@ -476,7 +476,7 @@ func TestDocumentOutputValuesNoSensitivity(t *testing.T) {
 		ShowSensitivity: false,
 	}).Build()
 
-	expected, err := testutil.GetExpected("table", "table-OutputValuesNoSensitivity")
+	expected, err := testutil.GetExpected("document", "document-OutputValuesNoSensitivity")
 	assert.Nil(err)
 
 	options, err := module.NewOptions().With(&module.Options{
@@ -488,7 +488,7 @@ func TestDocumentOutputValuesNoSensitivity(t *testing.T) {
 	module, err := testutil.GetModule(options)
 	assert.Nil(err)
 
-	printer := NewTable(settings)
+	printer := NewDocument(settings)
 	actual, err := printer.Print(module, settings)
 
 	assert.Nil(err)

--- a/internal/format/table.go
+++ b/internal/format/table.go
@@ -72,13 +72,16 @@ const (
 		{{ if not .Module.Outputs }}
 			No output.
 		{{ else }}
-			| Name | Description |{{ if .Settings.OutputValues }} Value | Sensitive |{{ end }}
-			|------|-------------|{{ if .Settings.OutputValues }}-------|:---------:|{{ end }}
+			| Name | Description |{{ if .Settings.OutputValues }} Value |{{ if $.Settings.ShowSensitivity }} Sensitive |{{ end }}{{ end }}
+			|------|-------------|{{ if .Settings.OutputValues }}-------|{{ if $.Settings.ShowSensitivity }}:---------:|{{ end }}{{ end }}
 			{{- range .Module.Outputs }}
 				| {{ name .Name }} | {{ tostring .Description | sanitizeTbl }} |
 				{{- if $.Settings.OutputValues -}}
 					{{- $sensitive := ternary .Sensitive "<sensitive>" .GetValue -}}
-					{{ printf " " }}{{ value $sensitive | sanitizeTbl }} | {{ ternary (.Sensitive) "yes" "no" }} |
+					{{ printf " " }}{{ value $sensitive | sanitizeTbl }} |
+					{{- if $.Settings.ShowSensitivity -}} 
+						{{ printf " " }}{{ ternary (.Sensitive) "yes" "no" }} |
+					{{- end -}}
 				{{- end -}}
 			{{- end }}
 		{{ end }}

--- a/internal/format/table_test.go
+++ b/internal/format/table_test.go
@@ -421,7 +421,7 @@ func TestTableIndentationOfFour(t *testing.T) {
 	assert.Equal(expected, actual)
 }
 
-func TestTableOutputValuesNoSensitivity(t *testing.T) {
+func TestTableOutputValues(t *testing.T) {
 	assert := assert.New(t)
 	settings := testutil.Settings().WithSections().With(&print.Settings{
 		OutputValues:    true,
@@ -469,7 +469,7 @@ func TestTableHeaderFromFile(t *testing.T) {
 	assert.Equal(expected, actual)
 }
 
-func TestTableOutputValues(t *testing.T) {
+func TestTableOutputValuesNoSensitivity(t *testing.T) {
 	assert := assert.New(t)
 	settings := testutil.Settings().WithSections().With(&print.Settings{
 		OutputValues:    true,
@@ -479,10 +479,12 @@ func TestTableOutputValues(t *testing.T) {
 	expected, err := testutil.GetExpected("table", "table-OutputValuesNoSensitivity")
 	assert.Nil(err)
 
-	options := module.NewOptions().With(&module.Options{
+	options, err := module.NewOptions().With(&module.Options{
 		OutputValues:     true,
 		OutputValuesPath: "output_values.json",
 	})
+	assert.Nil(err)
+
 	module, err := testutil.GetModule(options)
 	assert.Nil(err)
 

--- a/internal/format/table_test.go
+++ b/internal/format/table_test.go
@@ -421,10 +421,11 @@ func TestTableIndentationOfFour(t *testing.T) {
 	assert.Equal(expected, actual)
 }
 
-func TestTableOutputValues(t *testing.T) {
+func TestTableOutputValuesNoSensitivity(t *testing.T) {
 	assert := assert.New(t)
 	settings := testutil.Settings().WithSections().With(&print.Settings{
-		OutputValues: true,
+		OutputValues:    true,
+		ShowSensitivity: true,
 	}).Build()
 
 	expected, err := testutil.GetExpected("table", "table-OutputValues")
@@ -458,6 +459,30 @@ func TestTableHeaderFromFile(t *testing.T) {
 	})
 	assert.Nil(err)
 
+	module, err := testutil.GetModule(options)
+	assert.Nil(err)
+
+	printer := NewTable(settings)
+	actual, err := printer.Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}
+
+func TestTableOutputValues(t *testing.T) {
+	assert := assert.New(t)
+	settings := testutil.Settings().WithSections().With(&print.Settings{
+		OutputValues:    true,
+		ShowSensitivity: false,
+	}).Build()
+
+	expected, err := testutil.GetExpected("table", "table-OutputValuesNoSensitivity")
+	assert.Nil(err)
+
+	options := module.NewOptions().With(&module.Options{
+		OutputValues:     true,
+		OutputValuesPath: "output_values.json",
+	})
 	module, err := testutil.GetModule(options)
 	assert.Nil(err)
 

--- a/internal/format/testdata/document/document-OutputValuesNoSensitivity.golden
+++ b/internal/format/testdata/document/document-OutputValuesNoSensitivity.golden
@@ -36,6 +36,14 @@ followed by another line of text.
 | Foo  | Foo description |
 | Bar  | Bar description |
 
+## Requirements
+
+The following requirements are needed by this module:
+
+- terraform (>= 0.12)
+
+- aws (>= 2.15.0)
+
 ## Providers
 
 The following providers are used by this module:

--- a/internal/format/testdata/document/document-OutputValuesNoSensitivity.golden
+++ b/internal/format/testdata/document/document-OutputValuesNoSensitivity.golden
@@ -1,0 +1,337 @@
+Usage:
+
+Example of 'foo_bar' module in `foo_bar.tf`.
+
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.  
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
+```hcl
+module "foo_bar" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+```
+
+Here is some trailing text after code block,  
+followed by another line of text.
+
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
+## Providers
+
+The following providers are used by this module:
+
+- tls
+
+- aws (>= 2.15.0)
+
+- aws.ident (>= 2.15.0)
+
+- null
+
+## Inputs
+
+The following input variables are supported:
+
+### unquoted
+
+Description: n/a
+
+Type: `any`
+
+Default: n/a
+
+### bool-3
+
+Description: n/a
+
+Type: `bool`
+
+Default: `true`
+
+### bool-2
+
+Description: It's bool number two.
+
+Type: `bool`
+
+Default: `false`
+
+### bool-1
+
+Description: It's bool number one.
+
+Type: `bool`
+
+Default: `true`
+
+### string-3
+
+Description: n/a
+
+Type: `string`
+
+Default: `""`
+
+### string-2
+
+Description: It's string number two.
+
+Type: `string`
+
+Default: n/a
+
+### string-1
+
+Description: It's string number one.
+
+Type: `string`
+
+Default: `"bar"`
+
+### number-3
+
+Description: n/a
+
+Type: `number`
+
+Default: `"19"`
+
+### number-4
+
+Description: n/a
+
+Type: `number`
+
+Default: `15.75`
+
+### number-2
+
+Description: It's number number two.
+
+Type: `number`
+
+Default: n/a
+
+### number-1
+
+Description: It's number number one.
+
+Type: `number`
+
+Default: `42`
+
+### map-3
+
+Description: n/a
+
+Type: `map`
+
+Default: `{}`
+
+### map-2
+
+Description: It's map number two.
+
+Type: `map`
+
+Default: n/a
+
+### map-1
+
+Description: It's map number one.
+
+Type: `map`
+
+Default:
+
+```json
+{
+  "a": 1,
+  "b": 2,
+  "c": 3
+}
+```
+
+### list-3
+
+Description: n/a
+
+Type: `list`
+
+Default: `[]`
+
+### list-2
+
+Description: It's list number two.
+
+Type: `list`
+
+Default: n/a
+
+### list-1
+
+Description: It's list number one.
+
+Type: `list`
+
+Default:
+
+```json
+[
+  "a",
+  "b",
+  "c"
+]
+```
+
+### input_with_underscores
+
+Description: A variable with underscores.
+
+Type: `any`
+
+Default: n/a
+
+### input-with-pipe
+
+Description: It includes v1 \| v2 \| v3
+
+Type: `string`
+
+Default: `"v1"`
+
+### input-with-code-block
+
+Description: This is a complicated one. We need a newline.  
+And an example in a code block
+```
+default     = [
+  "machine rack01:neptune"
+]
+```
+
+Type: `list`
+
+Default:
+
+```json
+[
+  "name rack:location"
+]
+```
+
+### long_type
+
+Description: This description is itself markdown.
+
+It spans over multiple lines.
+
+Type:
+
+```hcl
+object({
+    name = string,
+    foo  = object({ foo = string, bar = string }),
+    bar  = object({ foo = string, bar = string }),
+    fizz = list(string),
+    buzz = list(string)
+  })
+```
+
+Default:
+
+```json
+{
+  "bar": {
+    "bar": "bar",
+    "foo": "bar"
+  },
+  "buzz": [
+    "fizz",
+    "buzz"
+  ],
+  "fizz": [],
+  "foo": {
+    "bar": "foo",
+    "foo": "foo"
+  },
+  "name": "hello"
+}
+```
+
+### no-escape-default-value
+
+Description: The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'.
+
+Type: `string`
+
+Default: `"VALUE_WITH_UNDERSCORE"`
+
+### with-url
+
+Description: The description contains url. https://www.domain.com/foo/bar_baz.html
+
+Type: `string`
+
+Default: `""`
+
+## Outputs
+
+The following outputs are exported:
+
+### unquoted
+
+Description: It's unquoted output.
+
+Value:
+
+```json
+{
+  "leon": "cat"
+}
+```
+
+### output-2
+
+Description: It's output number two.
+
+Value:
+
+```json
+[
+  "jack",
+  "lola"
+]
+```
+
+### output-1
+
+Description: It's output number one.
+
+Value: `1`
+
+### output-0.12
+
+Description: terraform 0.12 only
+
+Value: `<sensitive>`

--- a/internal/format/testdata/table/table-OutputValuesNoSensitivity.golden
+++ b/internal/format/testdata/table/table-OutputValuesNoSensitivity.golden
@@ -36,6 +36,13 @@ followed by another line of text.
 | Foo  | Foo description |
 | Bar  | Bar description |
 
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.12 |
+| aws | >= 2.15.0 |
+
 ## Providers
 
 | Name | Version |

--- a/internal/format/testdata/table/table-OutputValuesNoSensitivity.golden
+++ b/internal/format/testdata/table/table-OutputValuesNoSensitivity.golden
@@ -1,0 +1,83 @@
+Usage:
+
+Example of 'foo_bar' module in `foo_bar.tf`.
+
+- list item 1
+- list item 2
+
+Even inline **formatting** in _here_ is possible.  
+and some [link](https://domain.com/)
+
+* list item 3
+* list item 4
+
+```hcl
+module "foo_bar" {
+  source = "github.com/foo/bar"
+
+  id   = "1234567890"
+  name = "baz"
+
+  zones = ["us-east-1", "us-west-1"]
+
+  tags = {
+    Name         = "baz"
+    Created-By   = "first.last@email.com"
+    Date-Created = "20180101"
+  }
+}
+```
+
+Here is some trailing text after code block,  
+followed by another line of text.
+
+| Name | Description     |
+|------|-----------------|
+| Foo  | Foo description |
+| Bar  | Bar description |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| tls | n/a |
+| aws | >= 2.15.0 |
+| aws.ident | >= 2.15.0 |
+| null | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default |
+|------|-------------|------|---------|
+| unquoted | n/a | `any` | n/a |
+| bool-3 | n/a | `bool` | `true` |
+| bool-2 | It's bool number two. | `bool` | `false` |
+| bool-1 | It's bool number one. | `bool` | `true` |
+| string-3 | n/a | `string` | `""` |
+| string-2 | It's string number two. | `string` | n/a |
+| string-1 | It's string number one. | `string` | `"bar"` |
+| number-3 | n/a | `number` | `"19"` |
+| number-4 | n/a | `number` | `15.75` |
+| number-2 | It's number number two. | `number` | n/a |
+| number-1 | It's number number one. | `number` | `42` |
+| map-3 | n/a | `map` | `{}` |
+| map-2 | It's map number two. | `map` | n/a |
+| map-1 | It's map number one. | `map` | <pre>{<br>  "a": 1,<br>  "b": 2,<br>  "c": 3<br>}</pre> |
+| list-3 | n/a | `list` | `[]` |
+| list-2 | It's list number two. | `list` | n/a |
+| list-1 | It's list number one. | `list` | <pre>[<br>  "a",<br>  "b",<br>  "c"<br>]</pre> |
+| input_with_underscores | A variable with underscores. | `any` | n/a |
+| input-with-pipe | It includes v1 \| v2 \| v3 | `string` | `"v1"` |
+| input-with-code-block | This is a complicated one. We need a newline.<br>And an example in a code block<pre>default     = [<br>  "machine rack01:neptune"<br>]</pre> | `list` | <pre>[<br>  "name rack:location"<br>]</pre> |
+| long_type | This description is itself markdown.<br><br>It spans over multiple lines. | <pre>object({<br>    name = string,<br>    foo  = object({ foo = string, bar = string }),<br>    bar  = object({ foo = string, bar = string }),<br>    fizz = list(string),<br>    buzz = list(string)<br>  })</pre> | <pre>{<br>  "bar": {<br>    "bar": "bar",<br>    "foo": "bar"<br>  },<br>  "buzz": [<br>    "fizz",<br>    "buzz"<br>  ],<br>  "fizz": [],<br>  "foo": {<br>    "bar": "foo",<br>    "foo": "foo"<br>  },<br>  "name": "hello"<br>}</pre> |
+| no-escape-default-value | The description contains `something_with_underscore`. Defaults to 'VALUE_WITH_UNDERSCORE'. | `string` | `"VALUE_WITH_UNDERSCORE"` |
+| with-url | The description contains url. https://www.domain.com/foo/bar_baz.html | `string` | `""` |
+
+## Outputs
+
+| Name | Description | Value |
+|------|-------------|-------|
+| unquoted | It's unquoted output. | <pre>{<br>  "leon": "cat"<br>}</pre> |
+| output-2 | It's output number two. | <pre>[<br>  "jack",<br>  "lola"<br>]</pre> |
+| output-1 | It's output number one. | `1` |
+| output-0.12 | terraform 0.12 only | `<sensitive>` |

--- a/pkg/print/settings.go
+++ b/pkg/print/settings.go
@@ -42,6 +42,10 @@ type Settings struct {
 	// scope: Markdown
 	ShowRequired bool
 
+	// ShowSensitivity show "Sensitive" column when generating Markdown (default: true)
+	// scope: Markdown
+	ShowSensitivity bool
+
 	// ShowRequirements show "Requirements" section (default: true)
 	// scope: Global
 	ShowRequirements bool
@@ -68,6 +72,7 @@ func NewSettings() *Settings {
 		ShowOutputs:      true,
 		ShowProviders:    true,
 		ShowRequired:     true,
+		ShowSensitivity:  true,
 		ShowRequirements: true,
 		SortByName:       true,
 		SortByRequired:   false,


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [x] This pull request adds a feature.
- [x] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

Use case: for projects where all outputs are expected to not be sensitive, it adds noise. This PR adds the `--no-sensitive` option to the markdown generation command. This options removes the sensitive column. The column will show by default, this is an opt-out

### Checklist

Put an `x` into all boxes that apply:

- [x] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [x] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

#### Code Style

- [x] My code follows the code style of this project.
