### PR TITLE
Put terraform-docs imports after 3rd-party packages

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/spf13/cobra"
+
 	"github.com/segmentio/terraform-docs/internal/format"
 	"github.com/segmentio/terraform-docs/internal/module"
 	"github.com/segmentio/terraform-docs/internal/version"
 	"github.com/segmentio/terraform-docs/pkg/print"
-	"github.com/spf13/cobra"
 )
 
 var settings = print.NewSettings()

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,8 +3,9 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/segmentio/terraform-docs/internal/version"
 	"github.com/spf13/cobra"
+
+	"github.com/segmentio/terraform-docs/internal/version"
 )
 
 var versionCmd = &cobra.Command{

--- a/internal/format/asciidoc_document_test.go
+++ b/internal/format/asciidoc_document_test.go
@@ -3,10 +3,11 @@ package format
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/segmentio/terraform-docs/internal/module"
 	"github.com/segmentio/terraform-docs/internal/testutil"
 	"github.com/segmentio/terraform-docs/pkg/print"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAsciidocDocument(t *testing.T) {

--- a/internal/format/asciidoc_table_test.go
+++ b/internal/format/asciidoc_table_test.go
@@ -3,10 +3,11 @@ package format
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/segmentio/terraform-docs/internal/module"
 	"github.com/segmentio/terraform-docs/internal/testutil"
 	"github.com/segmentio/terraform-docs/pkg/print"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAsciidocTable(t *testing.T) {

--- a/internal/format/factory_test.go
+++ b/internal/format/factory_test.go
@@ -4,8 +4,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/segmentio/terraform-docs/pkg/print"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/segmentio/terraform-docs/pkg/print"
 )
 
 func TestFormatFactory(t *testing.T) {

--- a/internal/format/json_test.go
+++ b/internal/format/json_test.go
@@ -3,10 +3,11 @@ package format
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/segmentio/terraform-docs/internal/module"
 	"github.com/segmentio/terraform-docs/internal/testutil"
 	"github.com/segmentio/terraform-docs/pkg/print"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestJson(t *testing.T) {

--- a/internal/format/markdown_document_test.go
+++ b/internal/format/markdown_document_test.go
@@ -3,10 +3,11 @@ package format
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/segmentio/terraform-docs/internal/module"
 	"github.com/segmentio/terraform-docs/internal/testutil"
 	"github.com/segmentio/terraform-docs/pkg/print"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDocument(t *testing.T) {

--- a/internal/format/markdown_table_test.go
+++ b/internal/format/markdown_table_test.go
@@ -3,10 +3,11 @@ package format
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/segmentio/terraform-docs/internal/module"
 	"github.com/segmentio/terraform-docs/internal/testutil"
 	"github.com/segmentio/terraform-docs/pkg/print"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestTable(t *testing.T) {

--- a/internal/format/pretty_test.go
+++ b/internal/format/pretty_test.go
@@ -3,10 +3,11 @@ package format
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/segmentio/terraform-docs/internal/module"
 	"github.com/segmentio/terraform-docs/internal/testutil"
 	"github.com/segmentio/terraform-docs/pkg/print"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestPretty(t *testing.T) {

--- a/internal/format/tfvars_hcl_test.go
+++ b/internal/format/tfvars_hcl_test.go
@@ -3,10 +3,11 @@ package format
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/segmentio/terraform-docs/internal/module"
 	"github.com/segmentio/terraform-docs/internal/testutil"
 	"github.com/segmentio/terraform-docs/pkg/print"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestTfvarsHcl(t *testing.T) {

--- a/internal/format/tfvars_json.go
+++ b/internal/format/tfvars_json.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/iancoleman/orderedmap"
+
 	"github.com/segmentio/terraform-docs/pkg/print"
 	"github.com/segmentio/terraform-docs/pkg/tfconf"
 )

--- a/internal/format/tfvars_json_test.go
+++ b/internal/format/tfvars_json_test.go
@@ -3,10 +3,11 @@ package format
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/segmentio/terraform-docs/internal/module"
 	"github.com/segmentio/terraform-docs/internal/testutil"
 	"github.com/segmentio/terraform-docs/pkg/print"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestTfvarsJson(t *testing.T) {

--- a/internal/format/toml.go
+++ b/internal/format/toml.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 
 	"github.com/BurntSushi/toml"
+
 	"github.com/segmentio/terraform-docs/pkg/print"
 	"github.com/segmentio/terraform-docs/pkg/tfconf"
 )

--- a/internal/format/toml_test.go
+++ b/internal/format/toml_test.go
@@ -3,10 +3,11 @@ package format
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/segmentio/terraform-docs/internal/module"
 	"github.com/segmentio/terraform-docs/internal/testutil"
 	"github.com/segmentio/terraform-docs/pkg/print"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestToml(t *testing.T) {

--- a/internal/format/xml_test.go
+++ b/internal/format/xml_test.go
@@ -3,10 +3,11 @@ package format
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/segmentio/terraform-docs/internal/module"
 	"github.com/segmentio/terraform-docs/internal/testutil"
 	"github.com/segmentio/terraform-docs/pkg/print"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestXml(t *testing.T) {

--- a/internal/format/yaml.go
+++ b/internal/format/yaml.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"strings"
 
+	"gopkg.in/yaml.v3"
+
 	"github.com/segmentio/terraform-docs/pkg/print"
 	"github.com/segmentio/terraform-docs/pkg/tfconf"
-	"gopkg.in/yaml.v3"
 )
 
 // YAML represents YAML format.

--- a/internal/format/yaml_test.go
+++ b/internal/format/yaml_test.go
@@ -3,10 +3,11 @@ package format
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/segmentio/terraform-docs/internal/module"
 	"github.com/segmentio/terraform-docs/internal/testutil"
 	"github.com/segmentio/terraform-docs/pkg/print"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestYaml(t *testing.T) {

--- a/internal/module/input_test.go
+++ b/internal/module/input_test.go
@@ -4,9 +4,10 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/segmentio/terraform-docs/internal/types"
 	"github.com/segmentio/terraform-docs/pkg/tfconf"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestInputsSortedByName(t *testing.T) {

--- a/internal/module/output_test.go
+++ b/internal/module/output_test.go
@@ -4,9 +4,10 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/segmentio/terraform-docs/internal/types"
 	"github.com/segmentio/terraform-docs/pkg/tfconf"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestOutputsSortedByName(t *testing.T) {

--- a/internal/module/provider_test.go
+++ b/internal/module/provider_test.go
@@ -4,9 +4,10 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/segmentio/terraform-docs/internal/types"
 	"github.com/segmentio/terraform-docs/pkg/tfconf"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestProvidersSortedByName(t *testing.T) {

--- a/internal/testutil/settings.go
+++ b/internal/testutil/settings.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"github.com/imdario/mergo"
+
 	"github.com/segmentio/terraform-docs/pkg/print"
 )
 

--- a/pkg/tfconf/input_test.go
+++ b/pkg/tfconf/input_test.go
@@ -3,8 +3,9 @@ package tfconf
 import (
 	"testing"
 
-	"github.com/segmentio/terraform-docs/internal/types"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/segmentio/terraform-docs/internal/types"
 )
 
 func TestInputValue(t *testing.T) {

--- a/pkg/tfconf/output_test.go
+++ b/pkg/tfconf/output_test.go
@@ -6,8 +6,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/segmentio/terraform-docs/internal/types"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/segmentio/terraform-docs/internal/types"
 )
 
 func TestOutputValue(t *testing.T) {

--- a/pkg/tfconf/provider_test.go
+++ b/pkg/tfconf/provider_test.go
@@ -3,8 +3,9 @@ package tfconf
 import (
 	"testing"
 
-	"github.com/segmentio/terraform-docs/internal/types"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/segmentio/terraform-docs/internal/types"
 )
 
 func TestProviderNameWithoutAlias(t *testing.T) {

--- a/pkg/tmpl/sanitizer.go
+++ b/pkg/tmpl/sanitizer.go
@@ -6,8 +6,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/segmentio/terraform-docs/pkg/print"
 	"mvdan.cc/xurls/v2"
+
+	"github.com/segmentio/terraform-docs/pkg/print"
 )
 
 // sanitizeName escapes underscore character which have special meaning in Markdown.

--- a/pkg/tmpl/sanitizer_test.go
+++ b/pkg/tmpl/sanitizer_test.go
@@ -5,9 +5,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/segmentio/terraform-docs/internal/testutil"
 	"github.com/segmentio/terraform-docs/pkg/print"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestSanitizeName(t *testing.T) {

--- a/pkg/tmpl/template_test.go
+++ b/pkg/tmpl/template_test.go
@@ -8,10 +8,11 @@ import (
 	"testing"
 	"text/template"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/segmentio/terraform-docs/internal/types"
 	"github.com/segmentio/terraform-docs/pkg/print"
 	"github.com/segmentio/terraform-docs/pkg/tfconf"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestTemplateRender(t *testing.T) {


### PR DESCRIPTION
### Prerequisites

Put an `x` into the box(es) that apply:

- [ ] This pull request fixes a bug.
- [ ] This pull request adds a feature.
- [x] This pull request enhances existing functionality.
- [ ] This pull request introduces breaking change.

For more information, see the [Contributing Guide](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

### Description

Enforcing `goimports -local <string>` to put `terraform-docs` imports and packages after 3rd-party packages.

### Issues Resolved

List any existing issues this pull request resolves.

### Checklist

Put an `x` into all boxes that apply:

- [ ] I have read the [Contributing Guidelines](https://github.com/segmentio/terraform-docs/tree/master/CONTRIBUTING.md).

#### Tests

- [ ] I have added tests to cover my changes.
- [ ] All tests pass when I run `make test`.

#### Documentation

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

#### Code Style

- [x] My code follows the code style of this project.
