### PR TITLE
--no-header should not attempt reading main.tf file

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,10 @@ var rootCmd = &cobra.Command{
 			return !val
 		}
 		settings.ShowHeader = oppositeBool("no-header")
+		if !settings.ShowHeader {
+			options.HeaderFromFile = ""
+		}
+
 		settings.ShowInputs = oppositeBool("no-inputs")
 		settings.ShowOutputs = oppositeBool("no-outputs")
 		settings.ShowProviders = oppositeBool("no-providers")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,9 +25,7 @@ var rootCmd = &cobra.Command{
 			return !val
 		}
 		settings.ShowHeader = oppositeBool("no-header")
-		if !settings.ShowHeader {
-			options.HeaderFromFile = ""
-		}
+		options.ShowHeader = settings.ShowHeader
 
 		settings.ShowInputs = oppositeBool("no-inputs")
 		settings.ShowOutputs = oppositeBool("no-outputs")

--- a/internal/format/document_test.go
+++ b/internal/format/document_test.go
@@ -504,11 +504,12 @@ func TestDocumentEmpty(t *testing.T) {
 		ShowOutputs:   false,
 	}).Build()
 
-	expected, err := testutil.GetExpected("document", "document-Empty")
+	options, err := module.NewOptions().WithOverwrite(&module.Options{
+		HeaderFromFile: "bad.tf",
+	})
+	options.ShowHeader = false // Since we don't show the header, the file won't be loaded at all
 	assert.Nil(err)
 
-	options := module.NewOptions()
-	options.HeaderFromFile = "" // An empty header file means it will be ignored. --no-header will clear the file name
 	module, err := testutil.GetModule(options)
 	assert.Nil(err)
 
@@ -516,5 +517,5 @@ func TestDocumentEmpty(t *testing.T) {
 	actual, err := printer.Print(module, settings)
 
 	assert.Nil(err)
-	assert.Equal(expected, actual)
+	assert.Equal("", actual)
 }

--- a/internal/format/document_test.go
+++ b/internal/format/document_test.go
@@ -467,3 +467,27 @@ func TestDocumentHeaderFromFile(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(expected, actual)
 }
+
+func TestDocumentEmpty(t *testing.T) {
+	assert := assert.New(t)
+	settings := testutil.Settings().With(&print.Settings{
+		ShowHeader:    false,
+		ShowProviders: false,
+		ShowInputs:    false,
+		ShowOutputs:   false,
+	}).Build()
+
+	expected, err := testutil.GetExpected("document", "document-Empty")
+	assert.Nil(err)
+
+	options := module.NewOptions()
+	options.HeaderFromFile = "" // An empty header file means it will be ignored. --no-header will clear the file name
+	module, err := testutil.GetModule(options)
+	assert.Nil(err)
+
+	printer := NewDocument(settings)
+	actual, err := printer.Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}

--- a/internal/format/json_test.go
+++ b/internal/format/json_test.go
@@ -387,3 +387,31 @@ func TestJsonHeaderFromFile(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(expected, actual)
 }
+
+func TestJsonEmpty(t *testing.T) {
+	assert := assert.New(t)
+	settings := testutil.Settings().With(&print.Settings{
+		ShowHeader:    false,
+		ShowProviders: false,
+		ShowInputs:    false,
+		ShowOutputs:   false,
+	}).Build()
+
+	expected, err := testutil.GetExpected("json", "json-Empty")
+	assert.Nil(err)
+
+	options, err := module.NewOptions().WithOverwrite(&module.Options{
+		HeaderFromFile: "bad.tf",
+	})
+	options.ShowHeader = false // Since we don't show the header, the file won't be loaded at all
+	assert.Nil(err)
+
+	module, err := testutil.GetModule(options)
+	assert.Nil(err)
+
+	printer := NewJSON(settings)
+	actual, err := printer.Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}

--- a/internal/format/pretty_test.go
+++ b/internal/format/pretty_test.go
@@ -387,3 +387,28 @@ func TestPrettyHeaderFromFile(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(expected, actual)
 }
+
+func TestPrettyEmpty(t *testing.T) {
+	assert := assert.New(t)
+	settings := testutil.Settings().With(&print.Settings{
+		ShowHeader:    false,
+		ShowProviders: false,
+		ShowInputs:    false,
+		ShowOutputs:   false,
+	}).Build()
+
+	options, err := module.NewOptions().WithOverwrite(&module.Options{
+		HeaderFromFile: "bad.tf",
+	})
+	options.ShowHeader = false // Since we don't show the header, the file won't be loaded at all
+	assert.Nil(err)
+
+	module, err := testutil.GetModule(options)
+	assert.Nil(err)
+
+	printer := NewPretty(settings)
+	actual, err := printer.Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal("", actual)
+}

--- a/internal/format/table_test.go
+++ b/internal/format/table_test.go
@@ -494,3 +494,28 @@ func TestTableOutputValuesNoSensitivity(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(expected, actual)
 }
+
+func TestTableEmpty(t *testing.T) {
+	assert := assert.New(t)
+	settings := testutil.Settings().With(&print.Settings{
+		ShowHeader:    false,
+		ShowProviders: false,
+		ShowInputs:    false,
+		ShowOutputs:   false,
+	}).Build()
+
+	options, err := module.NewOptions().WithOverwrite(&module.Options{
+		HeaderFromFile: "bad.tf",
+	})
+	options.ShowHeader = false // Since we don't show the header, the file won't be loaded at all
+	assert.Nil(err)
+
+	module, err := testutil.GetModule(options)
+	assert.Nil(err)
+
+	printer := NewTable(settings)
+	actual, err := printer.Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal("", actual)
+}

--- a/internal/format/testdata/json/json-Empty.golden
+++ b/internal/format/testdata/json/json-Empty.golden
@@ -1,0 +1,7 @@
+{
+  "header": "",
+  "inputs": [],
+  "outputs": [],
+  "providers": [],
+  "requirements": []
+}

--- a/internal/format/testdata/xml/xml-Empty.golden
+++ b/internal/format/testdata/xml/xml-Empty.golden
@@ -1,0 +1,7 @@
+<module>
+  <header></header>
+  <inputs></inputs>
+  <outputs></outputs>
+  <providers></providers>
+  <requirements></requirements>
+</module>

--- a/internal/format/testdata/yaml/yaml-Empty.golden
+++ b/internal/format/testdata/yaml/yaml-Empty.golden
@@ -1,0 +1,5 @@
+header: ""
+inputs: []
+outputs: []
+providers: []
+requirements: []

--- a/internal/format/xml_test.go
+++ b/internal/format/xml_test.go
@@ -367,3 +367,31 @@ func TestXmlHeaderFromFile(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(expected, actual)
 }
+
+func TestXmlEmpty(t *testing.T) {
+	assert := assert.New(t)
+	settings := testutil.Settings().With(&print.Settings{
+		ShowHeader:    false,
+		ShowProviders: false,
+		ShowInputs:    false,
+		ShowOutputs:   false,
+	}).Build()
+
+	expected, err := testutil.GetExpected("xml", "xml-Empty")
+	assert.Nil(err)
+
+	options, err := module.NewOptions().WithOverwrite(&module.Options{
+		HeaderFromFile: "bad.tf",
+	})
+	options.ShowHeader = false // Since we don't show the header, the file won't be loaded at all
+	assert.Nil(err)
+
+	module, err := testutil.GetModule(options)
+	assert.Nil(err)
+
+	printer := NewXML(settings)
+	actual, err := printer.Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}

--- a/internal/format/yaml_test.go
+++ b/internal/format/yaml_test.go
@@ -367,3 +367,31 @@ func TestYamlHeaderFromFile(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(expected, actual)
 }
+
+func TestYamlEmpty(t *testing.T) {
+	assert := assert.New(t)
+	settings := testutil.Settings().With(&print.Settings{
+		ShowHeader:    false,
+		ShowProviders: false,
+		ShowInputs:    false,
+		ShowOutputs:   false,
+	}).Build()
+
+	expected, err := testutil.GetExpected("yaml", "yaml-Empty")
+	assert.Nil(err)
+
+	options, err := module.NewOptions().WithOverwrite(&module.Options{
+		HeaderFromFile: "bad.tf",
+	})
+	options.ShowHeader = false // Since we don't show the header, the file won't be loaded at all
+	assert.Nil(err)
+
+	module, err := testutil.GetModule(options)
+	assert.Nil(err)
+
+	printer := NewYAML(settings)
+	actual, err := printer.Print(module, settings)
+
+	assert.Nil(err)
+	assert.Equal(expected, actual)
+}

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -39,10 +39,18 @@ func loadModule(path string) (*tfconfig.Module, error) {
 }
 
 func loadModuleItems(tfmodule *tfconfig.Module, options *Options) (*tfconf.Module, error) {
-	header, err := loadHeader(options.Path, options.HeaderFromFile)
-	if err != nil {
-		return nil, err
+	var (
+		header string
+		err    error
+	)
+
+	if options.HeaderFromFile != "" {
+		header, err = loadHeader(options.Path, options.HeaderFromFile)
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	inputs, required, optional := loadInputs(tfmodule)
 	outputs, err := loadOutputs(tfmodule, options)
 	if err != nil {

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -39,16 +39,9 @@ func loadModule(path string) (*tfconfig.Module, error) {
 }
 
 func loadModuleItems(tfmodule *tfconfig.Module, options *Options) (*tfconf.Module, error) {
-	var (
-		header string
-		err    error
-	)
-
-	if options.HeaderFromFile != "" {
-		header, err = loadHeader(options.Path, options.HeaderFromFile)
-		if err != nil {
-			return nil, err
-		}
+	header, err := loadHeader(options)
+	if err != nil {
+		return nil, err
 	}
 
 	inputs, required, optional := loadInputs(tfmodule)
@@ -71,8 +64,12 @@ func loadModuleItems(tfmodule *tfconfig.Module, options *Options) (*tfconf.Modul
 	}, nil
 }
 
-func loadHeader(base string, path string) (string, error) {
-	filename := filepath.Join(base, path)
+func loadHeader(options *Options) (string, error) {
+	if !options.ShowHeader {
+		return "", nil
+	}
+
+	filename := filepath.Join(options.Path, options.HeaderFromFile)
 	_, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return "", err

--- a/internal/module/module_test.go
+++ b/internal/module/module_test.go
@@ -107,7 +107,8 @@ func TestLoadHeader(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert := assert.New(t)
-			actual, err := loadHeader(filepath.Join("testdata", tt.path), tt.header)
+			options := &Options{Path: filepath.Join("testdata", tt.path), HeaderFromFile: tt.header, ShowHeader: true}
+			actual, err := loadHeader(options)
 			if tt.wantErr {
 				assert.NotNil(err)
 			} else {

--- a/internal/module/options.go
+++ b/internal/module/options.go
@@ -17,6 +17,7 @@ type SortBy struct {
 type Options struct {
 	Path             string
 	HeaderFromFile   string
+	ShowHeader       bool
 	SortBy           *SortBy
 	OutputValues     bool
 	OutputValuesPath string
@@ -27,6 +28,7 @@ func NewOptions() *Options {
 	return &Options{
 		Path:             "",
 		HeaderFromFile:   "main.tf",
+		ShowHeader:       true,
 		SortBy:           &SortBy{Name: false, Required: false},
 		OutputValues:     false,
 		OutputValuesPath: "",


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [x] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [ ] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

Our projects do not have that file. Even with `--no-header`, terraform-docs crashes. This PR stops the tool from reading a file when `--no-header` is set.
I'm not sure if the test is in the correct location. Let me know if that works for you

### Checklist

Put an `x` into all boxes that apply:

- [x] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [x] I have added tests to cover my changes.
- [x] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [x] My code follows the code style of this project.
